### PR TITLE
chore: Clean up `CacheHeaderInterceptor`

### DIFF
--- a/src/grpc/cache_header_interceptor.rs
+++ b/src/grpc/cache_header_interceptor.rs
@@ -8,9 +8,6 @@ impl tonic::service::Interceptor for CacheHeaderInterceptor {
         &mut self,
         mut request: tonic::Request<()>,
     ) -> Result<tonic::Request<()>, tonic::Status> {
-        let request_metadata = request.metadata().clone();
-        let cache_name = request_metadata.get("cache").unwrap();
-
         request.metadata_mut().insert(
             "authorization",
             tonic::metadata::AsciiMetadataValue::from_str(self.auth_key.as_str()).unwrap(),
@@ -21,9 +18,6 @@ impl tonic::service::Interceptor for CacheHeaderInterceptor {
             "content-type",
             tonic::metadata::AsciiMetadataValue::from_str("application/grpc").unwrap(),
         );
-
-        // need to re-add our `cache` header back into the interceptor or it will be stripped out
-        request.metadata_mut().insert("cache", cache_name.clone());
         Ok(request)
     }
 }


### PR DESCRIPTION
Make `request` arg mutable for `CacheHeaderInterceptor` so that we don't need to create a new request.
Related conversations: https://github.com/momentohq/client-sdk-rust/pull/31#discussion_r844538223