### PR TITLE
feat: Make TTL parameters use more idiomatic Rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod utils;
 
 pub use crate::response::MomentoError;
 pub use crate::simple_cache_client::{
-    Fields, IntoBytes, SimpleCacheClient, SimpleCacheClientBuilder,
+    Fields, IntoBytes, SimpleCacheClient, SimpleCacheClientBuilder, TtlPolicy,
 };
 
 pub type MomentoResult<T> = Result<T, MomentoError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod utils;
 
 pub use crate::response::MomentoError;
 pub use crate::simple_cache_client::{
-    Fields, IntoBytes, SimpleCacheClient, SimpleCacheClientBuilder, TtlPolicy,
+    Fields, IntoBytes, SimpleCacheClient, SimpleCacheClientBuilder, CollectionTtl,
 };
 
 pub type MomentoResult<T> = Result<T, MomentoError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod utils;
 
 pub use crate::response::MomentoError;
 pub use crate::simple_cache_client::{
-    Fields, IntoBytes, SimpleCacheClient, SimpleCacheClientBuilder, CollectionTtl,
+    CollectionTtl, Fields, IntoBytes, SimpleCacheClient, SimpleCacheClientBuilder,
 };
 
 pub type MomentoResult<T> = Result<T, MomentoError>;

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1107,19 +1107,11 @@ impl SimpleCacheClient {
         Ok(())
     }
 
-    fn validate_ttl(&self, policy: &TtlPolicy) -> MomentoResult<Duration> {
-        let ttl = policy.ttl().unwrap_or(self.item_default_ttl);
+    fn expand_ttl_ms(&self, ttl: Option<Duration>) -> MomentoResult<u64> {
+        let ttl = ttl.unwrap_or(self.item_default_ttl);
         utils::is_ttl_valid(ttl)?;
-        Ok(ttl)
-    }
 
-    fn expand_ttl_ms(&self, policy: TtlPolicy) -> MomentoResult<u64> {
-        let ttl_ms = self
-            .validate_ttl(&policy)?
-            .as_millis()
-            .try_into()
-            .unwrap_or(u64::MAX);
-        Ok(ttl_ms)
+        Ok(ttl.as_millis().try_into().unwrap_or(i64::MAX as u64))
     }
 }
 

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -8,10 +8,13 @@ use momento_protos::{
     },
 };
 use serde_json::Value;
-use std::{collections::{HashMap, HashSet}, convert::TryInto};
 use std::convert::TryFrom;
 use std::iter::FromIterator;
 use std::time::Duration;
+use std::{
+    collections::{HashMap, HashSet},
+    convert::TryInto,
+};
 use tonic::{codegen::InterceptedService, transport::Channel, Request};
 
 use crate::{endpoint_resolver::MomentoEndpointsResolver, utils::user_agent, MomentoResult};
@@ -625,7 +628,7 @@ impl SimpleCacheClient {
                 dictionary_name: dictionary_name.into_bytes(),
                 items,
                 ttl_milliseconds: self.expand_ttl_ms(policy.ttl())?,
-                refresh_ttl: policy.refresh()
+                refresh_ttl: policy.refresh(),
             },
         )?;
 
@@ -1147,7 +1150,7 @@ impl SimpleCacheClient {
 
         Ok(ttl.as_millis().try_into().unwrap_or(i64::MAX as u64))
     }
-    
+
     fn prep_request<R>(&self, cache_name: &str, request: R) -> MomentoResult<tonic::Request<R>> {
         utils::is_cache_name_valid(cache_name)?;
 

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -42,14 +42,14 @@ where
 }
 
 /// Represents the desired behavior for managing the TTL on collection objects.
-/// 
+///
 /// For cache operations that modify a collection (dictionaries, lists, or sets), there
 /// are a few things to consider. The first time the collection is created, we need to
 /// set a TTL on it. For subsequent operations that modify the collection you may choose
 /// to update the TTL in order to prolong the life of the cached collection object, or
 /// you may choose to leave the TTL unmodified in order to ensure that the collection
 /// expires at the original TTL.
-/// 
+///
 /// The default behaviour is to refresh the TTL (to prolong the life of the collection)
 /// each time it is written using the client's default item TTL.
 #[derive(Copy, Clone, Debug)]
