### PR TITLE
fix: resolve cargo audit errors from jsonwebtoken

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ prost = "0.9.0"
 rustls = { version = "0.19.1", features = ["dangerous_configuration"] }
 webpki = "0.21.3"
 tower = "0.4.8"
-jsonwebtoken = "7"
+jsonwebtoken = "8.0.1"
 serde = {version = "1.0", features = ["derive"] }
 serde_json = "1.0.79"
 base64-url = "1.4.13"

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -1,4 +1,4 @@
-use jsonwebtoken::dangerous_insecure_decode;
+use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde::{Deserialize, Serialize};
 
 use crate::response::error::MomentoError;
@@ -16,7 +16,16 @@ pub fn decode_jwt(jwt: &str) -> Result<Claims, MomentoError> {
             "Malformed Auth Token".to_string(),
         ));
     }
-    let token = dangerous_insecure_decode::<Claims>(jwt)?;
+    let key = DecodingKey::from_secret("".as_ref());
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.required_spec_claims.clear();
+    validation.required_spec_claims.insert("sub".to_string());
+    validation.required_spec_claims.insert("c".to_string());
+    validation.required_spec_claims.insert("cp".to_string());
+    validation.validate_exp = false;
+    validation.insecure_disable_signature_validation();
+    let token = decode(jwt, &key, &validation)?;
+
     Ok(token.claims)
 }
 


### PR DESCRIPTION
Resolves the cargo audit errors by upgrading jsonwebtoken to 8.0.1
and making necessary code changes.

Fixes #40