### PR TITLE
feat: add feature preview for topics

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install protoc
+        run: ./install_protoc.sh
+
       - name: rustfmt
         run: cargo fmt -- --check
       - name: Rigorous lint via Clippy
@@ -45,6 +49,9 @@ jobs:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
       - uses: actions/checkout@v2
+      - name: Install protoc
+        run: ./install_protoc.sh
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install protoc
+        run: ./install_protoc.sh
+
       - name: Commitlint and Other Shared Build Steps
         uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: rustfmt
         run: cargo fmt -- --check
@@ -31,6 +36,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install protoc
+        run: ./install_protoc.sh
+
+      - uses: Swatinem/rust-cache@v2
+
       - name: Build
         run: cargo build --verbose
       - name: Cargo Check
@@ -48,8 +59,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install protoc
+        run: ./install_protoc.sh
+
       - name: Commitlint and Other Shared Build Steps
         uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: rustfmt -> rigorous lint via Clippy -> build
         id: validation

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Install protoc
+        run: ./install_protoc.sh
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ homepage = "https://gomomento.com/"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-momento-protos = { version = "0.37.0" }
+momento-protos = { version = "0.42" }
 log = "0.4.17"
-tonic = { version = "0.7.2", features = ["tls", "tls-roots", "tls-webpki-roots"] }
+tonic = { version = "0.8", features = ["tls", "tls-roots", "tls-webpki-roots"] }
 jsonwebtoken = "8.0.1"
 rand = "0.8.5"
 serde = {version = "1.0", features = ["derive"] }

