### PR TITLE
chore: clean up doc tests and avoid cache leaks on failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,5 @@ env_logger = "0.9.0"
 tokio = { version = "1.9.0", features = ["full"] }
 tokio-test = "0.4.2"
 uuid = { version = "0.8", features = ["v4"] }
+futures = "0.3.25"
+anyhow = "1.0.68"

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -493,23 +493,31 @@ impl SimpleCacheClient {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> anyhow::Result<()> {
+    /// # tokio_test::block_on(async {
+    /// # use futures::FutureExt;
     /// use uuid::Uuid;
     /// use std::time::Duration;
-    /// # tokio_test::block_on(async {
-    ///     use momento::{CollectionTtl, SimpleCacheClientBuilder};
-    ///     use std::env;
-    ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
-    ///     let cache_name = Uuid::new_v4().to_string();
-    ///     let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(30))
-    ///         .expect("could not create a client")
-    ///         .build();
-    ///     momento.create_cache(&cache_name).await;
-    ///     momento.set(&cache_name, "cache_key", "cache_value", None).await;
+    /// use momento::SimpleCacheClientBuilder;
     ///
-    ///     // overriding default ttl
-    ///     momento.set(&cache_name, "cache_key", "cache_value", Duration::from_secs(10)).await;
-    ///     momento.delete_cache(&cache_name).await;
+    /// let auth_token = std::env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
+    /// let cache_name = Uuid::new_v4().to_string();
+    /// let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(30))?
+    ///     .build();
+    ///
+    /// momento.create_cache(&cache_name).await?;
+    /// # let result = std::panic::AssertUnwindSafe(async {
+    /// // use the default client TTL (30 seconds in this case)
+    /// momento.set(&cache_name, "key", "value", None).await?;
+    ///
+    /// // override the default TTL
+    /// momento.set(&cache_name, "key", "value", Duration::from_secs(10)).await?;
+    /// # Ok(())
+    /// # }).catch_unwind().await;
+    /// # momento.delete_cache(&cache_name).await?;
+    /// # result.unwrap_or_else(|e| std::panic::resume_unwind(e))
     /// # })
+    /// # }
     /// ```
     pub async fn set(
         &mut self,

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -290,19 +290,22 @@ impl SimpleCacheClient {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> anyhow::Result<()> {
+    /// # tokio_test::block_on(async {
     /// use uuid::Uuid;
     /// use std::time::Duration;
-    /// # tokio_test::block_on(async {
-    ///     use momento::SimpleCacheClientBuilder;
-    ///     use std::env;
-    ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
-    ///     let cache_name = Uuid::new_v4().to_string();
-    ///     let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(5))
-    ///         .expect("could not create a client")
-    ///         .build();
-    ///     momento.create_cache(&cache_name).await;
-    ///     momento.delete_cache(&cache_name).await;
+    /// use momento::SimpleCacheClientBuilder;
+    ///
+    /// let auth_token = std::env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
+    /// let cache_name = Uuid::new_v4().to_string();
+    /// let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(5))?
+    ///     .build();
+    ///
+    /// momento.create_cache(&cache_name).await?;
+    /// momento.delete_cache(&cache_name).await?;
+    /// # Ok(())
     /// # })
+    /// # }
     /// ```
     pub async fn delete_cache(&mut self, name: &str) -> MomentoResult<()> {
         utils::is_cache_name_valid(name)?;

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -425,19 +425,29 @@ impl SimpleCacheClient {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> anyhow::Result<()> {
+    /// # tokio_test::block_on(async {
+    /// # use futures::FutureExt;
     /// use uuid::Uuid;
     /// use std::time::Duration;
-    /// # tokio_test::block_on(async {
-    ///     use momento::SimpleCacheClientBuilder;
-    ///     use std::env;
-    ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
-    ///     let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(5))
-    ///         .expect("could not create a client")
-    ///         .build();
-    ///     let ttl_minutes = 10;
-    ///     momento.create_signing_key(ttl_minutes).await;
-    ///     let keys = momento.list_signing_keys(None).await;
+    /// use momento::SimpleCacheClientBuilder;
+    ///
+    /// let ttl_minutes = 10;
+    /// let auth_token = std::env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
+    /// let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(5))?
+    ///     .build();
+    ///
+    /// let key = momento.create_signing_key(ttl_minutes).await?;
+    /// # let result = std::panic::AssertUnwindSafe(async {
+    /// let list = momento.list_signing_keys(None).await?.signing_keys;
+    /// assert!(list.iter().any(|sk| sk.key_id == key.key_id));
+    /// # Ok(())
+    /// # }).catch_unwind().await;
+    ///
+    /// momento.revoke_signing_key(&key.key_id).await?;
+    /// # result.unwrap_or_else(|e| std::panic::resume_unwind(e))
     /// # })
+    /// # }
     /// ```
     pub async fn list_signing_keys(
         &mut self,

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -550,27 +550,35 @@ impl SimpleCacheClient {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> anyhow::Result<()> {
+    /// # tokio_test::block_on(async {
+    /// # use futures::FutureExt;
     /// use uuid::Uuid;
     /// use std::time::Duration;
-    /// # tokio_test::block_on(async {
-    ///     use std::env;
-    ///     use momento::{response::MomentoGetStatus, SimpleCacheClientBuilder};
-    ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
-    ///     let cache_name = Uuid::new_v4().to_string();
-    ///     let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(30))
-    ///         .expect("could not create a client")
-    ///         .build();
-    ///     momento.create_cache(&cache_name).await;
-    ///     let resp = momento.get(&cache_name, "cache_key").await.unwrap();
-    ///     match resp.result {
-    ///         MomentoGetStatus::HIT => println!("cache hit!"),
-    ///         MomentoGetStatus::MISS => println!("cache miss"),
-    ///         _ => println!("error occurred")
-    ///     };
+    /// use momento::SimpleCacheClientBuilder;
+    /// use momento::response::MomentoGetStatus;
     ///
-    ///     println!("cache value: {}", resp.as_string());
-    ///     momento.delete_cache(&cache_name).await;
+    /// let cache_name = Uuid::new_v4().to_string();
+    /// let auth_token = std::env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
+    /// let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(30))?
+    ///     .build();
+    ///
+    /// momento.create_cache(&cache_name).await?;
+    /// # let result = std::panic::AssertUnwindSafe(async {
+    /// let resp = momento.get(&cache_name, "cache_key").await?;
+    /// match resp.result {
+    ///     MomentoGetStatus::HIT => println!("cache hit!"),
+    ///     MomentoGetStatus::MISS => println!("cache miss"),
+    ///     _ => println!("error occurred")
+    /// }
+    ///
+    /// println!("cache value: {}", resp.as_string());
+    /// # Ok(())
+    /// # }).catch_unwind().await;
+    /// # momento.delete_cache(&cache_name).await?;
+    /// # result.unwrap_or_else(|e| std::panic::resume_unwind(e))
     /// # })
+    /// # }
     /// ```
     pub async fn get(
         &mut self,

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -321,19 +321,29 @@ impl SimpleCacheClient {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> anyhow::Result<()> {
+    /// # tokio_test::block_on(async {
+    /// # use futures::FutureExt;
     /// use uuid::Uuid;
     /// use std::time::Duration;
-    /// # tokio_test::block_on(async {
-    ///     use momento::SimpleCacheClientBuilder;
-    ///     let auth_token = std::env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
-    ///     let cache_name = Uuid::new_v4().to_string();
-    ///     let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(5))
-    ///         .expect("could not create a client")
-    ///         .build();
-    ///     momento.create_cache(&cache_name).await;
-    ///     let caches = momento.list_caches(None).await;
-    ///     momento.delete_cache(&cache_name).await;
+    /// use momento::SimpleCacheClientBuilder;
+    ///
+    /// let auth_token = std::env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
+    /// let cache_name = Uuid::new_v4().to_string();
+    /// let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(5))?
+    ///     .build();
+    ///
+    /// momento.create_cache(&cache_name).await?;
+    /// # let result = std::panic::AssertUnwindSafe(async {
+    /// let resp = momento.list_caches(None).await?;
+    ///
+    /// assert!(resp.caches.iter().any(|cache| cache.cache_name == cache_name));
+    /// # Ok(())
+    /// # }).catch_unwind().await;
+    /// # momento.delete_cache(&cache_name).await?;
+    /// # result.unwrap_or_else(|e| std::panic::resume_unwind(e))
     /// # })
+    /// # }
     /// ```
     pub async fn list_caches(
         &mut self,


### PR DESCRIPTION
This PR cleans up the documentation so that
1. It reads nicer from within rustdoc
2. It properly cleans up the cache even in the cases where the test case panics or errors out.
3. It uses `?` instead of `.expect` everywhere. I've added `anyhow` so that if debugging a test case becomes a necessary it is still possible to get a backtrace to the line on which the error was generated.

This PR doesn't hit all the doc comments. I will add a follow-up one which finishes up the rest of the methods on `SimpleCacheClient`.
