### PR TITLE
chore: Add more descriptive error message for auth token parse

### DIFF
--- a/src/endpoint_resolver.rs
+++ b/src/endpoint_resolver.rs
@@ -1,6 +1,5 @@
-use crate::jwt::Claims;
+use crate::jwt::{decode_jwt, Claims};
 use crate::response::error::MomentoError;
-use crate::utils;
 
 pub struct MomentoEndpoints {
     pub control_endpoint: String,
@@ -17,7 +16,7 @@ impl MomentoEndpointsResolver {
         auth_token: &str,
         hosted_zone: &Option<String>,
     ) -> Result<MomentoEndpoints, MomentoError> {
-        let claims = match utils::get_claims(auth_token) {
+        let claims = match decode_jwt(auth_token) {
             Ok(c) => c,
             Err(e) => return Err(e),
         };

--- a/src/endpoint_resolver.rs
+++ b/src/endpoint_resolver.rs
@@ -1,4 +1,5 @@
 use crate::jwt::Claims;
+use crate::response::error::MomentoError;
 use crate::utils;
 
 pub struct MomentoEndpoints {
@@ -12,14 +13,20 @@ const CONTROL_ENDPOINT_PREFIX: &str = "control.";
 const DATA_ENDPOINT_PREFIX: &str = "data.";
 
 impl MomentoEndpointsResolver {
-    pub fn resolve(auth_token: &str, hosted_zone: &Option<String>) -> MomentoEndpoints {
-        let claims = utils::get_claims(auth_token);
+    pub fn resolve(
+        auth_token: &str,
+        hosted_zone: &Option<String>,
+    ) -> Result<MomentoEndpoints, MomentoError> {
+        let claims = match utils::get_claims(auth_token) {
+            Ok(c) => c,
+            Err(e) => return Err(e),
+        };
         let control_endpoint = MomentoEndpointsResolver::get_control_endpoint(&claims, hosted_zone);
         let data_endpoint = MomentoEndpointsResolver::get_data_endpoint(&claims, hosted_zone);
-        MomentoEndpoints {
+        Ok(MomentoEndpoints {
             control_endpoint,
             data_endpoint,
-        }
+        })
     }
 
     fn get_control_endpoint(claims: &Claims, hosted_zone: &Option<String>) -> String {

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -27,7 +27,7 @@ pub fn decode_jwt(jwt: &str) -> Result<Claims, MomentoError> {
     match decode(jwt, &key, &validation) {
         Ok(token) => Ok(token.claims),
         Err(_) => Err(MomentoError::ClientSdkError(
-            "Please make sure entered auth token matches your auth token".to_string(),
+            "Could not parse token. Please ensure a valid token was entered correctly.".to_string(),
         )),
     }
 }
@@ -56,7 +56,8 @@ mod tests {
     #[test]
     fn invalid_jwt() {
         let e = decode_jwt("wfheofhriugheifweif").unwrap_err();
-        let _err_msg = "Please make sure entered auth token matches your auth token".to_owned();
+        let _err_msg =
+            "Could not parse token. Please ensure a valid token was entered correctly.".to_owned();
         assert!(matches!(e, MomentoError::ClientSdkError(_err_msg)));
     }
 }

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -24,9 +24,12 @@ pub fn decode_jwt(jwt: &str) -> Result<Claims, MomentoError> {
     validation.required_spec_claims.insert("cp".to_string());
     validation.validate_exp = false;
     validation.insecure_disable_signature_validation();
-    let token = decode(jwt, &key, &validation)?;
-
-    Ok(token.claims)
+    match decode(jwt, &key, &validation) {
+        Ok(token) => Ok(token.claims),
+        Err(_) => Err(MomentoError::ClientSdkError(
+            "Please make sure entered auth token matches your auth token".to_string(),
+        )),
+    }
 }
 
 #[cfg(test)]
@@ -44,9 +47,16 @@ mod tests {
     }
 
     #[test]
-    fn invalid_jwt() {
+    fn empty_jwt() {
         let e = decode_jwt("").unwrap_err();
-        let _err_msg = "Failed to parse Auth Token".to_owned();
+        let _err_msg = "Malformed Auth Token".to_owned();
+        assert!(matches!(e, MomentoError::ClientSdkError(_err_msg)));
+    }
+
+    #[test]
+    fn invalid_jwt() {
+        let e = decode_jwt("wfheofhriugheifweif").unwrap_err();
+        let _err_msg = "Please make sure entered auth token matches your auth token".to_owned();
         assert!(matches!(e, MomentoError::ClientSdkError(_err_msg)));
     }
 }

--- a/src/response/error.rs
+++ b/src/response/error.rs
@@ -56,13 +56,6 @@ impl From<http::uri::InvalidUri> for MomentoError {
     }
 }
 
-impl From<jsonwebtoken::errors::Error> for MomentoError {
-    fn from(_: jsonwebtoken::errors::Error) -> Self {
-        let err_msg = "Failed to parse Auth Token".to_string();
-        Self::ClientSdkError(err_msg)
-    }
-}
-
 impl From<String> for MomentoError {
     fn from(s: String) -> Self {
         Self::BadRequest(s)

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -22,6 +22,7 @@ use crate::{
     },
 };
 
+use crate::jwt::decode_jwt;
 use crate::response::{
     cache_get_response::MomentoGetStatus,
     cache_set_response::{MomentoSetResponse, MomentoSetStatus},
@@ -72,7 +73,7 @@ impl SimpleCacheClientBuilder {
         auth_token: String,
         default_ttl_seconds: NonZeroU64,
     ) -> Result<Self, MomentoError> {
-        let data_endpoint = match utils::get_claims(&auth_token) {
+        let data_endpoint = match decode_jwt(&auth_token) {
             Ok(claims) => claims.c,
             Err(e) => return Err(e),
         };
@@ -177,7 +178,7 @@ impl SimpleCacheClient {
         auth_token: String,
         default_ttl_seconds: NonZeroU64,
     ) -> Result<Self, MomentoError> {
-        let data_endpoint = match utils::get_claims(&auth_token) {
+        let data_endpoint = match decode_jwt(&auth_token) {
             Ok(claims) => claims.c,
             Err(e) => return Err(e),
         };
@@ -232,7 +233,7 @@ impl SimpleCacheClient {
         auth_token: String,
         default_ttl_seconds: NonZeroU64,
     ) -> Result<Self, MomentoError> {
-        let data_endpoint = match utils::get_claims(&auth_token) {
+        let data_endpoint = match decode_jwt(&auth_token) {
             Ok(claims) => claims.c,
             Err(e) => return Err(e),
         };

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -72,9 +72,15 @@ impl SimpleCacheClientBuilder {
         auth_token: String,
         default_ttl_seconds: NonZeroU64,
     ) -> Result<Self, MomentoError> {
-        let data_endpoint = utils::get_claims(&auth_token).c;
+        let data_endpoint = match utils::get_claims(&auth_token) {
+            Ok(claims) => claims.c,
+            Err(e) => return Err(e),
+        };
 
-        let momento_endpoints = MomentoEndpointsResolver::resolve(&auth_token, &None);
+        let momento_endpoints = match MomentoEndpointsResolver::resolve(&auth_token, &None) {
+            Ok(endpoints) => endpoints,
+            Err(e) => return Err(e),
+        };
         let control_endpoint_uri = Uri::try_from(&momento_endpoints.control_endpoint)?;
         let data_endpoint_uri = Uri::try_from(&momento_endpoints.data_endpoint)?;
 
@@ -171,9 +177,16 @@ impl SimpleCacheClient {
         auth_token: String,
         default_ttl_seconds: NonZeroU64,
     ) -> Result<Self, MomentoError> {
-        let data_endpoint = utils::get_claims(&auth_token).c;
+        let data_endpoint = match utils::get_claims(&auth_token) {
+            Ok(claims) => claims.c,
+            Err(e) => return Err(e),
+        };
+
         let agent_value = format!("rust:{}", VERSION);
-        let momento_endpoints = MomentoEndpointsResolver::resolve(&auth_token, &None);
+        let momento_endpoints = match MomentoEndpointsResolver::resolve(&auth_token, &None) {
+            Ok(endpoints) => endpoints,
+            Err(e) => return Err(e),
+        };
         let control_client = SimpleCacheClient::build_control_client(
             auth_token.clone(),
             momento_endpoints.control_endpoint,
@@ -219,9 +232,15 @@ impl SimpleCacheClient {
         auth_token: String,
         default_ttl_seconds: NonZeroU64,
     ) -> Result<Self, MomentoError> {
-        let data_endpoint = utils::get_claims(&auth_token).c;
+        let data_endpoint = match utils::get_claims(&auth_token) {
+            Ok(claims) => claims.c,
+            Err(e) => return Err(e),
+        };
         let agent_value = format!("momento-cli:{}", VERSION);
-        let momento_endpoints = MomentoEndpointsResolver::resolve(&auth_token, &None);
+        let momento_endpoints = match MomentoEndpointsResolver::resolve(&auth_token, &None) {
+            Ok(endpoints) => endpoints,
+            Err(e) => return Err(e),
+        };
         let control_client = SimpleCacheClient::build_control_client(
             auth_token.clone(),
             momento_endpoints.control_endpoint,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -31,6 +31,11 @@ pub fn is_key_id_valid(key_id: &str) -> Result<(), MomentoError> {
     Ok(())
 }
 
-pub fn get_claims(auth_token: &str) -> Claims {
-    decode_jwt(auth_token).unwrap()
+pub fn get_claims(auth_token: &str) -> Result<Claims, MomentoError> {
+    match decode_jwt(auth_token) {
+        Ok(c) => Ok(c),
+        Err(_) => Err(MomentoError::InvalidArgument(
+            "Cache name cannot be empty".to_string(),
+        )),
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,3 @@
-use crate::jwt::{decode_jwt, Claims};
 use crate::response::error::MomentoError;
 use std::num::NonZeroU64;
 
@@ -29,11 +28,4 @@ pub fn is_key_id_valid(key_id: &str) -> Result<(), MomentoError> {
         ));
     }
     Ok(())
-}
-
-pub fn get_claims(auth_token: &str) -> Result<Claims, MomentoError> {
-    match decode_jwt(auth_token) {
-        Ok(c) => Ok(c),
-        Err(e) => Err(e),
-    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -34,8 +34,6 @@ pub fn is_key_id_valid(key_id: &str) -> Result<(), MomentoError> {
 pub fn get_claims(auth_token: &str) -> Result<Claims, MomentoError> {
     match decode_jwt(auth_token) {
         Ok(c) => Ok(c),
-        Err(_) => Err(MomentoError::InvalidArgument(
-            "Cache name cannot be empty".to_string(),
-        )),
+        Err(e) => Err(e),
     }
 }


### PR DESCRIPTION
Is users paste an invalid auth token, the following error message will be displayed: `Please make sure entered auth token matches your auth token`

Closes #45 