### PR TITLE
fix: remove import for non-existant path in doctest

### DIFF
--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -782,7 +782,6 @@ impl SimpleCacheClient {
     /// # tokio_test::block_on(async {
     ///     use std::env;
     ///     use momento::{
-    ///         response::cache_dictionary_delete_response::MomentoDictionaryDeleteStatus,
     ///         simple_cache_client::Fields,
     ///         simple_cache_client::SimpleCacheClientBuilder,
     ///     };
@@ -806,7 +805,7 @@ impl SimpleCacheClient {
     ///     let resp = momento.dictionary_delete(
     ///         &cache_name,
     ///         &dictionary_name,
-    ///         Fields::All,
+    ///         Fields::<Vec<u8>>::All,
     ///     ).await.unwrap();
     ///
     ///     momento.delete_cache(&cache_name).await;


### PR DESCRIPTION
`cargo test` is failing because the doctests try and use a path that doesn't exist. Nothing in the doctest is actually using the imported item so I've just removed the import. This also fixes a type inference error in the same test.