### PR TITLE
chore: clean up SimpleCacheClientBuilder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ homepage = "https://gomomento.com/"
 
 [dependencies]
 momento-protos = { version = "0.18.0" }
+log = "0.4.17"
 tonic = { version = "0.7.2", features = ["tls", "tls-roots", "tls-webpki-roots"] }
 jsonwebtoken = "8.0.1"
 serde = {version = "1.0", features = ["derive"] }
@@ -21,6 +22,7 @@ chrono = {version = "0.4.19", features = ["serde"] }
 
 [dev-dependencies]
 base64-url = "1.4.13"
+env_logger = "0.9.0"
 tokio = { version = "1.9.0", features = ["full"] }
 tokio-test = "0.4.2"
 uuid = { version = "0.8", features = ["v4"] }

--- a/src/endpoint_resolver.rs
+++ b/src/endpoint_resolver.rs
@@ -1,6 +1,7 @@
 use crate::jwt::{decode_jwt, Claims};
 use crate::response::error::MomentoError;
 
+#[derive(Debug)]
 pub struct MomentoEndpoints {
     pub control_endpoint: String,
     pub data_endpoint: String,

--- a/src/endpoint_resolver.rs
+++ b/src/endpoint_resolver.rs
@@ -38,7 +38,7 @@ impl MomentoEndpointsResolver {
     fn wrapped_endpoint(prefix: &str, hostname: String, suffix: &str) -> MomentoEndpoint {
         MomentoEndpoint {
             url: format!("{prefix}{hostname}{suffix}"),
-            hostname: hostname,
+            hostname,
         }
     }
 
@@ -61,10 +61,14 @@ impl MomentoEndpointsResolver {
             return None;
         }
         let hostname = format!("{}{}", prefix, hosted_zone.clone().unwrap());
-        Some(MomentoEndpointsResolver::wrapped_endpoint(prefix, hostname, ""))
+        Some(MomentoEndpointsResolver::wrapped_endpoint(
+            prefix, hostname, "",
+        ))
     }
 
-    fn get_control_endpoint_from_hosted_zone(hosted_zone: &Option<String>) -> Option<MomentoEndpoint> {
+    fn get_control_endpoint_from_hosted_zone(
+        hosted_zone: &Option<String>,
+    ) -> Option<MomentoEndpoint> {
         MomentoEndpointsResolver::hosted_zone_endpoint(hosted_zone, CONTROL_ENDPOINT_PREFIX)
     }
 

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -100,12 +100,12 @@ impl SimpleCacheClientBuilder {
         };
         log::debug!("connecting to endpoints: {:?}", momento_endpoints);
 
-        let control_channel = connect_channel_lazily(&momento_endpoints.control_endpoint)?;
-        let data_channel = connect_channel_lazily(&momento_endpoints.data_endpoint)?;
+        let control_channel = connect_channel_lazily(&momento_endpoints.control_endpoint.url)?;
+        let data_channel = connect_channel_lazily(&momento_endpoints.data_endpoint.url)?;
 
         match utils::is_ttl_valid(&default_ttl_seconds) {
             Ok(_) => Ok(Self {
-                data_endpoint: momento_endpoints.data_endpoint,
+                data_endpoint: momento_endpoints.data_endpoint.hostname,
                 control_channel,
                 data_channel,
                 auth_token,

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -70,13 +70,13 @@ impl SimpleCacheClientBuilder {
     ///
     /// ```
     /// # tokio_test::block_on(async {
-    ///     use momento::simple_cache_client::SimpleCacheClient;
+    ///     use momento::simple_cache_client::SimpleCacheClientBuilder;
     ///     use std::env;
     ///     use std::num::NonZeroU64;
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let default_ttl = 30;
     ///     let momento = SimpleCacheClientBuilder::new(auth_token, NonZeroU64::new(default_ttl).unwrap())
-    ///         .await?
+    ///         .expect("could not create a client")
     ///         .build();
     /// # })
     /// ```
@@ -184,11 +184,13 @@ impl SimpleCacheClient {
     /// use uuid::Uuid;
     /// use std::num::NonZeroU64;
     /// # tokio_test::block_on(async {
-    ///     use momento::simple_cache_client::SimpleCacheClient;
+    ///     use momento::simple_cache_client::SimpleCacheClientBuilder;
     ///     use std::env;
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let cache_name = Uuid::new_v4().to_string();
-    ///     let mut momento = SimpleCacheClient::new(auth_token, NonZeroU64::new(5).unwrap()).await.unwrap();
+    ///     let mut momento = SimpleCacheClientBuilder::new(auth_token, NonZeroU64::new(5).unwrap())
+    ///         .expect("could not create a client")
+    ///         .build();
     ///     momento.create_cache(&cache_name).await;
     ///     momento.delete_cache(&cache_name).await;
     /// # })
@@ -210,11 +212,13 @@ impl SimpleCacheClient {
     /// use uuid::Uuid;
     /// use std::num::NonZeroU64;
     /// # tokio_test::block_on(async {
-    ///     use momento::simple_cache_client::SimpleCacheClient;
+    ///     use momento::simple_cache_client::SimpleCacheClientBuilder;
     ///     use std::env;
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let cache_name = Uuid::new_v4().to_string();
-    ///     let mut momento = SimpleCacheClient::new(auth_token, NonZeroU64::new(5).unwrap()).await.unwrap();
+    ///     let mut momento = SimpleCacheClientBuilder::new(auth_token, NonZeroU64::new(5).unwrap())
+    ///         .expect("could not create a client")
+    ///         .build();
     ///     momento.create_cache(&cache_name).await;
     ///     let caches = momento.list_caches(None).await;
     ///     momento.delete_cache(&cache_name).await;
@@ -294,10 +298,12 @@ impl SimpleCacheClient {
     /// use uuid::Uuid;
     /// use std::num::NonZeroU64;
     /// # tokio_test::block_on(async {
-    ///     use momento::simple_cache_client::SimpleCacheClient;
+    ///     use momento::simple_cache_client::SimpleCacheClientBuilder;
     ///     use std::env;
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
-    ///     let mut momento = SimpleCacheClient::new(auth_token, NonZeroU64::new(5).unwrap()).await.unwrap();
+    ///     let mut momento = SimpleCacheClientBuilder::new(auth_token, NonZeroU64::new(5).unwrap())
+    ///         .expect("could not create a client")
+    ///         .build();
     ///     let ttl_minutes = 10;
     ///     momento.create_signing_key(ttl_minutes).await;
     ///     let keys = momento.list_signing_keys(None).await;
@@ -349,11 +355,13 @@ impl SimpleCacheClient {
     /// use uuid::Uuid;
     /// use std::num::NonZeroU64;
     /// # tokio_test::block_on(async {
-    ///     use momento::simple_cache_client::SimpleCacheClient;
+    ///     use momento::simple_cache_client::SimpleCacheClientBuilder;
     ///     use std::env;
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let cache_name = Uuid::new_v4().to_string();
-    ///     let mut momento = SimpleCacheClient::new(auth_token, NonZeroU64::new(30).unwrap()).await.unwrap();
+    ///     let mut momento = SimpleCacheClientBuilder::new(auth_token, NonZeroU64::new(30).unwrap())
+    ///         .expect("could not create a client")
+    ///         .build();
     ///     momento.create_cache(&cache_name).await;
     ///     momento.set(&cache_name, "cache_key", "cache_value", None).await;
     ///
@@ -404,10 +412,12 @@ impl SimpleCacheClient {
     /// use std::num::NonZeroU64;
     /// # tokio_test::block_on(async {
     ///     use std::env;
-    ///     use momento::{response::cache_get_response::MomentoGetStatus, simple_cache_client::SimpleCacheClient};
+    ///     use momento::{response::cache_get_response::MomentoGetStatus, simple_cache_client::SimpleCacheClientBuilder};
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let cache_name = Uuid::new_v4().to_string();
-    ///     let mut momento = SimpleCacheClient::new(auth_token, NonZeroU64::new(30).unwrap()).await.unwrap();
+    ///     let mut momento = SimpleCacheClientBuilder::new(auth_token, NonZeroU64::new(30).unwrap())
+    ///         .expect("could not create a client")
+    ///         .build();
     ///     momento.create_cache(&cache_name).await;
     ///     let resp = momento.get(&cache_name, "cache_key").await.unwrap();
     ///     match resp.result {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,12 +32,8 @@ pub fn is_key_id_valid(key_id: &str) -> Result<(), MomentoError> {
     Ok(())
 }
 
-pub async fn connect_channel(uri_string: &str, lazy: bool) -> Result<Channel, MomentoError> {
+pub fn connect_channel_lazily(uri_string: &str) -> Result<Channel, MomentoError> {
     let uri = Uri::try_from(uri_string)?;
     let endpoint = Channel::builder(uri).tls_config(ClientTlsConfig::default())?;
-    Ok(if lazy {
-        endpoint.connect_lazy()
-    } else {
-        endpoint.connect().await?
-    })
+    Ok(endpoint.connect_lazy())
 }


### PR DESCRIPTION
* delete a bunch of copy/paste code (let's slow down on that a little)
* add log dependency and inaugural 1 log message that helped me
* add env_logger dev-dependency so a developer can enable logging in tests if they want
* change SimpleCacheClientBuilder's new() to have the same semantics as our
  pre-existing copy/paste method family for creating SimpleCacheClient. It is now lazy
  and will allow endpoint resolution to only happen when an interaction is performed,
  not eagerly (will create a data-only client more quickly now)
* change rust user agents: rust-sdk:VERSION is now the default, and we now have
  rust-integration_test:VERSION and will soon have rust-cli:VERSION.
* fix up tests
