### PR TITLE
chore: improve login()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://gomomento.com/"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-momento-protos = { version = "0.18.0" }
+momento-protos = { version = "0.18.1" }
 log = "0.4.17"
 tonic = { version = "0.7.2", features = ["tls", "tls-roots", "tls-webpki-roots"] }
 jsonwebtoken = "8.0.1"

--- a/src/momento/auth.rs
+++ b/src/momento/auth.rs
@@ -28,8 +28,7 @@ pub type LoginActionConsumer = fn(LoginAction) -> EarlyOutActionResult;
 ///     };
 /// # };
 /// ```
-pub async fn login(action_sink: LoginActionConsumer) -> LoginResult
-{
+pub async fn login(action_sink: LoginActionConsumer) -> LoginResult {
     let mut client = match auth_client() {
         Ok(client) => client,
         Err(error) => return not_logged_in(format!("Failed to create a channel: {:?}", error)),


### PR DESCRIPTION
* add login message handler early-out ability to abort login when
  browsers fail to open
* add session validity seconds to logged in message
* simplify login message handler callback type (`Fn` is not needed, `fn` is enough)
