### PR TITLE
feat: remove redundant nested momento module

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -12,7 +12,7 @@ pub type LoginActionConsumer = fn(LoginAction) -> EarlyOutActionResult;
 /// Initiate a login workflow
 /// You need to provide an implementation for the LoginActions.
 /// ```rust
-/// # use momento::momento::auth::{login, LoginAction, LoginResult};
+/// # use momento::auth::{login, LoginAction, LoginResult};
 /// # async {
 ///     let result = login(|action| {
 ///       match action {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod momento;
+pub mod auth;
 pub mod response;
 pub mod simple_cache_client;
 

--- a/src/momento/mod.rs
+++ b/src/momento/mod.rs
@@ -1,1 +1,0 @@
-pub mod auth;


### PR DESCRIPTION
Before this PR the auth module was in a nested momento module. So, to access it, you would need to look in `momento::momento::auth`. This is unnecessary and rather hard to use. This PR removes the nested momento module and drops the auth module into the crate root.