### PR TITLE
feat: add auth login() binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ momento-protos = { version = "0.18.0" }
 log = "0.4.17"
 tonic = { version = "0.7.2", features = ["tls", "tls-roots", "tls-webpki-roots"] }
 jsonwebtoken = "8.0.1"
+rand = "0.8.5"
 serde = {version = "1.0", features = ["derive"] }
 serde_json = "1.0.79"
 chrono = {version = "0.4.19", features = ["serde"] }

--- a/src/endpoint_resolver.rs
+++ b/src/endpoint_resolver.rs
@@ -17,6 +17,7 @@ pub struct MomentoEndpointsResolver {}
 
 const CONTROL_ENDPOINT_PREFIX: &str = "control.";
 const DATA_ENDPOINT_PREFIX: &str = "data.";
+const LOGIN_HOSTNAMES: &[&str] = &["control.cell-us-east-1-1.prod.a.momentohq.com"];
 
 impl MomentoEndpointsResolver {
     pub fn resolve(
@@ -33,6 +34,16 @@ impl MomentoEndpointsResolver {
             control_endpoint,
             data_endpoint,
         })
+    }
+
+    pub fn get_login_hostname() -> String {
+        match std::env::var("LOGIN_HOSTNAME") {
+            Ok(override_hostname) => override_hostname,
+            Err(_) => {
+                let random = rand::random::<usize>();
+                LOGIN_HOSTNAMES[random % LOGIN_HOSTNAMES.len()].to_string()
+            }
+        }
     }
 
     fn wrapped_endpoint(prefix: &str, hostname: String, suffix: &str) -> MomentoEndpoint {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod momento;
 pub mod response;
 pub mod simple_cache_client;
 

--- a/src/momento/auth.rs
+++ b/src/momento/auth.rs
@@ -1,0 +1,125 @@
+use momento_protos::auth::{auth_client::AuthClient, LoginRequest, LoginResponse};
+use tonic::{transport::Channel, Streaming};
+
+use crate::{
+    endpoint_resolver::MomentoEndpointsResolver, response::error::MomentoError,
+    utils::connect_channel_lazily,
+};
+
+/// Initiate a login workflow
+/// You need to provide an implementation for the LoginActions.
+/// ```rust
+/// # use momento::momento::auth::{login, LoginAction, LoginResult};
+/// # async {
+///     let result = login(|action| {
+///       match action {
+///         LoginAction::OpenBrowser(directive) => println!("opening browser to: {}", directive.url),
+///         LoginAction::ShowMessage(message) => println!("showing message: {}", message.text),
+///       }
+///     });
+///     match result.await {
+///       LoginResult::LoggedIn(logged_in) => println!("logged in. session token: {}", logged_in.session_token),
+///       LoginResult::NotLoggedIn(not_logged_in) => println!("failed to log in: {}", not_logged_in.error_message),
+///     };
+/// # };
+/// ```
+pub async fn login<F>(action_sink: F) -> LoginResult
+where
+    F: Fn(LoginAction),
+{
+    let mut client = match auth_client() {
+        Ok(client) => client,
+        Err(error) => return not_logged_in(format!("Failed to create a channel: {:?}", error)),
+    };
+
+    let mut stream_response = match client.login(LoginRequest {}).await {
+        Ok(response) => response,
+        Err(error) => return not_logged_in(format!("Could not get a login response: {:?}", error)),
+    };
+
+    let stream = stream_response.get_mut();
+
+    match consume_login_messages(stream, &action_sink).await {
+        Ok(result) => result,
+        Err(error) => not_logged_in(format!("Failed to log in: {:?}", error)),
+    }
+}
+
+pub enum LoginResult {
+    LoggedIn(LoggedIn),
+    NotLoggedIn(NotLoggedIn),
+}
+
+/// Things that must be done to move the login process forward
+pub enum LoginAction {
+    /// You need to open a browser to an interactive login page. The url is in this message.
+    OpenBrowser(OpenBrowser),
+    /// You can log this; it's for informational purposes.
+    ShowMessage(ShowMessage),
+}
+
+pub struct LoggedIn {
+    pub session_token: String,
+}
+
+pub struct NotLoggedIn {
+    pub error_message: String,
+}
+
+pub struct ShowMessage {
+    pub text: String,
+}
+
+pub struct OpenBrowser {
+    pub url: String,
+}
+
+fn not_logged_in(message: String) -> LoginResult {
+    LoginResult::NotLoggedIn(NotLoggedIn {
+        error_message: message,
+    })
+}
+
+async fn consume_login_messages<F>(
+    stream: &mut Streaming<LoginResponse>,
+    action_sink: &F,
+) -> Result<LoginResult, MomentoError>
+where
+    F: Fn(LoginAction),
+{
+    while let Some(message) = stream.message().await? {
+        match message.state {
+            Some(state) => match state {
+                momento_protos::auth::login_response::State::DirectBrowser(direct) => {
+                    action_sink(LoginAction::OpenBrowser(OpenBrowser { url: direct.url }))
+                }
+                momento_protos::auth::login_response::State::Message(message) => {
+                    action_sink(LoginAction::ShowMessage(ShowMessage { text: message.text }))
+                }
+                momento_protos::auth::login_response::State::LoggedIn(success) => {
+                    return Ok(LoginResult::LoggedIn(LoggedIn {
+                        session_token: success.session_token,
+                    }))
+                }
+                momento_protos::auth::login_response::State::Error(failure) => {
+                    return Ok(LoginResult::NotLoggedIn(NotLoggedIn {
+                        error_message: failure.description,
+                    }))
+                }
+            },
+            None => action_sink(LoginAction::ShowMessage(ShowMessage {
+                text: "Invalid login state received: no state".to_string(),
+            })),
+        }
+    }
+
+    Ok(LoginResult::NotLoggedIn(NotLoggedIn {
+        error_message: "Login was aborted".to_string(),
+    }))
+}
+
+fn auth_client() -> Result<AuthClient<Channel>, MomentoError> {
+    let hostname = MomentoEndpointsResolver::get_login_hostname();
+    let channel = connect_channel_lazily(&hostname)?;
+    Ok(AuthClient::new(channel))
+}

--- a/src/momento/mod.rs
+++ b/src/momento/mod.rs
@@ -1,0 +1,1 @@
+pub mod auth;


### PR DESCRIPTION
This adds an auth module. The flagship functionality is the login()
method. This method is the bridge between the grpc login message
stream and login implementations; to wit, `momento` looms large in
one's mind.

These types are a bit obtuse, and Rust is a little nascent in its
support of a couple things that would allow me to make a cleaner
api. Asynchronous generators and yield syntax being moved into
the `stable` release would do nice things for this shape. As a
consequence of this, testing beyond doctest modeling has proven
to be more of an effort than it is worth - particularly as the
service implementation does not yet exist.

As it is, the doctest illustrates the 2 facets of a login:
* LoginAction - actions to be taken by an integration during a login
* LoginResult - the final outcome of the login.
The actor method that an integration supplies to a login simply follows
the instructions sent down by the Momento login server, and the caller
of login() simply uses the result of the login, whether successful or
not.

Note that there are no unwrap()'s or expect()'s. The only panics that
shall rise out of a login() invocation will be bugs or fatal
environment errors beyond our control.