### PR TITLE
chore: Update TTL data type to `NonZeroU64` and add publish workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,76 @@
+name: CD
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  rustfmt:
+    name: Style & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: rustfmt
+        run: cargo fmt -- --check
+      - name: Rigorous lint via Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  release:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release.outputs.release }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          override: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Set release
+        id: semrel
+        uses: go-semantic-release/action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-initial-development-versions: true
+          force-bump-patch-version: true
+
+      - name: Update Cargo Version
+        run: |
+          chmod +x set_cargo_version.sh
+          ./set_cargo_version.sh ${{ steps.semrel.outputs.version }}
+        shell: bash
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Output release
+        id: release
+        run: echo "::set-output name=release::${{ steps.semrel.outputs.version }}"
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: release
+    env:
+      TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Integration Tests
+        run: cargo test --tests
+
+      - name: Login to crates.io
+        run: cargo login $CARGO_REGISTRY_TOKEN
+
+      - name: Publish crate
+        run: cargo publish

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Momento client-sdk-rust
 
-:warning: Experimental SDK :warning:
+⚠️ Experimental SDK ⚠️
 
 Rust SDK for Momento is experimental and under active development.
 There could be non-backward compatible changes or removal in the future.
@@ -14,7 +14,7 @@ Rust SDK for Momento, a serverless cache that automatically scales without any o
 
 <br/>
 
-## Getting Started :running:
+## Getting Started 🏃
 
 ### Requirements
 
@@ -53,7 +53,7 @@ cache_client.delete_cache(&cache_name).await.unwrap();
 
 <br/>
 
-## Running Tests :zap:
+## Running Tests ⚡
 
 Doc and integration tests require an auth token for testing. Set the env var `TEST_AUTH_TOKEN` to
 provide it.

