### PR TITLE
feat: Move `SimpleCacheClient` and associated types to crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@ mod jwt;
 mod simple_cache_client;
 mod utils;
 
+pub use crate::response::MomentoError;
 pub use crate::simple_cache_client::{
     Fields, IntoBytes, SimpleCacheClient, SimpleCacheClientBuilder,
 };
+
+pub type MomentoResult<T> = Result<T, MomentoError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,12 @@
 pub mod auth;
 pub mod response;
-pub mod simple_cache_client;
 
 mod endpoint_resolver;
 mod grpc;
 mod jwt;
+mod simple_cache_client;
 mod utils;
+
+pub use crate::simple_cache_client::{
+    Fields, IntoBytes, SimpleCacheClient, SimpleCacheClientBuilder,
+};

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -51,7 +51,7 @@ pub struct SimpleCacheClientBuilder {
     user_agent_name: String,
 }
 
-pub fn request_meta_data<T>(
+fn request_meta_data<T>(
     request: &mut tonic::Request<T>,
     cache_name: &str,
 ) -> Result<(), MomentoError> {
@@ -78,7 +78,7 @@ impl SimpleCacheClientBuilder {
     ///
     /// ```
     /// # tokio_test::block_on(async {
-    ///     use momento::simple_cache_client::SimpleCacheClientBuilder;
+    ///     use momento::SimpleCacheClientBuilder;
     ///     use std::env;
     ///     use std::num::NonZeroU64;
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
@@ -213,7 +213,7 @@ impl SimpleCacheClient {
     /// use uuid::Uuid;
     /// use std::num::NonZeroU64;
     /// # tokio_test::block_on(async {
-    ///     use momento::simple_cache_client::SimpleCacheClientBuilder;
+    ///     use momento::SimpleCacheClientBuilder;
     ///     use std::env;
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let cache_name = Uuid::new_v4().to_string();
@@ -241,7 +241,7 @@ impl SimpleCacheClient {
     /// use uuid::Uuid;
     /// use std::num::NonZeroU64;
     /// # tokio_test::block_on(async {
-    ///     use momento::simple_cache_client::SimpleCacheClientBuilder;
+    ///     use momento::SimpleCacheClientBuilder;
     ///     use std::env;
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let cache_name = Uuid::new_v4().to_string();
@@ -336,7 +336,7 @@ impl SimpleCacheClient {
     /// use uuid::Uuid;
     /// use std::num::NonZeroU64;
     /// # tokio_test::block_on(async {
-    ///     use momento::simple_cache_client::SimpleCacheClientBuilder;
+    ///     use momento::SimpleCacheClientBuilder;
     ///     use std::env;
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let mut momento = SimpleCacheClientBuilder::new(auth_token, NonZeroU64::new(5).unwrap())
@@ -394,7 +394,7 @@ impl SimpleCacheClient {
     /// use uuid::Uuid;
     /// use std::num::NonZeroU64;
     /// # tokio_test::block_on(async {
-    ///     use momento::simple_cache_client::SimpleCacheClientBuilder;
+    ///     use momento::SimpleCacheClientBuilder;
     ///     use std::env;
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let cache_name = Uuid::new_v4().to_string();
@@ -448,7 +448,7 @@ impl SimpleCacheClient {
     /// use std::num::NonZeroU64;
     /// # tokio_test::block_on(async {
     ///     use std::env;
-    ///     use momento::{response::MomentoGetStatus, simple_cache_client::SimpleCacheClientBuilder};
+    ///     use momento::{response::MomentoGetStatus, SimpleCacheClientBuilder};
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let cache_name = Uuid::new_v4().to_string();
     ///     let mut momento = SimpleCacheClientBuilder::new(auth_token, NonZeroU64::new(30).unwrap())
@@ -509,7 +509,7 @@ impl SimpleCacheClient {
     /// use uuid::Uuid;
     /// use std::num::NonZeroU64;
     /// # tokio_test::block_on(async {
-    ///     use momento::simple_cache_client::SimpleCacheClientBuilder;
+    ///     use momento::SimpleCacheClientBuilder;
     ///     use std::collections::HashMap;
     ///     use std::env;
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
@@ -586,7 +586,7 @@ impl SimpleCacheClient {
     ///     use std::env;
     ///     use momento::{
     ///         response::MomentoDictionaryGetStatus,
-    ///         simple_cache_client::SimpleCacheClientBuilder,
+    ///         SimpleCacheClientBuilder,
     ///     };
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let cache_name = Uuid::new_v4().to_string();
@@ -680,7 +680,7 @@ impl SimpleCacheClient {
     ///     use std::env;
     ///     use momento::{
     ///         response::MomentoDictionaryFetchStatus,
-    ///         simple_cache_client::SimpleCacheClientBuilder,
+    ///         SimpleCacheClientBuilder,
     ///     };
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let cache_name = Uuid::new_v4().to_string();
@@ -767,10 +767,7 @@ impl SimpleCacheClient {
     /// use std::num::NonZeroU64;
     /// # tokio_test::block_on(async {
     ///     use std::env;
-    ///     use momento::{
-    ///         simple_cache_client::Fields,
-    ///         simple_cache_client::SimpleCacheClientBuilder,
-    ///     };
+    ///     use momento::{Fields, SimpleCacheClientBuilder};
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let cache_name = Uuid::new_v4().to_string();
     ///     let mut momento = SimpleCacheClientBuilder::new(auth_token, NonZeroU64::new(30).unwrap())
@@ -1071,7 +1068,7 @@ impl SimpleCacheClient {
     /// use std::num::NonZeroU64;
     /// # tokio_test::block_on(async {
     ///     use std::env;
-    ///     use momento::{response::MomentoGetStatus, simple_cache_client::SimpleCacheClientBuilder};
+    ///     use momento::{response::MomentoGetStatus, SimpleCacheClientBuilder};
     ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     ///     let cache_name = Uuid::new_v4().to_string();
     ///     let mut momento = SimpleCacheClientBuilder::new(auth_token, NonZeroU64::new(30).unwrap())

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -926,7 +926,7 @@ impl SimpleCacheClient {
     /// # tokio_test::block_on(async {
     /// use uuid::Uuid;
     /// use std::num::NonZeroU64;
-    /// use momento::simple_cache_client::SimpleCacheClientBuilder;
+    /// use momento::SimpleCacheClientBuilder;
     ///
     /// let auth_token = std::env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be defined");
     /// let cache_name = Uuid::new_v4().to_string();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,9 +3,15 @@ mod tests {
     use std::num::NonZeroU64;
     use std::{env, time::Duration};
 
+<<<<<<< HEAD
     use momento::response::MomentoError;
     use momento::simple_cache_client::SimpleCacheClientBuilder;
     use momento::{response::MomentoGetStatus, simple_cache_client::SimpleCacheClient};
+=======
+    use momento::response::error::MomentoError;
+    use momento::SimpleCacheClientBuilder;
+    use momento::{response::cache_get_response::MomentoGetStatus, SimpleCacheClient};
+>>>>>>> 7807ff5 (feat: Export contents of simple_cache_client module in the root)
     use serde_json::Value;
     use tokio::time::sleep;
     use uuid::Uuid;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,15 +3,8 @@ mod tests {
     use std::num::NonZeroU64;
     use std::{env, time::Duration};
 
-<<<<<<< HEAD
-    use momento::response::MomentoError;
-    use momento::simple_cache_client::SimpleCacheClientBuilder;
-    use momento::{response::MomentoGetStatus, simple_cache_client::SimpleCacheClient};
-=======
-    use momento::response::error::MomentoError;
-    use momento::SimpleCacheClientBuilder;
-    use momento::{response::cache_get_response::MomentoGetStatus, SimpleCacheClient};
->>>>>>> 7807ff5 (feat: Export contents of simple_cache_client module in the root)
+    use momento::{response::MomentoGetStatus, SimpleCacheClient};
+    use momento::{MomentoError, SimpleCacheClientBuilder};
     use serde_json::Value;
     use tokio::time::sleep;
     use uuid::Uuid;


### PR DESCRIPTION
This PR makes the `simple_cache_client` module private and exports everything it used to export in the root module. `SimpleCacheClient` is the main type that users of the crate will be interacting with so it should really be in the root module. I have also re-exported `MomentoError` in the root module and added a `MomentoResult` type as a shorthand for `Result<T, MomentoError>`.