--- a/install_protoc.sh
+++ b/install_protoc.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+set -x
+
+VERSION=3.18.1
+
+sudo apt-get -y install zip tree
+curl -L https://github.com/protocolbuffers/protobuf/releases/download/v$VERSION/protoc-$VERSION-linux-x86_64.zip -o protoc.zip
+unzip -o protoc.zip -d protoc
+
+mkdir temp
+pushd temp
+  curl -L https://github.com/protocolbuffers/protobuf/releases/download/v$VERSION/protoc-$VERSION-linux-x86_64.zip -o protoc.zip
+  unzip -o protoc.zip -d protoc
+  sudo mv protoc/bin/* /usr/local/bin/
+  sudo mv protoc/include/* /usr/local/include/
+popd
+rm -rf temp
+
+tree /usr/local/include/google

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod preview;
 pub mod response;
 
 mod endpoint_resolver;

--- a/src/preview/mod.rs
+++ b/src/preview/mod.rs
@@ -1,0 +1,1 @@
+pub mod topics;

--- a/src/preview/topics.rs
+++ b/src/preview/topics.rs
@@ -1,0 +1,292 @@
+use momento_protos::cache_client::pubsub::{
+    self, pubsub_client::PubsubClient, PublishRequest, SubscriptionRequest,
+};
+use tonic::{codegen::InterceptedService, transport::Channel};
+
+use crate::MomentoError;
+use crate::{
+    endpoint_resolver::MomentoEndpointsResolver,
+    grpc::header_interceptor::HeaderInterceptor,
+    utils::{connect_channel_lazily, user_agent},
+    MomentoResult,
+};
+
+type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
+
+pub struct Pubsub {
+    client: pubsub::pubsub_client::PubsubClient<ChannelType>,
+}
+
+/// Work with topics, publishing and subscribing.
+impl Pubsub {
+    pub fn connect(
+        auth_token: String,
+        momento_endpoint: Option<String>,
+        user_application_name: Option<&str>,
+    ) -> MomentoResult<Self> {
+        let momento_endpoints = MomentoEndpointsResolver::resolve(&auth_token, momento_endpoint)?;
+        let channel = connect_channel_lazily(&momento_endpoints.data_endpoint.url)?;
+        let authorized_channel = InterceptedService::new(
+            channel,
+            HeaderInterceptor::new(
+                &auth_token,
+                &user_agent(user_application_name.unwrap_or("sdk")),
+            ),
+        );
+        Ok(Self {
+            client: pubsub::pubsub_client::PubsubClient::new(authorized_channel),
+        })
+    }
+
+    /// Publish a value to a topic.
+    /// The cache is used as a namespace for your topics, and it needs to exist.
+    /// You don't create topics, you just start using them.
+    pub async fn publish(
+        &self,
+        cache_name: String,
+        topic: String,
+        value: impl IntoTopicValue,
+    ) -> Result<(), MomentoError> {
+        Pubsub::actually_publish(&mut self.client.clone(), cache_name, topic, value).await
+    }
+
+    /// Publish a value to a topic.
+    /// The cache is used as a namespace for your topics, and it needs to exist.
+    /// You don't create topics, you just start using them.
+    ///
+    /// Use this if you have &mut, as it will save you a small amount of overhead for reusing the client.
+    pub async fn publish_mut(
+        &mut self,
+        cache_name: String,
+        topic: String,
+        value: impl IntoTopicValue,
+    ) -> Result<(), MomentoError> {
+        Pubsub::actually_publish(&mut self.client, cache_name, topic, value).await
+    }
+
+    async fn actually_publish(
+        client: &mut PubsubClient<ChannelType>,
+        cache_name: String,
+        topic: String,
+        value: impl IntoTopicValue,
+    ) -> Result<(), MomentoError> {
+        client
+            .publish(PublishRequest {
+                cache_name,
+                topic,
+                value: Some(pubsub::TopicValue {
+                    kind: Some(value.into_topic_value()),
+                }),
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Subscribe to a topic.
+    /// The cache is used as a namespace for your topics, and it needs to exist.
+    /// You don't create topics, you just start using them.
+    pub async fn subscribe(
+        &self,
+        cache_name: String,
+        topic: String,
+        resume_at_topic_sequence_number: Option<u64>,
+    ) -> Result<Subscription, MomentoError> {
+        Pubsub::actually_subscribe(
+            &mut self.client.clone(),
+            cache_name,
+            topic,
+            resume_at_topic_sequence_number,
+        )
+        .await
+    }
+
+    /// Subscribe to a topic.
+    /// The cache is used as a namespace for your topics, and it needs to exist.
+    /// You don't create topics, you just start using them.
+    ///
+    /// Use this if you have &mut, as it will save you a small amount of overhead for reusing the client.
+    pub async fn subscribe_mut(
+        &mut self,
+        cache_name: String,
+        topic: String,
+        resume_at_topic_sequence_number: Option<u64>,
+    ) -> Result<Subscription, MomentoError> {
+        Pubsub::actually_subscribe(
+            &mut self.client,
+            cache_name,
+            topic,
+            resume_at_topic_sequence_number,
+        )
+        .await
+    }
+
+    async fn actually_subscribe(
+        client: &mut PubsubClient<ChannelType>,
+        cache_name: String,
+        topic: String,
+        resume_at_topic_sequence_number: Option<u64>,
+    ) -> Result<Subscription, MomentoError> {
+        let tonic_stream = client
+            .subscribe(SubscriptionRequest {
+                cache_name,
+                topic,
+                resume_at_topic_sequence_number: resume_at_topic_sequence_number
+                    .unwrap_or_default(),
+            })
+            .await?
+            .into_inner();
+        Ok(Subscription {
+            inner: tonic_stream,
+        })
+    }
+}
+
+/// A stream of items from a topic.
+/// This will run more or less forever and yield items as long as you're
+/// subscribed and someone is publishing.
+pub struct Subscription {
+    inner: tonic::Streaming<pubsub::SubscriptionItem>,
+}
+
+impl Subscription {
+    /// Wait for the next item in the stream.
+    ///
+    /// Result::Ok(Some(item))    -> the server sent you a subscription item!
+    /// Result::Ok(None)          -> the server is done - there will be no more items!
+    /// Result::Err(MomentoError) -> something went wrong - log it and maybe reach out if you need help!
+    pub async fn item(&mut self) -> Result<Option<SubscriptionItem>, MomentoError> {
+        self.inner
+            .message()
+            .await
+            .map_err(|e| e.into())
+            .map(Subscription::map_into)
+    }
+
+    /// Yeah this is a pain, but doing it here lets us yield a simpler-typed subscription stream.
+    /// Also, we don't want to expose protocol buffers types outside of the sdk, so some type map
+    /// had to happen. It's all one-off at the moment though so might as well leave it as one
+    /// triangle expression =)
+    fn map_into(possible_item: Option<pubsub::SubscriptionItem>) -> Option<SubscriptionItem> {
+        match possible_item {
+            Some(item) => match item.kind {
+                Some(kind) => match kind {
+                    pubsub::subscription_item::Kind::Item(item) => match item.value {
+                        Some(value) => {
+                            let sequence_number = item.topic_sequence_number;
+                            match value.kind {
+                                Some(topic_value_kind) => {
+                                    Some(SubscriptionItem::Value(SubscriptionValue {
+                                        topic_sequence_number: sequence_number,
+                                        kind: match topic_value_kind {
+                                            pubsub::topic_value::Kind::Text(text) => {
+                                                ValueKind::Text(text)
+                                            }
+                                            pubsub::topic_value::Kind::Binary(binary) => {
+                                                ValueKind::Binary(binary)
+                                            }
+                                        },
+                                    }))
+                                }
+                                // Broken protocol
+                                None => Some(SubscriptionItem::Discontinuity(Discontinuity {
+                                    last_sequence_number: None,
+                                    new_sequence_number: sequence_number,
+                                })),
+                            }
+                        }
+                        None => None, // Broken protocol
+                    },
+                    pubsub::subscription_item::Kind::Discontinuity(_) => todo!(),
+                },
+                None => None, // Broken protocol,
+            },
+            None => None, // Normal end-of-stream from server
+        }
+    }
+}
+
+/// An item from a topic.
+#[derive(Debug)]
+pub enum SubscriptionItem {
+    Value(SubscriptionValue),
+    /// Sometimes something will break in a subscription. It is an unfortunate reality
+    /// of network programming that errors occur. We do our best to tell you what we
+    /// know about those errors when they occur.
+    /// You might not care about these, and that's okay! It's probably a good idea to
+    /// log them though, so you can reach out for help if you notice something naughty
+    /// that hurts your users.
+    Discontinuity(Discontinuity),
+}
+
+/// An actual published value from a topic.
+#[derive(Debug)]
+pub struct SubscriptionValue {
+    /// The published value.
+    pub kind: ValueKind,
+    /// Best-effort sequence number for the topic. This is not transactional, it's just
+    /// to help you know when things are probably working well or probably not working well.
+    pub topic_sequence_number: u64,
+}
+
+#[derive(Debug)]
+pub enum ValueKind {
+    /// A value that was published to the topic as a string.
+    Text(String),
+    /// A value that was published to the topic as raw bytes.
+    Binary(Vec<u8>),
+}
+
+/// Sometimes something will break in a subscription. It is an unfortunate reality
+/// of network programming that errors occur. We do our best to tell you what we
+/// know about those errors when they occur.
+/// You might not care about these, and that's okay! It's probably a good idea to
+/// log them though, so you can reach out for help if you notice something naughty
+/// that hurts your users.
+#[derive(Debug)]
+pub struct Discontinuity {
+    /// The last sequence number we know we processed for this stream on your
+    /// behalf - it is not necessarily the last sequence number you received!
+    pub last_sequence_number: Option<u64>,
+
+    /// This discontinuity's sequence number. The next item on the stream should
+    /// be a value with the next sequence after this.
+    pub new_sequence_number: u64,
+}
+
+/// How a value should be presented on a subscription stream
+pub trait IntoTopicValue {
+    /// Consume self into a kind of topic value.
+    fn into_topic_value(self) -> pubsub::topic_value::Kind;
+}
+
+/// A convenience for you to pass into publish directly if you
+/// want to manually construct topic values.
+impl IntoTopicValue for pubsub::topic_value::Kind {
+    fn into_topic_value(self) -> pubsub::topic_value::Kind {
+        self
+    }
+}
+
+/// A convenience, this conversion copies the string. If you care
+/// you should use String instead, or directly use a Kind.
+///
+/// A Text topic value.
+impl IntoTopicValue for &str {
+    fn into_topic_value(self) -> pubsub::topic_value::Kind {
+        pubsub::topic_value::Kind::Text(self.to_string())
+    }
+}
+
+/// A Text topic value.
+impl IntoTopicValue for String {
+    fn into_topic_value(self) -> pubsub::topic_value::Kind {
+        pubsub::topic_value::Kind::Text(self)
+    }
+}
+
+/// A Binary topic value.
+impl IntoTopicValue for Vec<u8> {
+    fn into_topic_value(self) -> pubsub::topic_value::Kind {
+        pubsub::topic_value::Kind::Binary(self)
+    }
+}

--- a/src/preview/topics.rs
+++ b/src/preview/topics.rs
@@ -13,12 +13,35 @@ use crate::{
 
 type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
 
-pub struct Pubsub {
+pub struct TopicClient {
     client: pubsub::pubsub_client::PubsubClient<ChannelType>,
 }
 
 /// Work with topics, publishing and subscribing.
-impl Pubsub {
+/// ```rust
+/// use momento::preview::topics::TopicClient;
+/// 
+/// async {
+///     // Get a topic client
+///     let client = TopicClient::connect(
+///         "token".to_string(),
+///         Some("some.momento.endpoint".to_string()),
+///         Some("github-demo")
+///     ).expect("could not connect");
+/// 
+///     // Make a subscription
+///     let mut subscription = client
+///         .subscribe("some_cache".to_string(), "some topic".to_string(), None)
+///         .await
+///         .expect("subscribe rpc failed");
+/// 
+///     // Consume the subscription
+///     while let Some(item) = subscription.item().await.expect("subscription stream interrupted") {
+///         println!("{item:?}")
+///     }
+/// };
+/// ```
+impl TopicClient {
     pub fn connect(
         auth_token: String,
         momento_endpoint: Option<String>,
@@ -47,7 +70,7 @@ impl Pubsub {
         topic: String,
         value: impl IntoTopicValue,
     ) -> Result<(), MomentoError> {
-        Pubsub::actually_publish(&mut self.client.clone(), cache_name, topic, value).await
+        TopicClient::actually_publish(&mut self.client.clone(), cache_name, topic, value).await
     }
 
     /// Publish a value to a topic.
@@ -61,7 +84,7 @@ impl Pubsub {
         topic: String,
         value: impl IntoTopicValue,
     ) -> Result<(), MomentoError> {
-        Pubsub::actually_publish(&mut self.client, cache_name, topic, value).await
+        TopicClient::actually_publish(&mut self.client, cache_name, topic, value).await
     }
 
     async fn actually_publish(
@@ -91,7 +114,7 @@ impl Pubsub {
         topic: String,
         resume_at_topic_sequence_number: Option<u64>,
     ) -> Result<Subscription, MomentoError> {
-        Pubsub::actually_subscribe(
+        TopicClient::actually_subscribe(
             &mut self.client.clone(),
             cache_name,
             topic,
@@ -111,7 +134,7 @@ impl Pubsub {
         topic: String,
         resume_at_topic_sequence_number: Option<u64>,
     ) -> Result<Subscription, MomentoError> {
-        Pubsub::actually_subscribe(
+        TopicClient::actually_subscribe(
             &mut self.client,
             cache_name,
             topic,

--- a/src/preview/topics.rs
+++ b/src/preview/topics.rs
@@ -219,7 +219,12 @@ impl Subscription {
                         }
                         None => None, // Broken protocol
                     },
-                    pubsub::subscription_item::Kind::Discontinuity(_) => todo!(),
+                    pubsub::subscription_item::Kind::Discontinuity(discontinuity) => {
+                        Some(SubscriptionItem::Discontinuity(Discontinuity {
+                            last_sequence_number: Some(discontinuity.last_topic_sequence),
+                            new_sequence_number: discontinuity.new_topic_sequence,
+                        }))
+                    }
                 },
                 None => None, // Broken protocol,
             },

--- a/src/preview/topics.rs
+++ b/src/preview/topics.rs
@@ -20,7 +20,7 @@ pub struct TopicClient {
 /// Work with topics, publishing and subscribing.
 /// ```rust
 /// use momento::preview::topics::TopicClient;
-/// 
+///
 /// async {
 ///     // Get a topic client
 ///     let client = TopicClient::connect(
@@ -28,13 +28,13 @@ pub struct TopicClient {
 ///         Some("some.momento.endpoint".to_string()),
 ///         Some("github-demo")
 ///     ).expect("could not connect");
-/// 
+///
 ///     // Make a subscription
 ///     let mut subscription = client
 ///         .subscribe("some_cache".to_string(), "some topic".to_string(), None)
 ///         .await
 ///         .expect("subscribe rpc failed");
-/// 
+///
 ///     // Consume the subscription
 ///     while let Some(item) = subscription.item().await.expect("subscription stream interrupted") {
 ///         println!("{item:?}")

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -13,7 +13,7 @@ use std::convert::TryFrom;
 use std::num::NonZeroU64;
 use tonic::{codegen::InterceptedService, transport::Channel, Request};
 
-use crate::endpoint_resolver::MomentoEndpointsResolver;
+use crate::{endpoint_resolver::MomentoEndpointsResolver, utils::user_agent};
 use crate::{grpc::header_interceptor::HeaderInterceptor, utils::connect_channel_lazily};
 
 use crate::response::{
@@ -25,8 +25,6 @@ use crate::response::{
     MomentoSigningKey,
 };
 use crate::utils;
-
-const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub trait IntoBytes {
     fn into_bytes(self) -> Vec<u8>;
@@ -151,11 +149,7 @@ impl SimpleCacheClientBuilder {
     }
 
     pub fn build(self) -> SimpleCacheClient {
-        let agent_value = format!(
-            "rust-{agent_name}:{version}",
-            agent_name = self.user_agent_name,
-            version = VERSION
-        );
+        let agent_value = user_agent(&self.user_agent_name);
         let control_interceptor = InterceptedService::new(
             self.control_channel,
             HeaderInterceptor::new(&self.auth_token, &agent_value),

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -845,7 +845,7 @@ impl SimpleCacheClient {
     /// use uuid::Uuid;
     /// use std::num::NonZeroU64;
     /// use std::env;
-    /// use momento::simple_cache_client::SimpleCacheClientBuilder;
+    /// use momento::SimpleCacheClientBuilder;
     ///
     /// let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
     /// let cache_name = Uuid::new_v4().to_string();
@@ -992,7 +992,7 @@ impl SimpleCacheClient {
     /// # tokio_test::block_on(async {
     /// use uuid::Uuid;
     /// use std::num::NonZeroU64;
-    /// use momento::simple_cache_client::SimpleCacheClientBuilder;
+    /// use momento::SimpleCacheClientBuilder;
     ///
     /// let auth_token = std::env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be defined");
     /// let cache_name = Uuid::new_v4().to_string();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -44,10 +44,5 @@ pub fn connect_channel_lazily(uri_string: &str) -> Result<Channel, MomentoError>
 }
 
 pub fn user_agent(user_agent_name: &str) -> String {
-    let agent_value = format!(
-        "rust-{agent_name}:{version}",
-        agent_name = user_agent_name,
-        version = VERSION
-    );
-    agent_value
+    format!("rust-{user_agent_name}:{VERSION}")
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,6 +3,8 @@ use tonic::transport::{Channel, ClientTlsConfig, Uri};
 use crate::response::MomentoError;
 use std::{convert::TryFrom, num::NonZeroU64, time};
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub fn is_ttl_valid(ttl: &NonZeroU64) -> Result<(), MomentoError> {
     let max_ttl = u64::MAX / 1000_u64;
     if ttl.get() > max_ttl {
@@ -39,4 +41,13 @@ pub fn connect_channel_lazily(uri_string: &str) -> Result<Channel, MomentoError>
         .http2_keep_alive_interval(time::Duration::from_secs(2 * 60))
         .tls_config(ClientTlsConfig::default())?;
     Ok(endpoint.connect_lazy())
+}
+
+pub fn user_agent(user_agent_name: &str) -> String {
+    let agent_value = format!(
+        "rust-{agent_name}:{version}",
+        agent_name = user_agent_name,
+        version = VERSION
+    );
+    agent_value
 }


### PR DESCRIPTION
Momento topics are currently under development but this first step
helps enable end-user experimentation with the types.

This adds a Pubsub client, complete with connect(), publish() and
subscribe().

subscribe() is the more interesting method, as it returns a
Subscription, which is a new kind of user-facing functionality for
our sdk. I've wrapped the protobuf types into simpler non-Optional
messages, marshaling some of their safe/default notions into what
they mean for a Momento subscription.

For context, the subscription usage looks like:
```rust
let client = Pubsub::connect(token, endpoint, Some("github-demo"))?;

let subscription = client
    .subscribe(cache_name, topic, None)
    .await?;

while let Some(item) = subscription.item().await? {
    match item {
        SubscriptionItem::Value(value) => match value.kind {
            ValueKind::Text(text) => println!("{text}"),
            ValueKind::Binary(binary) => {
                println!("{{\"kind\": \"binary\", \"length\": {}}}", binary.len())
            }
        },
        SubscriptionItem::Discontinuity(discontinuity) => {
            println!("{discontinuity:?}")
        }
    }
}
```

add install_protoc.sh for tonic 0.8 in all the github files

also add dependency build cache for PR's. These approvals do not need to rebuild everything every time.