### PR TITLE
feat: allow dictionary client methods to take non-utf-8 dictionary names

### DIFF
--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -33,43 +33,16 @@ use crate::utils;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub trait MomentoRequest {
+pub trait IntoBytes {
     fn into_bytes(self) -> Vec<u8>;
 }
 
-impl MomentoRequest for String {
+impl<T> IntoBytes for T
+where
+    T: Into<Vec<u8>>,
+{
     fn into_bytes(self) -> Vec<u8> {
-        self.into_bytes()
-    }
-}
-
-impl MomentoRequest for Vec<u8> {
-    fn into_bytes(self) -> Vec<u8> {
-        self
-    }
-}
-
-impl MomentoRequest for &str {
-    fn into_bytes(self) -> Vec<u8> {
-        self.to_string().into_bytes()
-    }
-}
-
-impl MomentoRequest for &[u8] {
-    fn into_bytes(self) -> Vec<u8> {
-        self.to_owned()
-    }
-}
-
-impl MomentoRequest for &Vec<u8> {
-    fn into_bytes(self) -> Vec<u8> {
-        self.clone().into_bytes()
-    }
-}
-
-impl MomentoRequest for &String {
-    fn into_bytes(self) -> Vec<u8> {
-        self.clone().into_bytes()
+        self.into()
     }
 }
 
@@ -441,7 +414,7 @@ impl SimpleCacheClient {
     ///     momento.delete_cache(&cache_name).await;
     /// # })
     /// ```
-    pub async fn set<I: MomentoRequest>(
+    pub async fn set<I: IntoBytes>(
         &mut self,
         cache_name: &str,
         key: I,
@@ -498,7 +471,7 @@ impl SimpleCacheClient {
     ///     momento.delete_cache(&cache_name).await;
     /// # })
     /// ```
-    pub async fn get<I: MomentoRequest>(
+    pub async fn get<I: IntoBytes>(
         &mut self,
         cache_name: &str,
         key: I,
@@ -557,11 +530,11 @@ impl SimpleCacheClient {
     ///
     ///     let dictionary_name = Uuid::new_v4().to_string();
     ///
-    ///     momento.dictionary_set(&cache_name, &dictionary_name, dictionary, None, true).await;
+    ///     momento.dictionary_set(&cache_name, &*dictionary_name, dictionary, None, true).await;
     ///     momento.delete_cache(&cache_name).await;
     /// # })
     /// ```
-    pub async fn dictionary_set<K: MomentoRequest, V: MomentoRequest, D: MomentoRequest>(
+    pub async fn dictionary_set<K: IntoBytes, V: IntoBytes, D: IntoBytes>(
         &mut self,
         cache_name: &str,
         dictionary_name: D,
@@ -629,7 +602,7 @@ impl SimpleCacheClient {
     ///
     ///     let dictionary_name = Uuid::new_v4().to_string();
     ///
-    ///     let resp = momento.dictionary_get(&cache_name, &dictionary_name, vec![
+    ///     let resp = momento.dictionary_get(&cache_name, &*dictionary_name, vec![
     ///         "key1".to_string(),
     ///         "key2".to_string(),
     ///     ]).await.unwrap();
@@ -651,7 +624,7 @@ impl SimpleCacheClient {
     ///     momento.delete_cache(&cache_name).await;
     /// # })
     /// ```
-    pub async fn dictionary_get<K: MomentoRequest, D: MomentoRequest>(
+    pub async fn dictionary_get<K: IntoBytes, D: IntoBytes>(
         &mut self,
         cache_name: &str,
         dictionary: D,
@@ -723,7 +696,7 @@ impl SimpleCacheClient {
     ///
     ///     let dictionary_name = Uuid::new_v4().to_string();
     ///
-    ///     let resp = momento.dictionary_fetch(&cache_name, &dictionary_name).await.unwrap();
+    ///     let resp = momento.dictionary_fetch(&cache_name, &*dictionary_name).await.unwrap();
     ///
     ///     match resp.result {
     ///         MomentoDictionaryFetchStatus::FOUND => println!("dictionary found!"),
@@ -742,7 +715,7 @@ impl SimpleCacheClient {
     ///     momento.delete_cache(&cache_name).await;
     /// # })
     /// ```
-    pub async fn dictionary_fetch<D: MomentoRequest>(
+    pub async fn dictionary_fetch<D: IntoBytes>(
         &mut self,
         cache_name: &str,
         dictionary: D,
@@ -815,21 +788,21 @@ impl SimpleCacheClient {
     ///     // remove some fields
     ///     let resp = momento.dictionary_delete(
     ///         &cache_name,
-    ///         &dictionary_name,
+    ///         &*dictionary_name,
     ///         Fields::Some(vec!["field_1"]),
     ///     ).await.unwrap();
     ///
     ///     // remove entire dictionary
     ///     let resp = momento.dictionary_delete(
     ///         &cache_name,
-    ///         &dictionary_name,
+    ///         &*dictionary_name,
     ///         Fields::<Vec<u8>>::All,
     ///     ).await.unwrap();
     ///
     ///     momento.delete_cache(&cache_name).await;
     /// # })
     /// ```
-    pub async fn dictionary_delete<K: MomentoRequest, D: MomentoRequest>(
+    pub async fn dictionary_delete<K: IntoBytes, D: IntoBytes>(
         &mut self,
         cache_name: &str,
         dictionary: D,
@@ -885,7 +858,7 @@ impl SimpleCacheClient {
     ///     momento.delete_cache(&cache_name).await;
     /// # })
     /// ```
-    pub async fn delete<I: MomentoRequest>(
+    pub async fn delete<I: IntoBytes>(
         &mut self,
         cache_name: &str,
         key: I,

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -534,10 +534,10 @@ impl SimpleCacheClient {
     ///     momento.delete_cache(&cache_name).await;
     /// # })
     /// ```
-    pub async fn dictionary_set<K: IntoBytes, V: IntoBytes, D: IntoBytes>(
+    pub async fn dictionary_set<K: IntoBytes, V: IntoBytes>(
         &mut self,
         cache_name: &str,
-        dictionary_name: D,
+        dictionary_name: impl IntoBytes,
         dictionary: HashMap<K, V>,
         ttl_seconds: Option<NonZeroU64>,
         refresh_ttl: bool,
@@ -624,10 +624,10 @@ impl SimpleCacheClient {
     ///     momento.delete_cache(&cache_name).await;
     /// # })
     /// ```
-    pub async fn dictionary_get<K: IntoBytes, D: IntoBytes>(
+    pub async fn dictionary_get<K: IntoBytes>(
         &mut self,
         cache_name: &str,
-        dictionary: D,
+        dictionary: impl IntoBytes,
         fields: Vec<K>,
     ) -> Result<MomentoDictionaryGetResponse, MomentoError> {
         utils::is_cache_name_valid(cache_name)?;
@@ -715,10 +715,10 @@ impl SimpleCacheClient {
     ///     momento.delete_cache(&cache_name).await;
     /// # })
     /// ```
-    pub async fn dictionary_fetch<D: IntoBytes>(
+    pub async fn dictionary_fetch(
         &mut self,
         cache_name: &str,
-        dictionary: D,
+        dictionary: impl IntoBytes,
     ) -> Result<MomentoDictionaryFetchResponse, MomentoError> {
         utils::is_cache_name_valid(cache_name)?;
 
@@ -802,10 +802,10 @@ impl SimpleCacheClient {
     ///     momento.delete_cache(&cache_name).await;
     /// # })
     /// ```
-    pub async fn dictionary_delete<K: IntoBytes, D: IntoBytes>(
+    pub async fn dictionary_delete<K: IntoBytes>(
         &mut self,
         cache_name: &str,
-        dictionary: D,
+        dictionary: impl IntoBytes,
         fields: Fields<K>,
     ) -> Result<(), MomentoError> {
         utils::is_cache_name_valid(cache_name)?;

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -55,6 +55,24 @@ impl MomentoRequest for &str {
     }
 }
 
+impl MomentoRequest for &[u8] {
+    fn into_bytes(self) -> Vec<u8> {
+        self.to_owned()
+    }
+}
+
+impl MomentoRequest for &Vec<u8> {
+    fn into_bytes(self) -> Vec<u8> {
+        self.clone().into_bytes()
+    }
+}
+
+impl MomentoRequest for &String {
+    fn into_bytes(self) -> Vec<u8> {
+        self.clone().into_bytes()
+    }
+}
+
 #[derive(Clone)]
 pub struct SimpleCacheClientBuilder {
     data_endpoint: String,
@@ -543,10 +561,10 @@ impl SimpleCacheClient {
     ///     momento.delete_cache(&cache_name).await;
     /// # })
     /// ```
-    pub async fn dictionary_set<K: MomentoRequest, V: MomentoRequest>(
+    pub async fn dictionary_set<K: MomentoRequest, V: MomentoRequest, D: MomentoRequest>(
         &mut self,
         cache_name: &str,
-        dictionary_name: &str,
+        dictionary_name: D,
         dictionary: HashMap<K, V>,
         ttl_seconds: Option<NonZeroU64>,
         refresh_ttl: bool,
@@ -633,10 +651,10 @@ impl SimpleCacheClient {
     ///     momento.delete_cache(&cache_name).await;
     /// # })
     /// ```
-    pub async fn dictionary_get<K: MomentoRequest>(
+    pub async fn dictionary_get<K: MomentoRequest, D: MomentoRequest>(
         &mut self,
         cache_name: &str,
-        dictionary: &str,
+        dictionary: D,
         fields: Vec<K>,
     ) -> Result<MomentoDictionaryGetResponse, MomentoError> {
         utils::is_cache_name_valid(cache_name)?;
@@ -724,10 +742,10 @@ impl SimpleCacheClient {
     ///     momento.delete_cache(&cache_name).await;
     /// # })
     /// ```
-    pub async fn dictionary_fetch(
+    pub async fn dictionary_fetch<D: MomentoRequest>(
         &mut self,
         cache_name: &str,
-        dictionary: &str,
+        dictionary: D,
     ) -> Result<MomentoDictionaryFetchResponse, MomentoError> {
         utils::is_cache_name_valid(cache_name)?;
 
@@ -811,10 +829,10 @@ impl SimpleCacheClient {
     ///     momento.delete_cache(&cache_name).await;
     /// # })
     /// ```
-    pub async fn dictionary_delete<K: MomentoRequest>(
+    pub async fn dictionary_delete<K: MomentoRequest, D: MomentoRequest>(
         &mut self,
         cache_name: &str,
-        dictionary: &str,
+        dictionary: D,
         fields: Fields<K>,
     ) -> Result<(), MomentoError> {
         utils::is_cache_name_valid(cache_name)?;


### PR DESCRIPTION
As of now, the dictionary methods on `SimpleCacheClient` take the dictionary name as a `&str` and so they require that the dictionary name is valid UTF-8. As I understand it, momento has no such restriction and the protocol appears to allow any sequence of bytes as a name. This PR changes the dictionary argument to take anything that implements `MomentoRequest` and expands what implements `MomentoRequest` enough to cover all previous calling patterns.

This change came out of some comments on https://github.com/pelikan-io/pelikan/pull/12

This is a breaking change (although most users should be fine) so I have marked it as a feature.