### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/src/endpoint_resolver.rs
+++ b/src/endpoint_resolver.rs
@@ -99,7 +99,7 @@ impl MomentoEndpointsResolver {
 
     fn hosted_zone_endpoint(hosted_zone: Option<String>, prefix: &str) -> Option<MomentoEndpoint> {
         hosted_zone.map(|hosted_zone| {
-            let hostname = format!("{}{}", prefix, hosted_zone);
+            let hostname = format!("{prefix}{hosted_zone}");
             MomentoEndpointsResolver::wrapped_endpoint("https://", hostname, ":443")
         })
     }

--- a/src/response/error.rs
+++ b/src/response/error.rs
@@ -42,7 +42,7 @@ impl std::fmt::Display for MomentoError {
             | MomentoError::Timeout(e)
             | MomentoError::LimitExceeded(e)
             | MomentoError::ClientSdkError(e)
-            | MomentoError::InvalidArgument(e) => write!(f, "{}", e),
+            | MomentoError::InvalidArgument(e) => write!(f, "{e}"),
         }
     }
 }

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -151,8 +151,7 @@ fn request_meta_data<T>(request: &mut tonic::Request<T>, cache_name: &str) -> Mo
         })
         .map_err(|e| {
             MomentoError::InvalidArgument(format!(
-                "Could not treat cache name as a header value: {}",
-                e
+                "Could not treat cache name as a header value: {e}"
             ))
         })
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -79,10 +79,8 @@ mod tests {
             .set(&cache_name, cache_key, cache_body, Duration::from_secs(ttl)) // 18446744073709551615 > 2^64/1000
             .await
             .unwrap_err();
-        let _err_message = format!(
-            "TTL provided, {}, needs to be less than the maximum TTL {}",
-            ttl, max_ttl
-        );
+        let _err_message =
+            format!("TTL provided, {ttl}, needs to be less than the maximum TTL {max_ttl}");
         assert!(matches!(
             result,
             MomentoError::InvalidArgument(_err_message)


### PR DESCRIPTION
Clippy introduced some new warnings that are now causing CI to fail. This commit is just the result of having clippy fix them automatically.