### PR TITLE
feat: remove Fields enum and have dictionary_delete just take a vec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod utils;
 pub use crate::response::ErrorSource;
 pub use crate::response::MomentoError;
 pub use crate::simple_cache_client::{
-    CollectionTtl, Fields, IntoBytes, SimpleCacheClient, SimpleCacheClientBuilder,
+    CollectionTtl, IntoBytes, SimpleCacheClient, SimpleCacheClientBuilder,
 };
 
 pub type MomentoResult<T> = Result<T, MomentoError>;


### PR DESCRIPTION
`dictionary_delete` with `Fields::All` is exactly the same as just calling `delete`. Historically, there were reasons that there were different methods but those no longer apply. This PR removes the fields enum and makes `dictionary_delete` unconditionally take a `Vec<impl IntoBytes>`.