### PR TITLE
feat: allow changing builder default ttl

### DIFF
--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -97,6 +97,12 @@ impl SimpleCacheClientBuilder {
         }
     }
 
+    pub fn default_ttl_seconds(mut self, seconds: NonZeroU64) -> Result<Self, MomentoError> {
+        utils::is_ttl_valid(&seconds)?;
+        self.default_ttl_seconds = seconds;
+        Ok(self)
+    }
+
     pub fn build(self) -> SimpleCacheClient {
         let control_interceptor = InterceptedService::new(
             self.control_channel,


### PR DESCRIPTION
Allow the `SimpleCacheClientBuilder` default ttl to be modified by
adding a new function. This is necessary if we want to be able to
create several clients with different ttls after initializing the
builder.

For example, this is desirable in the proxy where we want to allow
a different ttl for each cache but use the same underlying grpc
channels.