### PR TITLE
chore: clean up .unwrap() uses and add clippy check to repo

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,7 @@ jobs:
       - name: rustfmt
         run: cargo fmt -- --check
       - name: Rigorous lint via Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings -W clippy::unwrap_used
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Rigorous lint via Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings -W clippy::unwrap_used
 
   build_rust:
     runs-on: ubuntu-latest
@@ -57,7 +57,7 @@ jobs:
         run: |
           pushd examples
             cargo fmt -- --check
-            cargo clippy --all-targets --all-features -- -D warnings
+            cargo clippy --all-targets --all-features -- -D warnings -W clippy::unwrap_used 
             cargo build --verbose
           popd
       - name: Send CI failure mail

--- a/README.md
+++ b/README.md
@@ -96,3 +96,23 @@ Running integration tests:
 ```
 TEST_AUTH_TOKEN=<auth token> cargo test --tests
 ```
+
+## Development 🔨
+
+At Momento, we believe [exceptions are bugs](https://www.gomomento.com/blog/exceptions-are-bugs). In Rust, this means the
+unchecked use of `.unwrap()` calls inherently fills your code with bugs and makes debugging `panic` calls a lot more difficult.
+
+We rigorously check for proper formatting and use `clippy` to check for good code practices as well as avoiding `.unwrap()` calls. Instead, try to use
+an alternative, including but not limited to:
+
+- `.expect("descriptive error message")`
+- `.unwrap_or_default("default string goes here")`
+- Use `?` to have the caller handle the error
+
+### Building
+
+Run this command to verify everything passes so that you can save yourself some time when our GitHub actions are ran against the commit:
+
+```bash
+cargo build && cargo clippy --all-targets --all-features -- -D warnings -W clippy::unwrap_used
+```

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -12,7 +12,7 @@ async fn main() {
     let item_default_ttl_seconds = 60;
     let mut cache_client = match SimpleCacheClientBuilder::new(
         auth_token,
-        NonZeroU64::new(item_default_ttl_seconds).unwrap(),
+        NonZeroU64::new(item_default_ttl_seconds).expect("expected a non-zero number"),
     ) {
         Ok(client) => client,
         Err(err) => {

--- a/src/endpoint_resolver.rs
+++ b/src/endpoint_resolver.rs
@@ -71,13 +71,29 @@ impl MomentoEndpointsResolver {
 
     fn get_control_endpoint(claims: &Claims, hosted_zone: Option<String>) -> MomentoEndpoint {
         MomentoEndpointsResolver::get_control_endpoint_from_hosted_zone(hosted_zone).unwrap_or_else(
-            || MomentoEndpointsResolver::https_endpoint(claims.cp.as_ref().expect("expected cp to be provided").to_owned()),
+            || {
+                MomentoEndpointsResolver::https_endpoint(
+                    claims
+                        .cp
+                        .as_ref()
+                        .expect("expected cp to be provided")
+                        .to_owned(),
+                )
+            },
         )
     }
 
     fn get_data_endpoint(claims: &Claims, hosted_zone: Option<String>) -> MomentoEndpoint {
         MomentoEndpointsResolver::get_data_endpoint_from_hosted_zone(hosted_zone).unwrap_or_else(
-            || MomentoEndpointsResolver::https_endpoint(claims.c.as_ref().expect("expected c to be provided").to_owned()),
+            || {
+                MomentoEndpointsResolver::https_endpoint(
+                    claims
+                        .c
+                        .as_ref()
+                        .expect("expected c to be provided")
+                        .to_owned(),
+                )
+            },
         )
     }
 
@@ -109,19 +125,35 @@ mod tests {
         let valid_auth_token = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzcXVpcnJlbCIsImNwIjoiY29udHJvbCBwbGFuZSBlbmRwb2ludCIsImMiOiJkYXRhIHBsYW5lIGVuZHBvaW50In0.zsTsEXFawetTCZI";
         let endpoints = MomentoEndpointsResolver::resolve(valid_auth_token, None);
         assert_eq!(
-            endpoints.as_ref().expect("expected valid endpoints result").data_endpoint.hostname,
+            endpoints
+                .as_ref()
+                .expect("expected valid endpoints result")
+                .data_endpoint
+                .hostname,
             "data plane endpoint"
         );
         assert_eq!(
-            endpoints.as_ref().expect("expected valid endpoints result").data_endpoint.url,
+            endpoints
+                .as_ref()
+                .expect("expected valid endpoints result")
+                .data_endpoint
+                .url,
             "https://data plane endpoint:443"
         );
         assert_eq!(
-            endpoints.as_ref().expect("expected valid endpoints result").control_endpoint.hostname,
+            endpoints
+                .as_ref()
+                .expect("expected valid endpoints result")
+                .control_endpoint
+                .hostname,
             "control plane endpoint"
         );
         assert_eq!(
-            endpoints.as_ref().expect("expected valid endpoints result").control_endpoint.url,
+            endpoints
+                .as_ref()
+                .expect("expected valid endpoints result")
+                .control_endpoint
+                .url,
             "https://control plane endpoint:443"
         );
     }
@@ -134,19 +166,35 @@ mod tests {
             Some("hello.gomomento.com".to_string()),
         );
         assert_eq!(
-            endpoints.as_ref().expect("expected valid endpoints result").data_endpoint.hostname,
+            endpoints
+                .as_ref()
+                .expect("expected valid endpoints result")
+                .data_endpoint
+                .hostname,
             "cache.hello.gomomento.com"
         );
         assert_eq!(
-            endpoints.as_ref().expect("expected valid endpoints result").data_endpoint.url,
+            endpoints
+                .as_ref()
+                .expect("expected valid endpoints result")
+                .data_endpoint
+                .url,
             "https://cache.hello.gomomento.com:443"
         );
         assert_eq!(
-            endpoints.as_ref().expect("expected valid endpoints result").control_endpoint.hostname,
+            endpoints
+                .as_ref()
+                .expect("expected valid endpoints result")
+                .control_endpoint
+                .hostname,
             "control.hello.gomomento.com"
         );
         assert_eq!(
-            endpoints.as_ref().expect("expected valid endpoints result").control_endpoint.url,
+            endpoints
+                .as_ref()
+                .expect("expected valid endpoints result")
+                .control_endpoint
+                .url,
             "https://control.hello.gomomento.com:443"
         );
     }

--- a/src/endpoint_resolver.rs
+++ b/src/endpoint_resolver.rs
@@ -71,13 +71,13 @@ impl MomentoEndpointsResolver {
 
     fn get_control_endpoint(claims: &Claims, hosted_zone: Option<String>) -> MomentoEndpoint {
         MomentoEndpointsResolver::get_control_endpoint_from_hosted_zone(hosted_zone).unwrap_or_else(
-            || MomentoEndpointsResolver::https_endpoint(claims.cp.as_ref().unwrap().to_owned()),
+            || MomentoEndpointsResolver::https_endpoint(claims.cp.as_ref().expect("expected cp to be provided").to_owned()),
         )
     }
 
     fn get_data_endpoint(claims: &Claims, hosted_zone: Option<String>) -> MomentoEndpoint {
         MomentoEndpointsResolver::get_data_endpoint_from_hosted_zone(hosted_zone).unwrap_or_else(
-            || MomentoEndpointsResolver::https_endpoint(claims.c.as_ref().unwrap().to_owned()),
+            || MomentoEndpointsResolver::https_endpoint(claims.c.as_ref().expect("expected c to be provided").to_owned()),
         )
     }
 
@@ -109,19 +109,19 @@ mod tests {
         let valid_auth_token = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzcXVpcnJlbCIsImNwIjoiY29udHJvbCBwbGFuZSBlbmRwb2ludCIsImMiOiJkYXRhIHBsYW5lIGVuZHBvaW50In0.zsTsEXFawetTCZI";
         let endpoints = MomentoEndpointsResolver::resolve(valid_auth_token, None);
         assert_eq!(
-            endpoints.as_ref().unwrap().data_endpoint.hostname,
+            endpoints.as_ref().expect("expected valid endpoints result").data_endpoint.hostname,
             "data plane endpoint"
         );
         assert_eq!(
-            endpoints.as_ref().unwrap().data_endpoint.url,
+            endpoints.as_ref().expect("expected valid endpoints result").data_endpoint.url,
             "https://data plane endpoint:443"
         );
         assert_eq!(
-            endpoints.as_ref().unwrap().control_endpoint.hostname,
+            endpoints.as_ref().expect("expected valid endpoints result").control_endpoint.hostname,
             "control plane endpoint"
         );
         assert_eq!(
-            endpoints.as_ref().unwrap().control_endpoint.url,
+            endpoints.as_ref().expect("expected valid endpoints result").control_endpoint.url,
             "https://control plane endpoint:443"
         );
     }
@@ -134,19 +134,19 @@ mod tests {
             Some("hello.gomomento.com".to_string()),
         );
         assert_eq!(
-            endpoints.as_ref().unwrap().data_endpoint.hostname,
+            endpoints.as_ref().expect("expected valid endpoints result").data_endpoint.hostname,
             "cache.hello.gomomento.com"
         );
         assert_eq!(
-            endpoints.as_ref().unwrap().data_endpoint.url,
+            endpoints.as_ref().expect("expected valid endpoints result").data_endpoint.url,
             "https://cache.hello.gomomento.com:443"
         );
         assert_eq!(
-            endpoints.as_ref().unwrap().control_endpoint.hostname,
+            endpoints.as_ref().expect("expected valid endpoints result").control_endpoint.hostname,
             "control.hello.gomomento.com"
         );
         assert_eq!(
-            endpoints.as_ref().unwrap().control_endpoint.url,
+            endpoints.as_ref().expect("expected valid endpoints result").control_endpoint.url,
             "https://control.hello.gomomento.com:443"
         );
     }

--- a/src/grpc/header_interceptor.rs
+++ b/src/grpc/header_interceptor.rs
@@ -25,13 +25,15 @@ impl tonic::service::Interceptor for HeaderInterceptor {
 
         request.metadata_mut().insert(
             tonic::metadata::AsciiMetadataKey::from_static("authorization"),
-            tonic::metadata::AsciiMetadataValue::try_from(&self.auth_token).expect("couldn't parse val from auth token"),
+            tonic::metadata::AsciiMetadataValue::try_from(&self.auth_token)
+                .expect("couldn't parse val from auth token"),
         );
 
         if !ARE_ONLY_ONCE_HEADER_SENT.load(Ordering::Relaxed) {
             request.metadata_mut().insert(
                 tonic::metadata::AsciiMetadataKey::from_static("agent"),
-                tonic::metadata::AsciiMetadataValue::try_from(&self.sdk_agent).expect("couldn't parse val from auth token"),
+                tonic::metadata::AsciiMetadataValue::try_from(&self.sdk_agent)
+                    .expect("couldn't parse val from auth token"),
             );
             ARE_ONLY_ONCE_HEADER_SENT.store(true, Ordering::Relaxed);
         }

--- a/src/grpc/header_interceptor.rs
+++ b/src/grpc/header_interceptor.rs
@@ -25,13 +25,13 @@ impl tonic::service::Interceptor for HeaderInterceptor {
 
         request.metadata_mut().insert(
             tonic::metadata::AsciiMetadataKey::from_static("authorization"),
-            tonic::metadata::AsciiMetadataValue::try_from(&self.auth_token).unwrap(),
+            tonic::metadata::AsciiMetadataValue::try_from(&self.auth_token).expect("couldn't parse val from auth token"),
         );
 
         if !ARE_ONLY_ONCE_HEADER_SENT.load(Ordering::Relaxed) {
             request.metadata_mut().insert(
                 tonic::metadata::AsciiMetadataKey::from_static("agent"),
-                tonic::metadata::AsciiMetadataValue::try_from(&self.sdk_agent).unwrap(),
+                tonic::metadata::AsciiMetadataValue::try_from(&self.sdk_agent).expect("couldn't parse val from auth token"),
             );
             ARE_ONLY_ONCE_HEADER_SENT.store(true, Ordering::Relaxed);
         }

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -60,7 +60,10 @@ mod tests {
         let valid_jwt = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzcXVpcnJlbCIsImNwIjoiY29udHJvbCBwbGFuZSBlbmRwb2ludCIsImMiOiJkYXRhIHBsYW5lIGVuZHBvaW50In0.zsTsEXFawetTCZI";
         let claims = decode_jwt(valid_jwt, None).expect("couldn't decode jwt");
         assert_eq!(claims.c.expect("c wasn't present"), "data plane endpoint");
-        assert_eq!(claims.cp.expect("cp wasn't present"), "control plane endpoint");
+        assert_eq!(
+            claims.cp.expect("cp wasn't present"),
+            "control plane endpoint"
+        );
     }
 
     #[test]

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -58,9 +58,9 @@ mod tests {
     #[test]
     fn valid_jwt() {
         let valid_jwt = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzcXVpcnJlbCIsImNwIjoiY29udHJvbCBwbGFuZSBlbmRwb2ludCIsImMiOiJkYXRhIHBsYW5lIGVuZHBvaW50In0.zsTsEXFawetTCZI";
-        let claims = decode_jwt(valid_jwt, None).unwrap();
-        assert_eq!(claims.c.unwrap(), "data plane endpoint");
-        assert_eq!(claims.cp.unwrap(), "control plane endpoint");
+        let claims = decode_jwt(valid_jwt, None).expect("couldn't decode jwt");
+        assert_eq!(claims.c.expect("c wasn't present"), "data plane endpoint");
+        assert_eq!(claims.cp.expect("cp wasn't present"), "control plane endpoint");
     }
 
     #[test]
@@ -80,7 +80,7 @@ mod tests {
 
     #[test]
     fn validate_no_c_cp_claims_jwt_with_momento_endpoint() {
-        let claims = decode_jwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhYmNkIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.PTgxba", Some("help.com".to_string())).unwrap();
+        let claims = decode_jwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhYmNkIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.PTgxba", Some("help.com".to_string())).expect("result not returned from jwt");
         assert_eq!(claims.sub, "abcd");
         assert!(claims.c.is_none());
         assert!(claims.cp.is_none());

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -300,14 +300,20 @@ impl SimpleCacheClient {
             .create_signing_key(request)
             .await?
             .into_inner();
-        let key: Value = serde_json::from_str(&res.key).unwrap();
-        let obj = key.as_object().unwrap();
-        let kid = obj.get("kid").unwrap();
+        let key: Value =
+            serde_json::from_str(&res.key).expect("failed to parse key from json string");
+        let obj = key
+            .as_object()
+            .expect("couldn't cast json value to a Map<String, Value>");
+        let kid = obj
+            .get("kid")
+            .expect("object didn't contain key 'kid', this is required");
         let response = MomentoCreateSigningKeyResponse {
-            key_id: kid.as_str().unwrap().to_owned(),
+            key_id: kid.as_str().expect("'kid' not a valid str").to_owned(),
             key: res.key,
             expires_at: DateTime::<Utc>::from_utc(
-                NaiveDateTime::from_timestamp_opt(res.expires_at as i64, 0).unwrap(),
+                NaiveDateTime::from_timestamp_opt(res.expires_at as i64, 0)
+                    .expect("couldn't parse from timestamp"),
                 Utc,
             ),
             endpoint: self.data_endpoint.clone(),
@@ -366,7 +372,8 @@ impl SimpleCacheClient {
             .map(|signing_key| MomentoSigningKey {
                 key_id: signing_key.key_id.to_string(),
                 expires_at: DateTime::<Utc>::from_utc(
-                    NaiveDateTime::from_timestamp_opt(signing_key.expires_at as i64, 0).unwrap(),
+                    NaiveDateTime::from_timestamp_opt(signing_key.expires_at as i64, 0)
+                        .expect("couldn't parse timestamp from signing key"),
                     Utc,
                 ),
                 endpoint: self.data_endpoint.clone(),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -17,7 +17,7 @@ mod tests {
     ) -> Result<SimpleCacheClientBuilder, MomentoError> {
         SimpleCacheClientBuilder::new_with_explicit_agent_name(
             auth_token,
-            NonZeroU64::new(5).unwrap(),
+            NonZeroU64::new(5).expect("expected a non-zero number"),
             "integration_test",
             None,
         )
@@ -35,10 +35,10 @@ mod tests {
         let cache_name = Uuid::new_v4().to_string();
         let cache_key = Uuid::new_v4().to_string();
         let mut mm = get_momento_instance();
-        mm.create_cache(&cache_name).await.unwrap();
-        let result = mm.get(&cache_name, cache_key).await.unwrap();
+        mm.create_cache(&cache_name).await.expect("failed to create cache");
+        let result = mm.get(&cache_name, cache_key).await.expect("failure when trying get");
         assert!(matches!(result.result, MomentoGetStatus::MISS));
-        mm.delete_cache(&cache_name).await.unwrap();
+        mm.delete_cache(&cache_name).await.expect("failed to delete cache");
     }
 
     #[tokio::test]
@@ -67,7 +67,7 @@ mod tests {
         let cache_key = Uuid::new_v4().to_string();
         let cache_body = Uuid::new_v4().to_string();
         let mut mm = get_momento_instance();
-        mm.create_cache(&cache_name).await.unwrap();
+        mm.create_cache(&cache_name).await.expect("failed to create cache");
         let ttl: u64 = 18446744073709551615;
         let max_ttl = u64::MAX / 1000_u64;
         let result = mm
@@ -75,7 +75,7 @@ mod tests {
                 &cache_name,
                 cache_key,
                 cache_body,
-                Some(NonZeroU64::new(ttl).unwrap()),
+                Some(NonZeroU64::new(ttl).expect("failed to get non zero u64")),
             ) // 18446744073709551615 > 2^64/1000
             .await
             .unwrap_err();
@@ -87,7 +87,7 @@ mod tests {
             result,
             MomentoError::InvalidArgument(_err_message)
         ));
-        mm.delete_cache(&cache_name).await.unwrap();
+        mm.delete_cache(&cache_name).await.expect("failed to delete cache");
     }
 
     #[tokio::test]
@@ -96,14 +96,14 @@ mod tests {
         let cache_key = Uuid::new_v4().to_string();
         let cache_body = Uuid::new_v4().to_string();
         let mut mm = get_momento_instance();
-        mm.create_cache(&cache_name).await.unwrap();
+        mm.create_cache(&cache_name).await.expect("failed to create cache");
         mm.set(&cache_name, cache_key.clone(), cache_body.clone(), None)
             .await
-            .unwrap();
-        let result = mm.get(&cache_name, cache_key.clone()).await.unwrap();
+            .expect("failed to perform set");
+        let result = mm.get(&cache_name, cache_key.clone()).await.expect("failed to perform get");
         assert!(matches!(result.result, MomentoGetStatus::HIT));
         assert_eq!(result.value, cache_body.as_bytes());
-        mm.delete_cache(&cache_name).await.unwrap();
+        mm.delete_cache(&cache_name).await.expect("failed to delete cache");
     }
 
     #[tokio::test]
@@ -112,14 +112,14 @@ mod tests {
         let cache_key = Uuid::new_v4().to_string();
         let cache_body = Uuid::new_v4().to_string();
         let mut mm = get_momento_instance();
-        mm.create_cache(&cache_name).await.unwrap();
+        mm.create_cache(&cache_name).await.expect("failed to create cache");
         mm.set(&cache_name, cache_key.clone(), cache_body.clone(), None)
             .await
-            .unwrap();
+            .expect("failed to perform set");
         sleep(Duration::new(1, 0)).await;
-        let result = mm.get(&cache_name, cache_key.clone()).await.unwrap();
+        let result = mm.get(&cache_name, cache_key.clone()).await.expect("failed to perform get");
         assert!(matches!(result.result, MomentoGetStatus::HIT));
-        mm.delete_cache(&cache_name).await.unwrap();
+        mm.delete_cache(&cache_name).await.expect("failed to delete cache");
     }
 
     #[tokio::test]
@@ -128,26 +128,26 @@ mod tests {
         let cache_key = Uuid::new_v4().to_string();
         let cache_body = Uuid::new_v4().to_string();
         let mut mm = get_momento_instance();
-        mm.create_cache(&cache_name).await.unwrap();
+        mm.create_cache(&cache_name).await.expect("failed to create cache");
         mm.set(&cache_name, cache_key.clone(), cache_body.clone(), None)
             .await
-            .unwrap();
-        let result = mm.get(&cache_name, cache_key.clone()).await.unwrap();
+            .expect("failed to perform set");
+        let result = mm.get(&cache_name, cache_key.clone()).await.expect("failed to perform get");
         assert!(matches!(result.result, MomentoGetStatus::HIT));
         assert_eq!(result.value, cache_body.as_bytes());
-        mm.delete_cache(&cache_name).await.unwrap();
+        mm.delete_cache(&cache_name).await.expect("failed to delete cache");
     }
 
     #[tokio::test]
     async fn list_caches() {
         let cache_name = Uuid::new_v4().to_string();
         let mut mm = get_momento_instance();
-        mm.create_cache(&cache_name).await.unwrap();
+        mm.create_cache(&cache_name).await.expect("failed to create cache");
 
         let mut next_token: Option<String> = None;
         let mut num_pages = 0;
         loop {
-            let list_cache_result = mm.list_caches(next_token).await.unwrap();
+            let list_cache_result = mm.list_caches(next_token).await.expect("failed to list caches");
             num_pages += 1;
             next_token = list_cache_result.next_token;
             if next_token == None {
@@ -156,38 +156,38 @@ mod tests {
         }
 
         assert_eq!(1, num_pages, "we expect a single page of caches to list");
-        mm.delete_cache(&cache_name).await.unwrap();
+        mm.delete_cache(&cache_name).await.expect("failed to delete cache");
     }
 
     #[tokio::test]
     async fn create_list_revoke_signing_key() {
         let mut mm = get_momento_instance();
-        let response = mm.create_signing_key(10).await.unwrap();
+        let response = mm.create_signing_key(10).await.expect("failed to create signing key");
 
-        let key: Value = serde_json::from_str(&response.key).unwrap();
-        let obj = key.as_object().unwrap();
-        let kid = obj.get("kid").unwrap();
-        assert_eq!(kid.as_str().unwrap(), response.key_id);
+        let key: Value = serde_json::from_str(&response.key).expect("failed to parse key from json");
+        let obj = key.as_object().expect("failed to map key to object");
+        let kid = obj.get("kid").expect("'kid' was not present");
+        assert_eq!(kid.as_str().expect("failed to cast kid to str"), response.key_id);
 
         let auth_token = env::var("TEST_AUTH_TOKEN").expect("env var TEST_AUTH_TOKEN must be set");
         let parts: Vec<&str> = auth_token.split('.').collect();
         assert!(
-            std::str::from_utf8(base64_url::decode(parts[1]).unwrap().as_slice())
-                .unwrap()
+            std::str::from_utf8(base64_url::decode(parts[1]).expect("expected base64 part not present in position 1").as_slice())
+                .expect("couldn't parse base64")
                 .contains(&response.endpoint)
         );
 
-        let list_response = mm.list_signing_keys(None).await.unwrap();
+        let list_response = mm.list_signing_keys(None).await.expect("couldn't list signing keys");
         assert!(
             list_response
                 .signing_keys
                 .iter()
                 .map(|k| k.key_id.as_str())
-                .any(|x| x == kid.as_str().unwrap()),
+                .any(|x| x == kid.as_str().expect("couldn't cast kid as str")),
             "newly created signing key was not found in list response"
         );
 
-        mm.revoke_signing_key(&response.key_id).await.unwrap();
+        mm.revoke_signing_key(&response.key_id).await.expect("couldn't revoke signing key");
     }
 
     #[tokio::test]
@@ -279,7 +279,7 @@ mod tests {
         let cache_key = Uuid::new_v4().to_string();
         let cache_body = Uuid::new_v4().to_string();
         let mut mm = get_momento_instance();
-        mm.create_cache(&cache_name).await.unwrap();
+        mm.create_cache(&cache_name).await.expect("failed to create cache");
         mm.set(
             &cache_name,
             cache_key.clone(),
@@ -287,13 +287,13 @@ mod tests {
             NonZeroU64::new(10000),
         )
         .await
-        .unwrap();
-        let result = mm.get(&cache_name, cache_key.clone()).await.unwrap();
+        .expect("failed to perform set");
+        let result = mm.get(&cache_name, cache_key.clone()).await.expect("failed to exercise get");
         assert!(matches!(result.result, MomentoGetStatus::HIT));
         assert_eq!(result.value, cache_body.as_bytes());
-        mm.delete(&cache_name, cache_key.clone()).await.unwrap();
-        let result = mm.get(&cache_name, cache_key.clone()).await.unwrap();
+        mm.delete(&cache_name, cache_key.clone()).await.expect("failed to delete cache");
+        let result = mm.get(&cache_name, cache_key.clone()).await.expect("failed to exercise get");
         assert!(matches!(result.result, MomentoGetStatus::MISS));
-        mm.delete_cache(&cache_name).await.unwrap();
+        mm.delete_cache(&cache_name).await.expect("failed to delete cache");
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -35,10 +35,17 @@ mod tests {
         let cache_name = Uuid::new_v4().to_string();
         let cache_key = Uuid::new_v4().to_string();
         let mut mm = get_momento_instance();
-        mm.create_cache(&cache_name).await.expect("failed to create cache");
-        let result = mm.get(&cache_name, cache_key).await.expect("failure when trying get");
+        mm.create_cache(&cache_name)
+            .await
+            .expect("failed to create cache");
+        let result = mm
+            .get(&cache_name, cache_key)
+            .await
+            .expect("failure when trying get");
         assert!(matches!(result.result, MomentoGetStatus::MISS));
-        mm.delete_cache(&cache_name).await.expect("failed to delete cache");
+        mm.delete_cache(&cache_name)
+            .await
+            .expect("failed to delete cache");
     }
 
     #[tokio::test]
@@ -67,7 +74,9 @@ mod tests {
         let cache_key = Uuid::new_v4().to_string();
         let cache_body = Uuid::new_v4().to_string();
         let mut mm = get_momento_instance();
-        mm.create_cache(&cache_name).await.expect("failed to create cache");
+        mm.create_cache(&cache_name)
+            .await
+            .expect("failed to create cache");
         let ttl: u64 = 18446744073709551615;
         let max_ttl = u64::MAX / 1000_u64;
         let result = mm
@@ -87,7 +96,9 @@ mod tests {
             result,
             MomentoError::InvalidArgument(_err_message)
         ));
-        mm.delete_cache(&cache_name).await.expect("failed to delete cache");
+        mm.delete_cache(&cache_name)
+            .await
+            .expect("failed to delete cache");
     }
 
     #[tokio::test]
@@ -96,14 +107,21 @@ mod tests {
         let cache_key = Uuid::new_v4().to_string();
         let cache_body = Uuid::new_v4().to_string();
         let mut mm = get_momento_instance();
-        mm.create_cache(&cache_name).await.expect("failed to create cache");
+        mm.create_cache(&cache_name)
+            .await
+            .expect("failed to create cache");
         mm.set(&cache_name, cache_key.clone(), cache_body.clone(), None)
             .await
             .expect("failed to perform set");
-        let result = mm.get(&cache_name, cache_key.clone()).await.expect("failed to perform get");
+        let result = mm
+            .get(&cache_name, cache_key.clone())
+            .await
+            .expect("failed to perform get");
         assert!(matches!(result.result, MomentoGetStatus::HIT));
         assert_eq!(result.value, cache_body.as_bytes());
-        mm.delete_cache(&cache_name).await.expect("failed to delete cache");
+        mm.delete_cache(&cache_name)
+            .await
+            .expect("failed to delete cache");
     }
 
     #[tokio::test]
@@ -112,14 +130,21 @@ mod tests {
         let cache_key = Uuid::new_v4().to_string();
         let cache_body = Uuid::new_v4().to_string();
         let mut mm = get_momento_instance();
-        mm.create_cache(&cache_name).await.expect("failed to create cache");
+        mm.create_cache(&cache_name)
+            .await
+            .expect("failed to create cache");
         mm.set(&cache_name, cache_key.clone(), cache_body.clone(), None)
             .await
             .expect("failed to perform set");
         sleep(Duration::new(1, 0)).await;
-        let result = mm.get(&cache_name, cache_key.clone()).await.expect("failed to perform get");
+        let result = mm
+            .get(&cache_name, cache_key.clone())
+            .await
+            .expect("failed to perform get");
         assert!(matches!(result.result, MomentoGetStatus::HIT));
-        mm.delete_cache(&cache_name).await.expect("failed to delete cache");
+        mm.delete_cache(&cache_name)
+            .await
+            .expect("failed to delete cache");
     }
 
     #[tokio::test]
@@ -128,26 +153,38 @@ mod tests {
         let cache_key = Uuid::new_v4().to_string();
         let cache_body = Uuid::new_v4().to_string();
         let mut mm = get_momento_instance();
-        mm.create_cache(&cache_name).await.expect("failed to create cache");
+        mm.create_cache(&cache_name)
+            .await
+            .expect("failed to create cache");
         mm.set(&cache_name, cache_key.clone(), cache_body.clone(), None)
             .await
             .expect("failed to perform set");
-        let result = mm.get(&cache_name, cache_key.clone()).await.expect("failed to perform get");
+        let result = mm
+            .get(&cache_name, cache_key.clone())
+            .await
+            .expect("failed to perform get");
         assert!(matches!(result.result, MomentoGetStatus::HIT));
         assert_eq!(result.value, cache_body.as_bytes());
-        mm.delete_cache(&cache_name).await.expect("failed to delete cache");
+        mm.delete_cache(&cache_name)
+            .await
+            .expect("failed to delete cache");
     }
 
     #[tokio::test]
     async fn list_caches() {
         let cache_name = Uuid::new_v4().to_string();
         let mut mm = get_momento_instance();
-        mm.create_cache(&cache_name).await.expect("failed to create cache");
+        mm.create_cache(&cache_name)
+            .await
+            .expect("failed to create cache");
 
         let mut next_token: Option<String> = None;
         let mut num_pages = 0;
         loop {
-            let list_cache_result = mm.list_caches(next_token).await.expect("failed to list caches");
+            let list_cache_result = mm
+                .list_caches(next_token)
+                .await
+                .expect("failed to list caches");
             num_pages += 1;
             next_token = list_cache_result.next_token;
             if next_token == None {
@@ -156,28 +193,42 @@ mod tests {
         }
 
         assert_eq!(1, num_pages, "we expect a single page of caches to list");
-        mm.delete_cache(&cache_name).await.expect("failed to delete cache");
+        mm.delete_cache(&cache_name)
+            .await
+            .expect("failed to delete cache");
     }
 
     #[tokio::test]
     async fn create_list_revoke_signing_key() {
         let mut mm = get_momento_instance();
-        let response = mm.create_signing_key(10).await.expect("failed to create signing key");
+        let response = mm
+            .create_signing_key(10)
+            .await
+            .expect("failed to create signing key");
 
-        let key: Value = serde_json::from_str(&response.key).expect("failed to parse key from json");
+        let key: Value =
+            serde_json::from_str(&response.key).expect("failed to parse key from json");
         let obj = key.as_object().expect("failed to map key to object");
         let kid = obj.get("kid").expect("'kid' was not present");
-        assert_eq!(kid.as_str().expect("failed to cast kid to str"), response.key_id);
+        assert_eq!(
+            kid.as_str().expect("failed to cast kid to str"),
+            response.key_id
+        );
 
         let auth_token = env::var("TEST_AUTH_TOKEN").expect("env var TEST_AUTH_TOKEN must be set");
         let parts: Vec<&str> = auth_token.split('.').collect();
-        assert!(
-            std::str::from_utf8(base64_url::decode(parts[1]).expect("expected base64 part not present in position 1").as_slice())
-                .expect("couldn't parse base64")
-                .contains(&response.endpoint)
-        );
+        assert!(std::str::from_utf8(
+            base64_url::decode(parts[1])
+                .expect("expected base64 part not present in position 1")
+                .as_slice()
+        )
+        .expect("couldn't parse base64")
+        .contains(&response.endpoint));
 
-        let list_response = mm.list_signing_keys(None).await.expect("couldn't list signing keys");
+        let list_response = mm
+            .list_signing_keys(None)
+            .await
+            .expect("couldn't list signing keys");
         assert!(
             list_response
                 .signing_keys
@@ -187,7 +238,9 @@ mod tests {
             "newly created signing key was not found in list response"
         );
 
-        mm.revoke_signing_key(&response.key_id).await.expect("couldn't revoke signing key");
+        mm.revoke_signing_key(&response.key_id)
+            .await
+            .expect("couldn't revoke signing key");
     }
 
     #[tokio::test]
@@ -279,7 +332,9 @@ mod tests {
         let cache_key = Uuid::new_v4().to_string();
         let cache_body = Uuid::new_v4().to_string();
         let mut mm = get_momento_instance();
-        mm.create_cache(&cache_name).await.expect("failed to create cache");
+        mm.create_cache(&cache_name)
+            .await
+            .expect("failed to create cache");
         mm.set(
             &cache_name,
             cache_key.clone(),
@@ -288,12 +343,22 @@ mod tests {
         )
         .await
         .expect("failed to perform set");
-        let result = mm.get(&cache_name, cache_key.clone()).await.expect("failed to exercise get");
+        let result = mm
+            .get(&cache_name, cache_key.clone())
+            .await
+            .expect("failed to exercise get");
         assert!(matches!(result.result, MomentoGetStatus::HIT));
         assert_eq!(result.value, cache_body.as_bytes());
-        mm.delete(&cache_name, cache_key.clone()).await.expect("failed to delete cache");
-        let result = mm.get(&cache_name, cache_key.clone()).await.expect("failed to exercise get");
+        mm.delete(&cache_name, cache_key.clone())
+            .await
+            .expect("failed to delete cache");
+        let result = mm
+            .get(&cache_name, cache_key.clone())
+            .await
+            .expect("failed to exercise get");
         assert!(matches!(result.result, MomentoGetStatus::MISS));
-        mm.delete_cache(&cache_name).await.expect("failed to delete cache");
+        mm.delete_cache(&cache_name)
+            .await
+            .expect("failed to delete cache");
     }
 }


### PR DESCRIPTION
Resolves https://github.com/momentohq/client-sdk-rust/issues/61

Commit summary:
- chore: use integrated clippy warnings to check for .unwrap() calls. clean up .unwrap() usages.
- chore: update README with new code style guidelines
