### PR TITLE
chore: move SDK examples from `client-sdk-examples`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo" # See documentation for possible values
+    directory: "/examples" # Location of package manifests
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "momento"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   rustfmt:
@@ -16,13 +17,13 @@ jobs:
 
       - name: Commitlint and Other Shared Build Steps
         uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: rustfmt
         run: cargo fmt -- --check
+
       - name: Rigorous lint via Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+
   build_rust:
     runs-on: ubuntu-latest
     env:
@@ -40,3 +41,31 @@ jobs:
         run: cargo test --doc
       - name: Integration Tests
         run: cargo test --tests
+
+  rustfmt-build-examples:
+    name: Style & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Commitlint and Other Shared Build Steps
+        uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1
+
+      - name: rustfmt -> rigorous lint via Clippy -> build
+        id: validation
+        continue-on-error: true
+        run: |
+          pushd examples
+            cargo fmt -- --check
+            cargo clippy --all-targets --all-features -- -D warnings
+            cargo build --verbose
+          popd
+      - name: Send CI failure mail
+        if: ${{ steps.validation.outcome == 'failure' }}
+        uses: ./.github/actions/error-email-action
+        with:
+          username: ${{secrets.MOMENTO_ROBOT_GMAIL_USERNAME}}
+          password: ${{secrets.MOMENTO_ROBOT_GMAIL_PASSWORD}}
+      - name: Flag Job Failure
+        if: ${{ steps.validation.outcome == 'failure' }}
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Rust SDK for Momento, a serverless cache that automatically scales without any o
 
 <br/>
 
+### Installing Momento and Running the Example
+
+Check out [examples](./examples/) directory!
+
+<br/>
+
 ### Using Momento
 
 ```rust

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,3 @@
+/target
+.idea/
+.DS_Store

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+momento = "0.7.3"
+tokio = { version = "1.18.2", features = ["full"] }

--- a/examples/README.ja.md
+++ b/examples/README.ja.md
@@ -1,0 +1,23 @@
+# Rust クライアント SDK
+
+_他言語バージョンもあります_：[English](README.md)
+
+<br>
+
+## SDK のコード例を実行する
+
+- Rust と Cargo が必要です。 [インストレーションガイド](https://doc.rust-lang.org/cargo/getting-started/installation.html)。
+- Momento オーストークンが必要です。トークン発行は[Momento CLI](https://github.com/momentohq/momento-cli)から行えます。
+
+```bash
+cargo build
+
+# SDKコード例を実行する
+MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> ./target/debug/rust
+```
+
+SDK コード例: [main.rs](src/main.rs)
+
+## SDK を自身のプロジェクトで使用する
+
+`momento = "0.3.1"`をご自身の Cargo.toml ファイルに追加してください。もしくは最新バージョンを[こちら](https://crates.io/crates/momento)からご確認下さい。

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,23 @@
+# Rust Client SDK
+
+_Read this in other languages_: [日本語](README.ja.md)
+
+<br>
+
+## Running the Example
+
+- Rust and Cargo are needed. [Installation guide](https://doc.rust-lang.org/cargo/getting-started/installation.html).
+- A Momento Auth Token is required, you can generate one using the [Momento CLI](https://github.com/momentohq/momento-cli)
+
+```bash
+cargo build
+
+# Run example code
+MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> ./target/debug/rust
+```
+
+Example Code: [main.rs](src/main.rs)
+
+## Using the SDK in your projects
+
+Add the following line to your Cargo.toml file: `momento = "0.3.1"`, or you can check out the latest version [here](https://crates.io/crates/momento).

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -1,0 +1,88 @@
+use momento::response::cache_get_response::MomentoGetStatus;
+use momento::simple_cache_client::SimpleCacheClientBuilder;
+use std::env;
+use std::num::NonZeroU64;
+use std::process;
+
+#[tokio::main]
+async fn main() {
+    // Initializing Momento
+    let auth_token =
+        env::var("MOMENTO_AUTH_TOKEN").expect("env var MOMENTO_AUTH_TOKEN must be set");
+    let item_default_ttl_seconds = 60;
+    let mut cache_client = match SimpleCacheClientBuilder::new(
+        auth_token,
+        NonZeroU64::new(item_default_ttl_seconds).unwrap(),
+    ) {
+        Ok(client) => client,
+        Err(err) => {
+            eprintln!("{}", err);
+            process::exit(1);
+        }
+    }
+    .build();
+
+    // Creating a cache named "cache"
+    let cache_name = String::from("cache");
+    match cache_client.create_cache(&cache_name).await {
+        Ok(_) => {}
+        Err(err) => {
+            eprintln!("{}", err);
+        }
+    }
+
+    // List the caches
+    println!("Listing caches:");
+    let mut next_token: Option<String> = None;
+    loop {
+        next_token = match cache_client.list_caches(next_token).await {
+            Ok(list_cache_result) => {
+                for listed_cache in list_cache_result.caches {
+                    println!("{}", listed_cache.cache_name);
+                }
+                list_cache_result.next_token
+            }
+            Err(err) => {
+                eprintln!("{}", err);
+                break;
+            }
+        };
+        if next_token == None {
+            break;
+        }
+    }
+    println!();
+
+    // Sets key with default TTL and get value with that key
+    let key = String::from("my_key");
+    let value = String::from("my_value");
+    println!("Setting key: {}, value: {}", key, value);
+    match cache_client
+        .set(&cache_name, key.clone(), value.clone(), None)
+        .await
+    {
+        Ok(_) => {}
+        Err(err) => {
+            eprintln!("{}", err);
+        }
+    };
+    match cache_client.get(&cache_name, key.clone()).await {
+        Ok(r) => match r.result {
+            MomentoGetStatus::HIT => println!("cache hit!"),
+            MomentoGetStatus::MISS => println!("cache miss"),
+            _ => println!("error occurred"),
+        },
+        Err(err) => {
+            eprintln!("{}", err);
+        }
+    };
+    // Permanently deletes cache
+    match cache_client.delete_cache(&cache_name).await {
+        Ok(_) => {
+            println!("Permanently deleted cache named, {}", cache_name);
+        }
+        Err(err) => {
+            eprintln!("{}", err);
+        }
+    };
+}


### PR DESCRIPTION
Added dependabot and updated the ci workflow as well.