### PR TITLE
chore: Align MomentoCacheListResponse and list_caches

### DIFF
--- a/src/response/list_cache_response.rs
+++ b/src/response/list_cache_response.rs
@@ -11,5 +11,5 @@ pub struct MomentoListCacheResult {
     /// Vector of cache information defined in MomentoCache.
     pub caches: Vec<MomentoCache>,
     /// Next Page Token returned by Simple Cache Service along with the list of caches.
-    pub next_token: String,
+    pub next_token: Option<String>,
 }

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -241,7 +241,10 @@ impl SimpleCacheClient {
             .collect();
         let response = MomentoListCacheResult {
             caches,
-            next_token: res.next_token,
+            next_token: match res.next_token.is_empty() {
+                true => None,
+                false => Some(res.next_token),
+            },
         };
         Ok(response)
     }

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -226,10 +226,10 @@ impl SimpleCacheClient {
     /// ```
     pub async fn list_caches(
         &mut self,
-        next_token: Option<&str>,
+        next_token: Option<String>,
     ) -> Result<MomentoListCacheResult, MomentoError> {
         let request = Request::new(ListCachesRequest {
-            next_token: next_token.unwrap_or_default().to_string(),
+            next_token: next_token.unwrap_or("".to_string())
         });
         let res = self.control_client.list_caches(request).await?.into_inner();
         let caches = res

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -229,7 +229,7 @@ impl SimpleCacheClient {
         next_token: Option<String>,
     ) -> Result<MomentoListCacheResult, MomentoError> {
         let request = Request::new(ListCachesRequest {
-            next_token: next_token.unwrap_or("".to_string())
+            next_token: next_token.unwrap_or("".to_string()),
         });
         let res = self.control_client.list_caches(request).await?.into_inner();
         let caches = res

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -229,7 +229,7 @@ impl SimpleCacheClient {
         next_token: Option<String>,
     ) -> Result<MomentoListCacheResult, MomentoError> {
         let request = Request::new(ListCachesRequest {
-            next_token: next_token.unwrap_or("".to_string()),
+            next_token: next_token.unwrap_or_else(|| "".to_string()),
         });
         let res = self.control_client.list_caches(request).await?.into_inner();
         let caches = res

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -142,7 +142,11 @@ mod tests {
         let cache_name = Uuid::new_v4().to_string();
         let mut mm = get_momento_instance();
         mm.create_cache(&cache_name).await.unwrap();
-        mm.list_caches(None).await.unwrap();
+        let list_cache_response = mm.list_caches(None).await.unwrap();
+        assert_eq!(
+            list_cache_response.next_token, None,
+            "we expect a single page of caches to list"
+        );
         mm.delete_cache(&cache_name).await.unwrap();
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -154,10 +154,7 @@ mod tests {
             }
         }
 
-        assert_eq!(
-            1, num_pages,
-            "we expect a single page of caches to list"
-        );
+        assert_eq!(1, num_pages, "we expect a single page of caches to list");
         mm.delete_cache(&cache_name).await.unwrap();
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -142,9 +142,20 @@ mod tests {
         let cache_name = Uuid::new_v4().to_string();
         let mut mm = get_momento_instance();
         mm.create_cache(&cache_name).await.unwrap();
-        let list_cache_response = mm.list_caches(None).await.unwrap();
+
+        let mut next_token: Option<String> = None;
+        let mut num_pages = 0;
+        loop {
+            let list_cache_result = mm.list_caches(next_token).await.unwrap();
+            num_pages += 1;
+            next_token = list_cache_result.next_token;
+            if next_token == None {
+                break;
+            }
+        }
+
         assert_eq!(
-            list_cache_response.next_token, None,
+            1, num_pages,
             "we expect a single page of caches to list"
         );
         mm.delete_cache(&cache_name).await.unwrap();


### PR DESCRIPTION
The method `SimpleCacheClient::list_caches` supports pagination. It does this by means of
the parameter `next_token`: the client starts iteration with this set to
`None`, and ends when `MomentoCacheListResponse::next_token` is `None`.

Previously `MomentoCacheListResponse::next_token` was not optional, so
the end sentinel was empty string as opposed to `None`. This means the
client would have to start iteration with `None` and test for end
iteration comparing to empty string, which is confusing.