@@ -59,13 +59,14 @@ pub struct CollectionTtl {
 }
 
 impl CollectionTtl {
+    /// Create a collection TTL with the provided `ttl` and `refresh` settings.
     pub const fn new(ttl: Option<Duration>, refresh: bool) -> Self {
         Self { ttl, refresh }
     }
 
     /// Create a collection TTL that updates the TTL for the collection any time it is
     /// modified.
-    /// 
+    ///
     /// If `ttl` is `None` then the default item TTL for the client will be used.
     pub fn refresh_on_update(ttl: impl Into<Option<Duration>>) -> Self {
         Self::new(ttl.into(), true)
@@ -73,26 +74,50 @@ impl CollectionTtl {
 
     /// Create a collection TTL that will not refresh the TTL for the collection when
     /// it is updated.
-    /// 
+    ///
     /// Use this if you want to be sure that the collection expires at the originally
     /// specified time, even if you make modifications to the value of the collection.
-    /// 
+    ///
     /// The TTL will still be used when a new collection is created. If `ttl` is `None`
     /// then the default item TTL for the client will be used.
     pub fn initialize_only(ttl: impl Into<Option<Duration>>) -> Self {
         Self::new(ttl.into(), false)
     }
 
+    /// Create a collection TTL that updates the TTL for the collection only if an
+    /// explicit `ttl` is provided here.
+    pub fn refresh_if_provided(ttl: impl Into<Option<Duration>>) -> Self {
+        let ttl = ttl.into();
+        Self::new(ttl, ttl.is_some())
+    }
+
+    /// Return a new collection TTL which uses the same TTL but refreshes on updates.
+    pub fn with_refresh_on_update(self) -> Self {
+        Self::new(self.ttl(), true)
+    }
+
+    /// Return a new collection TTL which uses the same TTL but does not refresh on
+    /// updates.
+    pub fn with_no_refresh_on_update(self) -> Self {
+        Self::new(self.ttl(), false)
+    }
+
+    /// Return a new collecton TTL which has the same refresh behaviour but uses the
+    /// provided TTL.
+    pub fn with_ttl(self, ttl: impl Into<Option<Duration>>) -> Self {
+        Self::new(ttl.into(), self.refresh())
+    }
+
     /// The [`Duration`] after which the cached collection should be expired from the
     /// cache.
-    /// 
+    ///
     /// If `None`, the default item TTL for the client will be used.
     pub fn ttl(&self) -> Option<Duration> {
         self.ttl
     }
 
     /// Whether the collection's TTL will be refreshed on every update.
-    /// 
+    ///
     /// If true, this will extend the time at which the collection would expire when
     /// an update operation happens. Otherwise, the collection's TTL will only be set
     /// when it is initially created.
@@ -445,7 +470,7 @@ impl SimpleCacheClient {
     /// * `cache_name` - name of cache
     /// * `cache_key` - key of entry within the cache.
     /// * `cache_body` - data stored within the cache entry.
-    /// * `ttl` - The TTL to use for the 
+    /// * `ttl` - The TTL to use for the
     ///
     /// # Examples
     ///

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -209,7 +209,6 @@ impl SimpleCacheClientBuilder {
         );
         let data_client = ScsClient::new(data_interceptor);
 
-        #[allow(deprecated)]
         SimpleCacheClient {
             data_endpoint: self.data_endpoint,
             control_client,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use tonic::transport::{Channel, ClientTlsConfig, Uri};
 
-use crate::MomentoResult;
 use crate::response::MomentoError;
+use crate::MomentoResult;
 use std::convert::TryFrom;
 use std::time::{self, Duration};
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,14 +1,16 @@
 use tonic::transport::{Channel, ClientTlsConfig, Uri};
 
 use crate::response::MomentoError;
-use std::{convert::TryFrom, num::NonZeroU64, time};
+use std::convert::TryFrom;
+use std::time::{self, Duration};
 
-pub fn is_ttl_valid(ttl: &NonZeroU64) -> Result<(), MomentoError> {
-    let max_ttl = u64::MAX / 1000_u64;
-    if ttl.get() > max_ttl {
+pub fn is_ttl_valid(ttl: Duration) -> Result<(), MomentoError> {
+    let max_ttl = Duration::from_millis(u64::MAX);
+    if ttl > max_ttl {
         return Err(MomentoError::InvalidArgument(format!(
             "TTL provided, {}, needs to be less than the maximum TTL {}",
-            ttl, max_ttl
+            ttl.as_secs(),
+            max_ttl.as_secs()
         )));
     }
     Ok(())

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,7 +3,7 @@ mod tests {
     use std::{env, time::Duration};
 
     use momento::{response::MomentoGetStatus, SimpleCacheClient};
-    use momento::{MomentoError, SimpleCacheClientBuilder, TtlPolicy};
+    use momento::{MomentoError, SimpleCacheClientBuilder};
     use serde_json::Value;
     use tokio::time::sleep;
     use uuid::Uuid;
@@ -76,12 +76,7 @@ mod tests {
         let ttl: u64 = 18446744073709551615;
         let max_ttl = u64::MAX / 1000_u64;
         let result = mm
-            .set(
-                &cache_name,
-                cache_key,
-                cache_body,
-                TtlPolicy::initialize(Duration::from_secs(ttl)),
-            ) // 18446744073709551615 > 2^64/1000
+            .set(&cache_name, cache_key, cache_body, Duration::from_secs(ttl)) // 18446744073709551615 > 2^64/1000
             .await
             .unwrap_err();
         let _err_message = format!(
@@ -106,14 +101,9 @@ mod tests {
         mm.create_cache(&cache_name)
             .await
             .expect("failed to create cache");
-        mm.set(
-            &cache_name,
-            cache_key.clone(),
-            cache_body.clone(),
-            TtlPolicy::default(),
-        )
-        .await
-        .expect("failed to perform set");
+        mm.set(&cache_name, cache_key.clone(), cache_body.clone(), None)
+            .await
+            .expect("failed to perform set");
         let result = mm
             .get(&cache_name, cache_key.clone())
             .await
@@ -134,14 +124,9 @@ mod tests {
         mm.create_cache(&cache_name)
             .await
             .expect("failed to create cache");
-        mm.set(
-            &cache_name,
-            cache_key.clone(),
-            cache_body.clone(),
-            TtlPolicy::default(),
-        )
-        .await
-        .expect("failed to perform set");
+        mm.set(&cache_name, cache_key.clone(), cache_body.clone(), None)
+            .await
+            .expect("failed to perform set");
         sleep(Duration::new(1, 0)).await;
         let result = mm
             .get(&cache_name, cache_key.clone())
@@ -162,14 +147,9 @@ mod tests {
         mm.create_cache(&cache_name)
             .await
             .expect("failed to create cache");
-        mm.set(
-            &cache_name,
-            cache_key.clone(),
-            cache_body.clone(),
-            TtlPolicy::default(),
-        )
-        .await
-        .expect("failed to perform set");
+        mm.set(&cache_name, cache_key.clone(), cache_body.clone(), None)
+            .await
+            .expect("failed to perform set");
         let result = mm
             .get(&cache_name, cache_key.clone())
             .await
@@ -281,7 +261,7 @@ mod tests {
         ));
         // Can reach data plane
         let set_result = client
-            .set("cache", "hello", "world", TtlPolicy::default())
+            .set("cache", "hello", "world", None)
             .await
             .unwrap_err();
         let _err_msg_unauthenticated = "Invalid signature".to_string();
@@ -322,7 +302,7 @@ mod tests {
         ));
         // Unable to reach data plane
         let set_result = client
-            .set("cache", "hello", "world", TtlPolicy::default())
+            .set("cache", "hello", "world", None)
             .await
             .unwrap_err();
         let _err_msg_internal = "error trying to connect: dns error: failed to lookup address information: nodename nor servname provided, or not known".to_string();
@@ -350,7 +330,7 @@ mod tests {
             &cache_name,
             cache_key.clone(),
             cache_body.clone(),
-            TtlPolicy::initialize(Duration::from_millis(10000)),
+            Duration::from_millis(10000),
         )
         .await
         .expect("failed to perform set");


### PR DESCRIPTION
This PR does two main things:
- Use Duration for all time-span values with the exception of ttl_minutes when creating a signing key.
- Introduce a TtlPolicy type and use that for all TTL parameters in cache client methods where a TTL was previously taken. This is similar to the CollectionTtl type in the JS SDK but I've used it a bit more widely.

This means that all time-spans now go through std's Duration type and there is now now way that users could, for example, pass seconds to a method that is expecting milliseconds. The one exception to this for create_signing_key. Duration has no from_minutes method and I felt that having the duration silently truncate down to the last minute would be too unintuitive if the only constructor is Duration::from_secs.

One thing to note is that now users of the SDK can set TTLs to zero where that wasn't possible before. I consider this pretty minor since it was previously possible to set a TTL of 1ms which has effectively the same behaviour.