### PR TITLE
chore: Add support for SDK set difference command

### DIFF
--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -42,3 +42,8 @@ impl ListCacheEntry {
 }
 
 pub type MomentoListFetchResponse = Option<ListCacheEntry>;
+
+pub enum MomentoSetDifferenceResponse {
+    Found,
+    Missing,
+}


### PR DESCRIPTION
As in the title. I have also added aliases here to match those used in the .NET SDK - although I've still kept `set_union` and `set_difference` methods as the main ones with example documentation.

I've also made an attempt to make the doctest behave better in the face of assertion failures.