### PR TITLE
fix: ensure SDK can handle all GRPC error codes. Add cache name validation

### DIFF
--- a/src/endpoint_resolver.rs
+++ b/src/endpoint_resolver.rs
@@ -16,8 +16,8 @@ impl MomentoEndpointsResolver {
         let control_endpoint = MomentoEndpointsResolver::get_control_endpoint(&claims, hosted_zone);
         let data_endpoint = MomentoEndpointsResolver::get_data_endpoint(&claims, hosted_zone);
         return MomentoEndpoints {
-            control_endpoint: control_endpoint,
-            data_endpoint: data_endpoint,
+            control_endpoint,
+            data_endpoint,
         };
     }
 

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -10,6 +10,11 @@ pub struct Claims {
 }
 
 pub fn decode_jwt(jwt: &str) -> Result<Claims, MomentoError> {
+    if jwt.is_empty() {
+        return Err(MomentoError::ClientSdkError(
+            "Malformed Auth Token".to_string(),
+        ));
+    }
     let token = dangerous_insecure_decode::<Claims>(jwt)?;
     Ok(token.claims)
 }
@@ -31,6 +36,7 @@ mod tests {
     #[test]
     fn invalid_jwt() {
         let e = decode_jwt("").unwrap_err();
-        assert!(matches!(e, MomentoError::InvalidJwt));
+        let _err_msg = "Failed to parse Auth Token".to_owned();
+        assert!(matches!(e, MomentoError::ClientSdkError(_err_msg)));
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,6 +2,7 @@
 mod tests {
     use std::{env, time::Duration};
 
+    use momento::response::error::MomentoError;
     use momento::{
         response::cache_get_response::MomentoGetStatus, simple_cache_client::SimpleCacheClient,
     };
@@ -24,6 +25,18 @@ mod tests {
         let mut mm = get_momento_instance().await;
         let result = mm.get(&cache_name, cache_key).await.unwrap();
         assert!(matches!(result.result, MomentoGetStatus::MISS));
+    }
+
+    #[tokio::test]
+    async fn cache_validation() {
+        let cache_name = "";
+        let mut mm = get_momento_instance().await;
+        let result = mm.create_cache(cache_name).await.unwrap_err();
+        let _err_msg = "Cache name cannot be empty".to_string();
+        assert!(matches!(
+            result,
+            MomentoError::InvalidArgument(_err_message)
+        ))
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes https://github.com/momentohq/client-sdk-rust/issues/14.

This was written to have a similar change as our Java SDK: https://github.com/momentohq/client-sdk-java/pull/116/files. I am by no means a Rust expert so based on the unit/integration tests I'm inclined to presume this is the correct implementation, but extra eyes will be best for this.

Follows the guidelines set by our internal doc for GRPC status code matching.
