### PR TITLE
fix: Hosted Endpoint Construction and Claim validation

### DIFF
--- a/src/endpoint_resolver.rs
+++ b/src/endpoint_resolver.rs
@@ -153,7 +153,7 @@ mod tests {
 
     #[test]
     fn error_when_no_cp_c_claims_and_no_hosted_zone() {
-        let valid_auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhYmNkIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.PTgxba";
+        let invalid_auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhYmNkIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.PTgxba";
         let e = MomentoEndpointsResolver::resolve(valid_auth_token, None).unwrap_err();
         let _err_msg =
             "Could not parse token. Please ensure a valid token was entered correctly.".to_owned();

--- a/src/endpoint_resolver.rs
+++ b/src/endpoint_resolver.rs
@@ -154,7 +154,7 @@ mod tests {
     #[test]
     fn error_when_no_cp_c_claims_and_no_hosted_zone() {
         let invalid_auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhYmNkIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.PTgxba";
-        let e = MomentoEndpointsResolver::resolve(valid_auth_token, None).unwrap_err();
+        let e = MomentoEndpointsResolver::resolve(invalid_auth_token, None).unwrap_err();
         let _err_msg =
             "Could not parse token. Please ensure a valid token was entered correctly.".to_owned();
         assert!(matches!(e, MomentoError::ClientSdkError(_err_msg)));

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -33,6 +33,7 @@ pub fn decode_jwt(jwt: &str, momento_endpoint: Option<String>) -> Result<Claims,
             // If Momento Endpoint is not provided, then `c` and `cp` claims must be present
             if momento_endpoint.is_none() && (token_claims.c.is_none() || token_claims.cp.is_none())
             {
+                log::debug!("Momento Endpoint is none and auth token is missing endpoints");
                 Err(token_parsing_error())
             } else {
                 Ok(token_claims)

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -21,16 +21,16 @@ pub fn decode_jwt(jwt: &str, momento_endpoint: Option<String>) -> Result<Claims,
     validation.required_spec_claims.clear();
     validation.required_spec_claims.insert("sub".to_string());
 
-    validation.required_spec_claims.insert("c".to_string());
-    validation.required_spec_claims.insert("cp".to_string());
-
     validation.validate_exp = false;
     validation.insecure_disable_signature_validation();
+
     match decode(jwt, &key, &validation) {
         Ok(token) => {
             let token_claims: Claims = token.claims;
 
-            // If Momento Endpoint is not provided, then `c` and `cp` claims must be present
+            // If Momento Endpoint is not provided, then `c` and `cp` claims must be present.
+            // If Momento Endpoint is present then that always takes precedence over the c and cp
+            // claims in the JWT, hence, there is no need to look for all possibilities.
             if momento_endpoint.is_none() && (token_claims.c.is_none() || token_claims.cp.is_none())
             {
                 log::debug!("Momento Endpoint is none and auth token is missing endpoints");

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -21,20 +21,31 @@ pub fn decode_jwt(jwt: &str, momento_endpoint: Option<String>) -> Result<Claims,
     validation.required_spec_claims.clear();
     validation.required_spec_claims.insert("sub".to_string());
 
-    // Global session tokens and new auth tokens will not contain these claims.
-    if momento_endpoint.is_none() {
-        validation.required_spec_claims.insert("c".to_string());
-        validation.required_spec_claims.insert("cp".to_string());
-    }
+    validation.required_spec_claims.insert("c".to_string());
+    validation.required_spec_claims.insert("cp".to_string());
 
     validation.validate_exp = false;
     validation.insecure_disable_signature_validation();
     match decode(jwt, &key, &validation) {
-        Ok(token) => Ok(token.claims),
-        Err(_) => Err(MomentoError::ClientSdkError(
-            "Could not parse token. Please ensure a valid token was entered correctly.".to_string(),
-        )),
+        Ok(token) => {
+            let token_claims: Claims = token.claims;
+
+            // If Momento Endpoint is not provided, then `c` and `cp` claims must be present
+            if momento_endpoint.is_none() && (token_claims.c.is_none() || token_claims.cp.is_none())
+            {
+                Err(token_parsing_error())
+            } else {
+                Ok(token_claims)
+            }
+        }
+        Err(_) => Err(token_parsing_error()),
     }
+}
+
+fn token_parsing_error() -> MomentoError {
+    MomentoError::ClientSdkError(
+        "Could not parse token. Please ensure a valid token was entered correctly.".to_string(),
+    )
 }
 
 #[cfg(test)]
@@ -72,5 +83,13 @@ mod tests {
         assert_eq!(claims.sub, "abcd");
         assert!(claims.c.is_none());
         assert!(claims.cp.is_none());
+    }
+
+    #[test]
+    fn invalid_no_c_cp_claims_jwt_with_no_momento_endpoint() {
+        let e = decode_jwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhYmNkIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.PTgxba", None).unwrap_err();
+        let _err_msg =
+            "Could not parse token. Please ensure a valid token was entered correctly.".to_owned();
+        assert!(matches!(e, MomentoError::ClientSdkError(_err_msg)));
     }
 }


### PR DESCRIPTION
1. Hosted endpoint construction was incomplete and didn't generate correct urls.

2. The claim validation is based on the fields in `Claims`. So even if we require validation for `c` and `cp` claims, since these are Option<String> the validation succeeds. It required an additional check to enforce validation that `c` or `cp` claims must not be none when `momento_endpoint` is not specified.