### PR TITLE
chore: add a test-utils crate to make writing doctests easier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,13 @@ license = "Apache-2.0"
 repository = "https://github.com/momentohq/client-sdk-rust"
 homepage = "https://gomomento.com/"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[workspace]
+members = [
+  ".",
+  "test-util"
+]
+
+exclude = [ "example" ]
 
 [dependencies]
 momento-protos = { version = "0.42" }
@@ -27,6 +33,7 @@ base64-url = "1.4.13"
 env_logger = "0.9.0"
 tokio = { version = "1.9.0", features = ["full"] }
 tokio-test = "0.4.2"
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "1.2.2", features = ["v4"] }
 futures = "0.3.25"
 anyhow = "1.0.68"
+momento-test-util = { path = "test-util" }

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[workspace]
+
 [dependencies]
 momento = "0.15.0"
 tokio = { version = "1.18.2", features = ["full"] }

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1155,21 +1155,19 @@ impl SimpleCacheClient {
     /// # Examples
     ///
     /// ```
-    /// use uuid::Uuid;
+    /// # fn main() -> momento_test_util::DoctestResult {
+    /// # momento_test_util::doctest(|cache_name, auth_token| async move {
     /// use std::time::Duration;
-    /// # tokio_test::block_on(async {
-    ///     use std::env;
-    ///     use momento::{response::MomentoGetStatus, CollectionTtl, SimpleCacheClientBuilder};
-    ///     let auth_token = env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
-    ///     let cache_name = Uuid::new_v4().to_string();
-    ///     let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(30))
-    ///         .expect("could not create a client")
-    ///         .build();
-    ///     momento.create_cache(&cache_name).await;
-    ///     let result = momento.set(&cache_name, "cache_key", "cache_value", None).await;
-    ///     momento.delete(&cache_name, "cache_key").await.unwrap();
-    ///     momento.delete_cache(&cache_name).await;
+    /// use momento::SimpleCacheClientBuilder;
+    ///
+    /// let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(30))?
+    ///     .build();
+    ///
+    /// momento.set(&cache_name, "key", "value", None).await?;
+    /// momento.delete(&cache_name, "key").await?;
+    /// # Ok(())
     /// # })
+    /// # }
     /// ```
     pub async fn delete(&mut self, cache_name: &str, key: impl IntoBytes) -> MomentoResult<()> {
         let request = self.prep_request(

--- a/test-util/Cargo.toml
+++ b/test-util/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "momento-test-util"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+momento = { path = ".." }
+anyhow = "1.0.68"
+tokio = { version = "1.25.0", features = ["full"] }
+uuid = { version = "1.2.2", features = ["v4"] }
+scopeguard = "1.1.0"

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -1,0 +1,45 @@
+use std::future::Future;
+use std::time::Duration;
+
+use momento::SimpleCacheClientBuilder;
+use uuid::Uuid;
+
+pub type DoctestResult = anyhow::Result<()>;
+
+/// Doctest helper function.
+///
+/// This function takes care of common setup/cleanup tasks for doctests:
+/// - Reading the auth token from the environment
+/// - Creating a cache for the doctest to use.
+/// - Ensuring that cache is deleted, even if the test case panics.
+pub fn doctest<'ctx, Fn: 'ctx, Fut: 'ctx>(func: Fn) -> DoctestResult
+where
+    Fn: FnOnce(String, String) -> Fut,
+    Fut: Future<Output = DoctestResult>,
+{
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+
+    // The constructor for the cache client needs a tokio runtime to be active.
+    let _guard = runtime.enter();
+
+    let cache_name = Uuid::new_v4().to_string();
+    let auth_token = std::env::var("TEST_AUTH_TOKEN").expect("TEST_AUTH_TOKEN must be set");
+
+    let mut client =
+        SimpleCacheClientBuilder::new(auth_token.clone(), Duration::from_secs(5))?.build();
+    runtime.block_on(client.create_cache(&cache_name))?;
+
+    let runtime = scopeguard::guard(runtime, {
+        let cache_name = cache_name.clone();
+        move |runtime| {
+            let _ = runtime.block_on(client.delete_cache(&cache_name));
+
+            // If any background tasks were spawned we give them some time to exit cleanly.
+            runtime.shutdown_timeout(Duration::from_secs(1));
+        }
+    });
+
+    runtime.block_on(func(cache_name, auth_token))
+}


### PR DESCRIPTION
As per some offline discussions, this refactors some of the common boilerplate in the doctests out to a utility function in a utility crate. It ended up being simpler than I thought it would be. I have also changed the doctest for `delete` to use this as an example.