### PR TITLE
fix: don't call verify_cache_exists() every time we connect()

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -89,18 +89,7 @@ impl CacheClient {
         );
         let client = ScsClient::new(interceptor);
         self.client = Some(client);
-        self.verify_cache_exists().await?;
         Ok(())
-    }
-
-    async fn verify_cache_exists(&self) -> Result<(), MomentoError> {
-        let get_response = self.get("0000".to_string()).await;
-        match get_response {
-            Ok(_) => return Ok(()),
-            Err(e) => match e {
-                _ => return Err(e),
-            },
-        };
     }
 
     /// Gets an item from a Momento Cache


### PR DESCRIPTION
Fixes: https://github.com/momentohq/client-sdk-rust/issues/10

Our Rust SDK hasn't yet been updated to follow parity with our other SDKs. One remaining bug was that every time we would attempt to connect to
a cache we would call `verify_cache_exists()`, which performs a `get` on every operation. Instead, we can omit this line so we aren't calling `get`
with every `set`.

To test this, I made this same change in my local `momento-cli` repo and built both targets with `cargo build`. I confirmed manually that
testing with an existing and non-existing cache that expected results came through:

```
# Cache exists
Tylers-MacBook-Pro :: ~/repo/momento-cli ‹fix-get-after-set› » ./target/debug/momento cache set --key foo --value bar --ttl 30 --name example-cache                                                                        1 ↵
[2022-02-02T19:12:54Z INFO  momento::commands::cache::cache] setting key: foo into cache: example-cache
[2022-02-02T19:12:55Z INFO  momento::commands::cache::cache] set success
Tylers-MacBook-Pro :: ~/repo/momento-cli ‹fix-get-after-set› »

# Cache does not exist
Tylers-MacBook-Pro :: ~/repo/momento-cli ‹fix-get-after-set› » ./target/debug/momento cache set --key foo --value bar --ttl 30 --name notasdf
[2022-02-02T19:09:09Z INFO  momento::commands::cache::cache] setting key: foo into cache: notasdf
ERROR: Cache not found
Tylers-MacBook-Pro :: ~/repo/momento-cli ‹fix-get-after-set› »
```

I also exercised load against my dev cell and checked Grafana, confirmed there were no `gets` associated with the `set`
