### PR TITLE
fix: add keepalive settings to preserve idle connections

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,10 +10,8 @@ _Read this in other languages_: [日本語](README.ja.md)
 - A Momento Auth Token is required, you can generate one using the [Momento CLI](https://github.com/momentohq/momento-cli)
 
 ```bash
-cargo build
-
 # Run example code
-MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> ./target/debug/rust
+MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> cargo run
 ```
 
 Example Code: [main.rs](src/main.rs)


### PR DESCRIPTION
Prior to this commit, we did not have keepalives enabled for
idle gRPC channels.  As a result, any channel that was idle
for longer than NLB's idle connection timeout (about 6 minutes)
would be closed by the server, and the next attempt to use
it in the client would result in a transport error.

This commit enables keepalive for idle connections, sending
keepalive pings once every 2 minutes.  In local testing I observed
that a channel I left idle for over 6 minutes was still able
to be used successful on the next request after the idle period.