--- a/set_cargo_version.sh
+++ b/set_cargo_version.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+function log() {
+  local msg=$1
+  >&2 echo "$msg"
+}
+
+function usage() {
+  log "
+This script updates the Cargo.toml file to match the semver release version
+Usage:
+$0 <SEMVER_VERSION>
+Example:
+$0 1.0.3
+  "
+  exit 1
+}
+
+if [ "$#" -ne 1 ]; then
+    log "Expected 1 positional argument: <SEMVER_VERSION>"
+    log ""
+    usage
+fi
+
+log "updating Cargo.toml to version $1"
+
+pip3 install toml
+python3 update_cargo_toml.py $1

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -143,9 +143,10 @@ impl SimpleCacheClient {
     /// # tokio_test::block_on(async {
     ///     use momento::simple_cache_client::SimpleCacheClient;
     ///     use std::env;
+    ///     use std::num::NonZeroU64;
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let default_ttl = 30;
-    ///     let momento = SimpleCacheClient::new(auth_token, default_ttl).await;
+    ///     let momento = SimpleCacheClient::new(auth_token, NonZeroU64::new(default_ttl).unwrap()).await;
     /// # })
     /// ```
     pub async fn new(
@@ -241,12 +242,13 @@ impl SimpleCacheClient {
     ///
     /// ```
     /// use uuid::Uuid;
+    /// use std::num::NonZeroU64;
     /// # tokio_test::block_on(async {
     ///     use momento::simple_cache_client::SimpleCacheClient;
     ///     use std::env;
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let cache_name = Uuid::new_v4().to_string();
-    ///     let mut momento = SimpleCacheClient::new(auth_token, 5).await.unwrap();
+    ///     let mut momento = SimpleCacheClient::new(auth_token, NonZeroU64::new(5).unwrap()).await.unwrap();
     ///     momento.create_cache(&cache_name).await;
     ///     momento.delete_cache(&cache_name).await;
     /// # })
@@ -266,12 +268,13 @@ impl SimpleCacheClient {
     ///
     /// ```
     /// use uuid::Uuid;
+    /// use std::num::NonZeroU64;
     /// # tokio_test::block_on(async {
     ///     use momento::simple_cache_client::SimpleCacheClient;
     ///     use std::env;
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let cache_name = Uuid::new_v4().to_string();
-    ///     let mut momento = SimpleCacheClient::new(auth_token, 5).await.unwrap();
+    ///     let mut momento = SimpleCacheClient::new(auth_token, NonZeroU64::new(5).unwrap()).await.unwrap();
     ///     momento.create_cache(&cache_name).await;
     ///     let caches = momento.list_caches(None).await;
     ///     momento.delete_cache(&cache_name).await;
@@ -353,17 +356,18 @@ impl SimpleCacheClient {
     ///
     /// ```
     /// use uuid::Uuid;
+    /// use std::num::NonZeroU64;
     /// # tokio_test::block_on(async {
     ///     use momento::simple_cache_client::SimpleCacheClient;
     ///     use std::env;
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let cache_name = Uuid::new_v4().to_string();
-    ///     let mut momento = SimpleCacheClient::new(auth_token, 30).await.unwrap();
+    ///     let mut momento = SimpleCacheClient::new(auth_token, NonZeroU64::new(30).unwrap()).await.unwrap();
     ///     momento.create_cache(&cache_name).await;
     ///     momento.set(&cache_name, "cache_key", "cache_value", None).await;
     ///
     ///     // overriding default ttl
-    ///     momento.set(&cache_name, "cache_key", "cache_value", Some(10)).await;
+    ///     momento.set(&cache_name, "cache_key", "cache_value", Some(NonZeroU64::new(10).unwrap())).await;
     ///     momento.delete_cache(&cache_name).await;
     /// # })
     /// ```
@@ -406,12 +410,13 @@ impl SimpleCacheClient {
     ///
     /// ```
     /// use uuid::Uuid;
+    /// use std::num::NonZeroU64;
     /// # tokio_test::block_on(async {
     ///     use std::env;
     ///     use momento::{response::cache_get_response::MomentoGetStatus, simple_cache_client::SimpleCacheClient};
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let cache_name = Uuid::new_v4().to_string();
-    ///     let mut momento = SimpleCacheClient::new(auth_token, 30).await.unwrap();
+    ///     let mut momento = SimpleCacheClient::new(auth_token, NonZeroU64::new(30).unwrap()).await.unwrap();
     ///     momento.create_cache(&cache_name).await;
     ///     let resp = momento.get(&cache_name, "cache_key").await.unwrap();
     ///     match resp.result {

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
 use std::convert::TryFrom;
+use std::num::NonZeroU64;
 use tonic::{
     codegen::InterceptedService,
     transport::{Channel, ClientTlsConfig, Uri},
@@ -58,11 +59,14 @@ pub struct SimpleCacheClientBuilder {
     control_channel: Channel,
     data_channel: Channel,
     auth_token: String,
-    default_ttl_seconds: u64,
+    default_ttl_seconds: NonZeroU64,
 }
 
 impl SimpleCacheClientBuilder {
-    pub async fn new(auth_token: String, default_ttl_seconds: u64) -> Result<Self, MomentoError> {
+    pub async fn new(
+        auth_token: String,
+        default_ttl_seconds: NonZeroU64,
+    ) -> Result<Self, MomentoError> {
         let data_endpoint = utils::get_claims(&auth_token).c;
 
         let momento_endpoints = MomentoEndpointsResolver::resolve(&auth_token, &None);
@@ -123,7 +127,7 @@ pub struct SimpleCacheClient {
     data_endpoint: String,
     control_client: ScsControlClient<InterceptedService<Channel, AuthHeaderInterceptor>>,
     data_client: ScsClient<InterceptedService<Channel, CacheHeaderInterceptor>>,
-    item_default_ttl_seconds: u64,
+    item_default_ttl_seconds: NonZeroU64,
 }
 
 impl SimpleCacheClient {
@@ -132,7 +136,7 @@ impl SimpleCacheClient {
     /// # Arguments
     ///
     /// * `auth_token` - Momento Token
-    /// * `item_default_ttl_seconds` - Default TTL for items put into a cache
+    /// * `item_default_ttl_seconds` - Default TTL for items put into a cache.
     /// # Examples
     ///
     /// ```
@@ -144,7 +148,10 @@ impl SimpleCacheClient {
     ///     let momento = SimpleCacheClient::new(auth_token, default_ttl).await;
     /// # })
     /// ```
-    pub async fn new(auth_token: String, default_ttl_seconds: u64) -> Result<Self, MomentoError> {
+    pub async fn new(
+        auth_token: String,
+        default_ttl_seconds: NonZeroU64,
+    ) -> Result<Self, MomentoError> {
         let data_endpoint = utils::get_claims(&auth_token).c;
 
         let momento_endpoints = MomentoEndpointsResolver::resolve(&auth_token, &None);
@@ -365,12 +372,12 @@ impl SimpleCacheClient {
         cache_name: &str,
         key: I,
         body: I,
-        ttl_seconds: Option<u64>,
+        ttl_seconds: Option<NonZeroU64>,
     ) -> Result<MomentoSetResponse, MomentoError> {
         utils::is_cache_name_valid(cache_name)?;
         let temp_ttl = ttl_seconds.unwrap_or(self.item_default_ttl_seconds);
         let ttl_to_use = match utils::is_ttl_valid(&temp_ttl) {
-            Ok(_) => temp_ttl * 1000_u64,
+            Ok(_) => temp_ttl.get() * 1000_u64,
             Err(e) => return Err(e),
         };
         let mut request = tonic::Request::new(SetRequest {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,10 @@
 use crate::jwt::{decode_jwt, Claims};
 use crate::response::error::MomentoError;
+use std::num::NonZeroU64;
 
-pub fn is_ttl_valid(ttl: &u64) -> Result<(), MomentoError> {
+pub fn is_ttl_valid(ttl: &NonZeroU64) -> Result<(), MomentoError> {
     let max_ttl = u64::MAX / 1000_u64;
-    if *ttl > max_ttl {
+    if ttl.get() > max_ttl {
         return Err(MomentoError::InvalidArgument(format!(
             "TTL provided, {}, needs to be less than the maximum TTL {}",
             ttl, max_ttl

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU64;
     use std::{env, time::Duration};
 
     use momento::response::error::MomentoError;
@@ -12,7 +13,9 @@ mod tests {
 
     async fn get_momento_instance() -> SimpleCacheClient {
         let auth_token = env::var("TEST_AUTH_TOKEN").expect("env var TEST_AUTH_TOKEN must be set");
-        return SimpleCacheClient::new(auth_token, 5).await.unwrap();
+        return SimpleCacheClient::new(auth_token, NonZeroU64::new(5).unwrap())
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -56,7 +59,12 @@ mod tests {
         let ttl: u64 = 18446744073709551615;
         let max_ttl = u64::MAX / 1000_u64;
         let result = mm
-            .set(&cache_name, cache_key, cache_body, Some(ttl)) // 18446744073709551615 > 2^64/1000
+            .set(
+                &cache_name,
+                cache_key,
+                cache_body,
+                Some(NonZeroU64::new(ttl).unwrap()),
+            ) // 18446744073709551615 > 2^64/1000
             .await
             .unwrap_err();
         let _err_message = format!(
@@ -161,7 +169,7 @@ mod tests {
             + &jwt_payload_bad_control_plane_base64.clone()
             + "."
             + &jwt_invalid_signature_base_64.clone();
-        let mut client = SimpleCacheClient::new(bad_control_plane_jwt, 5)
+        let mut client = SimpleCacheClient::new(bad_control_plane_jwt, NonZeroU64::new(5).unwrap())
             .await
             .unwrap();
 
@@ -202,7 +210,9 @@ mod tests {
             + &jwt_payload_bad_data_plane_base64.clone()
             + "."
             + &jwt_invalid_signature_base_64.clone();
-        let mut client = SimpleCacheClient::new(bad_data_plane_jwt, 5).await.unwrap();
+        let mut client = SimpleCacheClient::new(bad_data_plane_jwt, NonZeroU64::new(5).unwrap())
+            .await
+            .unwrap();
 
         // Can reach control plane
         let create_cache_result = client.create_cache("cache").await.unwrap_err();

--- a/update_cargo_toml.py
+++ b/update_cargo_toml.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+import sys
+import toml
+
+if len(sys.argv) != 2:
+    print(sys.argv)
+    sys.exit("must pass 1 positional argument, ex: python3 ./update_cargo_toml.py 1.0.1")
+
+filename = "Cargo.toml"
+
+toml_data = toml.load(filename)
+toml_data["package"]["version"] = sys.argv[1]
+
+with open(filename, 'w') as cargo:
+    toml.dump(toml_data, cargo)


### PR DESCRIPTION
This enforces users to pass `NonZeroU64::new(u64).unwrap()` to set default TTL or overwrite default TTL.
If users pass 0 to initialize `NonZeroU64` then `None` will be returned and thrown an error.
This adds an extra layer to make sure users pass an integer other than 0 before they blindly pass 0 without any thoughts.

Also added publish workflow to publish our SDK to crates.io as we merge prs to `main`.

Closes #23 