### PR TITLE
chore: fix clippy warnings for timestamps parsing

### DIFF
--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -307,7 +307,7 @@ impl SimpleCacheClient {
             key_id: kid.as_str().unwrap().to_owned(),
             key: res.key,
             expires_at: DateTime::<Utc>::from_utc(
-                NaiveDateTime::from_timestamp(res.expires_at as i64, 0),
+                NaiveDateTime::from_timestamp_opt(res.expires_at as i64, 0).unwrap(),
                 Utc,
             ),
             endpoint: self.data_endpoint.clone(),
@@ -366,7 +366,7 @@ impl SimpleCacheClient {
             .map(|signing_key| MomentoSigningKey {
                 key_id: signing_key.key_id.to_string(),
                 expires_at: DateTime::<Utc>::from_utc(
-                    NaiveDateTime::from_timestamp(signing_key.expires_at as i64, 0),
+                    NaiveDateTime::from_timestamp_opt(signing_key.expires_at as i64, 0).unwrap(),
                     Utc,
                 ),
                 endpoint: self.data_endpoint.clone(),


### PR DESCRIPTION
Resolves the following clippy errors
```bash
error: use of deprecated associated function `chrono::NaiveDateTime::from_timestamp`: use `from_timestamp_opt()` instead
   --> src/simple_cache_client.rs:310:32
    |
310 |                 NaiveDateTime::from_timestamp(res.expires_at as i64, 0),
    |                                ^^^^^^^^^^^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`

error: use of deprecated associated function `chrono::NaiveDateTime::from_timestamp`: use `from_timestamp_opt()` instead
   --> src/simple_cache_client.rs:369:36
    |
369 |                     NaiveDateTime::from_timestamp(signing_key.expires_at as i64, 0),
    |                                    ^^^^^^^^^^^^^^

error: could not compile `momento` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: build failed
```