### PR TITLE
chore: implement all SDK list operations

### DIFF
--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -21,3 +21,24 @@ pub use self::create_signing_key_response::*;
 pub use self::error::*;
 pub use self::list_cache_response::*;
 pub use self::list_signing_keys_response::*;
+
+#[derive(Debug, Clone)]
+pub struct ListCacheEntry {
+    value: Vec<Vec<u8>>,
+}
+
+impl ListCacheEntry {
+    pub(crate) fn new(value: Vec<Vec<u8>>) -> Self {
+        Self { value }
+    }
+
+    pub fn into_value(self) -> Vec<Vec<u8>> {
+        self.value
+    }
+
+    pub fn value(&self) -> &[Vec<u8>] {
+        &self.value
+    }
+}
+
+pub type MomentoListFetchResponse = Option<ListCacheEntry>;

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1382,6 +1382,28 @@ impl SimpleCacheClient {
     ///
     /// * `cache_name` - name of the cache in which the list is stored.
     /// * `list_name` - name of the list to pop from.
+    ///
+    /// # Example
+    /// ```
+    /// # fn main() -> momento_test_util::DoctestResult {
+    /// # momento_test_util::doctest(|cache_name, auth_token| async move {
+    /// use std::time::Duration;
+    /// use momento::{CollectionTtl, SimpleCacheClientBuilder};
+    ///
+    /// let ttl = CollectionTtl::default();
+    /// let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(30))?
+    ///     .build();
+    ///
+    /// momento.list_set(&cache_name, "list", ["a", "b"], ttl).await?;
+    ///
+    /// assert!(matches!(
+    ///     momento.list_pop_back(&cache_name, "list").await?,
+    ///     Some(v) if v == b"b"
+    /// ));
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
     pub async fn list_pop_back(
         &mut self,
         cache_name: &str,
@@ -1420,6 +1442,29 @@ impl SimpleCacheClient {
     /// * `cache_name` - name of the cache in which to look for the list.
     /// * `list_name` - name of the list from which to remove elements.
     /// * `value` - the value to remove from the list.
+    ///
+    /// # Example
+    /// ```
+    /// # fn main() -> momento_test_util::DoctestResult {
+    /// # momento_test_util::doctest(|cache_name, auth_token| async move {
+    /// use std::time::Duration;
+    /// use momento::{CollectionTtl, SimpleCacheClientBuilder};
+    ///
+    /// let ttl = CollectionTtl::default();
+    /// let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(30))?
+    ///     .build();
+    ///
+    /// momento.list_set(&cache_name, "list", ["a", "b", "c", "a"], ttl).await?;
+    /// momento.list_remove_value(&cache_name, "list", "a").await?;
+    ///
+    /// let entry = momento.list_fetch(&cache_name, "list").await?.unwrap();
+    /// let values: Vec<_> = entry.value().iter().map(|v| &v[..]).collect();
+    /// let expected: Vec<&[u8]> = vec![b"b", b"c"];
+    /// assert_eq!(values, expected);
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
     pub async fn list_remove_value(
         &mut self,
         cache_name: &str,

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1159,6 +1159,29 @@ impl SimpleCacheClient {
     /// * `policy` - the TTL policy to use for this operation.
     /// * `truncate_to` - should the list exceed this length, it will be truncated.
     ///   If `None`, no truncation will be done. Truncation occurs from the front.
+    ///
+    /// # Example
+    /// ```
+    /// # fn main() -> momento_test_util::DoctestResult {
+    /// # momento_test_util::doctest(|cache_name, auth_token| async move {
+    /// use std::time::Duration;
+    /// use momento::{CollectionTtl, SimpleCacheClientBuilder};
+    ///
+    /// let ttl = CollectionTtl::default();
+    /// let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(30))?
+    ///     .build();
+    ///
+    /// momento.list_set(&cache_name, "list", ["a", "b"], ttl).await?;
+    /// momento.list_push_back(&cache_name, "list", "!", None, ttl).await?;
+    ///
+    /// let entry = momento.list_fetch(&cache_name, "list").await?.unwrap();
+    /// let values: Vec<_> = entry.value().iter().map(|v| &v[..]).collect();
+    /// let expected: Vec<&[u8]> = vec![b"a", b"b", b"!"];
+    /// assert_eq!(values, expected);
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
     pub async fn list_push_back(
         &mut self,
         cache_name: &str,

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1271,6 +1271,28 @@ impl SimpleCacheClient {
     ///
     /// * `cache_name` - name of the cache to fetch list from.
     /// * `list_name` - the list to fetch.
+    ///
+    /// # Example
+    /// ```
+    /// # fn main() -> momento_test_util::DoctestResult {
+    /// # momento_test_util::doctest(|cache_name, auth_token| async move {
+    /// use std::time::Duration;
+    /// use momento::{CollectionTtl, SimpleCacheClientBuilder};
+    ///
+    /// let ttl = CollectionTtl::default();
+    /// let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(30))?
+    ///     .build();
+    ///
+    /// momento.list_set(&cache_name, "list", ["a", "b"], ttl).await?;
+    ///
+    /// let entry = momento.list_fetch(&cache_name, "list").await?.unwrap();
+    /// let values: Vec<_> = entry.value().iter().map(|v| &v[..]).collect();
+    /// let expected: Vec<&[u8]> = vec![b"a", b"b"];
+    /// assert_eq!(values, expected);
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
     pub async fn list_fetch(
         &mut self,
         cache_name: &str,

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -988,6 +988,45 @@ impl SimpleCacheClient {
             .map_err(From::from)
     }
 
+    /// Push multiple values to the end of a list.
+    ///
+    /// *NOTE*: This is preview functionality and requires that you contact
+    /// Momento Support to enable these APIs for your cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `cache_name` - name of the cache to store the list in.
+    /// * `list_name` - list to modify.
+    /// * `values` - values to push to the front of the list.
+    /// * `truncate_to` - if set, indicates the maximum number of elements the
+    ///   list may contain before truncating elements from the front.
+    /// * `policy` - TTL policy to use.
+    pub async fn list_concat_back<V: IntoBytes>(
+        &mut self,
+        cache_name: &str,
+        list_name: impl IntoBytes,
+        values: impl IntoIterator<Item = V>,
+        truncate_to: impl Into<Option<u32>>,
+        policy: CollectionTtl,
+    ) -> MomentoResult<u32> {
+        let request = self.prep_request(
+            cache_name,
+            ListConcatenateBackRequest {
+                list_name: list_name.into_bytes(),
+                values: convert_vec(values),
+                ttl_milliseconds: self.expand_ttl_ms(policy.ttl())?,
+                refresh_ttl: policy.refresh(),
+                truncate_front_to_size: truncate_to.into().unwrap_or(u32::MAX),
+            },
+        )?;
+
+        self.data_client
+            .list_concatenate_back(request)
+            .await
+            .map(|resp| resp.into_inner().list_length)
+            .map_err(From::from)
+    }
+
     /// Inserts a value at the start of a list.
     ///
     /// A missing entry is treated as a list of length 0.

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1027,6 +1027,32 @@ impl SimpleCacheClient {
     /// * `truncate_to` - if set, indicates the maximum number of elements the
     ///   list may contain before truncating elements from the front.
     /// * `policy` - TTL policy to use.
+    ///
+    /// # Example
+    /// ```
+    /// # fn main() -> momento_test_util::DoctestResult {
+    /// # momento_test_util::doctest(|cache_name, auth_token| async move {
+    /// use std::time::Duration;
+    /// use momento::{CollectionTtl, SimpleCacheClientBuilder};
+    ///
+    /// let ttl = CollectionTtl::default();
+    /// let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(30))?
+    ///     .build();
+    ///
+    /// assert_eq!(momento.list_concat_back(&cache_name, "list", ["a", "b"], 3, ttl).await?, 2);
+    /// assert_eq!(momento.list_concat_back(&cache_name, "list", ["c", "d"], 3, ttl).await?, 3);
+    ///
+    /// let entry = momento
+    ///     .list_fetch(&cache_name, "list")
+    ///     .await?
+    ///     .expect("list was missing within the cache");
+    /// let values: Vec<_> = entry.value().iter().map(|v| &v[..]).collect();
+    /// let expected: Vec<&[u8]> = vec![b"b", b"c", b"d"];
+    /// assert_eq!(values, expected);
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
     pub async fn list_concat_back<V: IntoBytes>(
         &mut self,
         cache_name: &str,

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1033,6 +1033,43 @@ impl SimpleCacheClient {
             .list_length)
     }
 
+    /// Retrieve and remove the first item from a list.
+    ///
+    /// *NOTE*: This is preview functionality and requires that you contact
+    /// Momento Support to enable these APIs for your cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `cache_name` - name of the cache in which the list is stored.
+    /// * `list_name` - name of the list to pop from.
+    pub async fn list_pop_front(
+        &mut self,
+        cache_name: &str,
+        list_name: impl IntoBytes,
+    ) -> MomentoResult<Option<Vec<u8>>> {
+        use momento_protos::cache_client::list_pop_front_response::List;
+
+        let request = self.prep_request(
+            cache_name,
+            ListPopFrontRequest {
+                list_name: list_name.into_bytes(),
+            },
+        )?;
+
+        Ok(
+            match self
+                .data_client
+                .list_pop_front(request)
+                .await?
+                .into_inner()
+                .list
+            {
+                Some(List::Found(list)) => Some(list.front),
+                _ => None,
+            },
+        )
+    }
+
     /// Fetches a set from a Momento Cache.
     ///
     /// *NOTE*: This is preview functionality and requires that you contact

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1094,6 +1094,29 @@ impl SimpleCacheClient {
     /// * `policy` - the TTL policy to use for this operation.
     /// * `truncate_to` - should the list exceed this length, it will be truncated.
     ///   If `None`, no truncation will be done. Truncation occurs from the front.
+    ///
+    /// # Example
+    /// ```
+    /// # fn main() -> momento_test_util::DoctestResult {
+    /// # momento_test_util::doctest(|cache_name, auth_token| async move {
+    /// use std::time::Duration;
+    /// use momento::{CollectionTtl, SimpleCacheClientBuilder};
+    ///
+    /// let ttl = CollectionTtl::default();
+    /// let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(30))?
+    ///     .build();
+    ///
+    /// momento.list_set(&cache_name, "list", ["a", "b"], ttl).await?;
+    /// momento.list_push_front(&cache_name, "list", "!", None, ttl).await?;
+    ///
+    /// let entry = momento.list_fetch(&cache_name, "list").await?.unwrap();
+    /// let values: Vec<_> = entry.value().iter().map(|v| &v[..]).collect();
+    /// let expected: Vec<&[u8]> = vec![b"!", b"a", b"b"];
+    /// assert_eq!(values, expected);
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
     pub async fn list_push_front(
         &mut self,
         cache_name: &str,

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -991,6 +991,48 @@ impl SimpleCacheClient {
             .list_length)
     }
 
+    /// Inserts a value at the end of a list.
+    ///
+    /// A missing entry is treated as a list of length 0.
+    ///
+    /// *NOTE*: This is preview functionality and requires that you contact
+    /// Momento Support to enable these APIs for your cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `cache_name` - name of the cache to store the list in.
+    /// * `list_name` - the list to insert the value in to.
+    /// * `value` - value to insert at the end of the list.
+    /// * `policy` - the TTL policy to use for this operation.
+    /// * `truncate_to` - should the list exceed this length, it will be truncated.
+    ///   If `None`, no truncation will be done. Truncation occurs from the front.
+    pub async fn list_push_back(
+        &mut self,
+        cache_name: &str,
+        list_name: impl IntoBytes,
+        value: impl IntoBytes,
+        truncate_to: impl Into<Option<u32>>,
+        policy: CollectionTtl,
+    ) -> MomentoResult<u32> {
+        let request = self.prep_request(
+            cache_name,
+            ListPushBackRequest {
+                list_name: list_name.into_bytes(),
+                value: value.into_bytes(),
+                ttl_milliseconds: self.expand_ttl_ms(policy.ttl())?,
+                refresh_ttl: policy.refresh(),
+                truncate_front_to_size: truncate_to.into().unwrap_or(u32::MAX),
+            },
+        )?;
+
+        Ok(self
+            .data_client
+            .list_push_back(request)
+            .await?
+            .into_inner()
+            .list_length)
+    }
+
     /// Fetches a set from a Momento Cache.
     ///
     /// *NOTE*: This is preview functionality and requires that you contact

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1107,6 +1107,36 @@ impl SimpleCacheClient {
         )
     }
 
+    /// Remove all elements in a list matching a particular value.
+    ///
+    /// *NOTE*: This is preview functionality and requires that you contact
+    /// Momento Support to enable these APIs for your cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `cache_name` - name of the cache in which to look for the list.
+    /// * `list_name` - name of the list from which to remove elements.
+    /// * `value` - the value to remove from the list.
+    pub async fn list_remove_value(
+        &mut self,
+        cache_name: &str,
+        list_name: impl IntoBytes,
+        value: impl IntoBytes,
+    ) -> MomentoResult<()> {
+        use list_remove_request::Remove;
+
+        let request = self.prep_request(
+            cache_name,
+            ListRemoveRequest {
+                list_name: list_name.into_bytes(),
+                remove: Some(Remove::AllElementsWithValue(value.into_bytes())),
+            },
+        )?;
+
+        self.data_client.list_remove(request).await?;
+        Ok(())
+    }
+
     /// Fetches a set from a Momento Cache.
     ///
     /// *NOTE*: This is preview functionality and requires that you contact

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -962,6 +962,32 @@ impl SimpleCacheClient {
     /// * `truncate_to` - if set, indicates the maximum number of elements the
     ///   list may contain before truncating elements from the back.
     /// * `policy` - TTL policy to use.
+    ///
+    /// # Example
+    /// ```
+    /// # fn main() -> momento_test_util::DoctestResult {
+    /// # momento_test_util::doctest(|cache_name, auth_token| async move {
+    /// use std::time::Duration;
+    /// use momento::{CollectionTtl, SimpleCacheClientBuilder};
+    ///
+    /// let ttl = CollectionTtl::default();
+    /// let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(30))?
+    ///     .build();
+    ///
+    /// assert_eq!(momento.list_concat_front(&cache_name, "list", ["a", "b"], 3, ttl).await?, 2);
+    /// assert_eq!(momento.list_concat_front(&cache_name, "list", ["c", "d"], 3, ttl).await?, 3);
+    ///
+    /// let entry = momento
+    ///     .list_fetch(&cache_name, "list")
+    ///     .await?
+    ///     .expect("list was missing within the cache");
+    /// let values: Vec<_> = entry.value().iter().map(|v| &v[..]).collect();
+    /// let expected: Vec<&[u8]> = vec![b"c", b"d", b"a"];
+    /// assert_eq!(values, expected);
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
     pub async fn list_concat_front<V: IntoBytes>(
         &mut self,
         cache_name: &str,

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1186,6 +1186,36 @@ impl SimpleCacheClient {
             .list_length)
     }
 
+    /// Set a list within the cache.
+    ///
+    /// *NOTE*: This is preview functionality and requires that you contact
+    /// Momento Support to enable these APIs for your cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `cache_name` - name of the cache to store the list in.
+    /// * `list_name` - list to be set in the cache.
+    /// * `values` - the values that make up the list.
+    /// * `policy` - TTL policy to use for this operation.
+    pub async fn list_set<V: IntoBytes>(
+        &mut self,
+        cache_name: &str,
+        list_name: impl IntoBytes,
+        values: impl IntoIterator<Item = V>,
+        policy: CollectionTtl,
+    ) -> MomentoResult<()> {
+        // We're exposing this as a set so updating an existing entry should count as if
+        // we are creating a new entry.
+        let policy = policy.with_refresh_on_update();
+        let values: Vec<_> = values.into_iter().map(|v| v.into_bytes()).collect();
+        let count = values.len();
+
+        self.list_concat_front(cache_name, list_name, values, count as u32, policy)
+            .await?;
+
+        Ok(())
+    }
+
     /// Fetch the entire list from the cache.
     ///
     /// *NOTE*: This is preview functionality and requires that you contact

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1338,6 +1338,6 @@ pub enum Fields<K> {
     Some(Vec<K>),
 }
 
-fn convert_vec<E: IntoBytes>(vec: Vec<E>) -> Vec<Vec<u8>> {
+fn convert_vec<E: IntoBytes>(vec: impl IntoIterator<Item = E>) -> Vec<Vec<u8>> {
     vec.into_iter().map(|e| e.into_bytes()).collect()
 }

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1220,6 +1220,29 @@ impl SimpleCacheClient {
     /// * `list_name` - list to be set in the cache.
     /// * `values` - the values that make up the list.
     /// * `policy` - TTL policy to use for this operation.
+    ///
+    /// # Example
+    /// ```
+    /// # fn main() -> momento_test_util::DoctestResult {
+    /// # momento_test_util::doctest(|cache_name, auth_token| async move {
+    /// use std::time::Duration;
+    /// use momento::{CollectionTtl, SimpleCacheClientBuilder};
+    ///
+    /// let ttl = CollectionTtl::default();
+    /// let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(30))?
+    ///     .build();
+    ///
+    /// momento.list_set(&cache_name, "list", ["a", "b"], ttl).await?;
+    /// momento.list_set(&cache_name, "list", ["c", "d"], ttl).await?;
+    ///
+    /// let entry = momento.list_fetch(&cache_name, "list").await?.unwrap();
+    /// let values: Vec<_> = entry.value().iter().map(|v| &v[..]).collect();
+    /// let expected: Vec<&[u8]> = vec![b"c", b"d"];
+    /// assert_eq!(values, expected);
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
     pub async fn list_set<V: IntoBytes>(
         &mut self,
         cache_name: &str,

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1070,6 +1070,43 @@ impl SimpleCacheClient {
         )
     }
 
+    /// Retrieve and remove the last item from a list.
+    ///
+    /// *NOTE*: This is preview functionality and requires that you contact
+    /// Momento Support to enable these APIs for your cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `cache_name` - name of the cache in which the list is stored.
+    /// * `list_name` - name of the list to pop from.
+    pub async fn list_pop_back(
+        &mut self,
+        cache_name: &str,
+        list_name: impl IntoBytes,
+    ) -> MomentoResult<Option<Vec<u8>>> {
+        use momento_protos::cache_client::list_pop_back_response::List;
+
+        let request = self.prep_request(
+            cache_name,
+            ListPopBackRequest {
+                list_name: list_name.into_bytes(),
+            },
+        )?;
+
+        Ok(
+            match self
+                .data_client
+                .list_pop_back(request)
+                .await?
+                .into_inner()
+                .list
+            {
+                Some(List::Found(list)) => Some(list.back),
+                _ => None,
+            },
+        )
+    }
+
     /// Fetches a set from a Momento Cache.
     ///
     /// *NOTE*: This is preview functionality and requires that you contact

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1323,6 +1323,28 @@ impl SimpleCacheClient {
     ///
     /// * `cache_name` - name of the cache in which the list is stored.
     /// * `list_name` - name of the list to pop from.
+    ///
+    /// # Example
+    /// ```
+    /// # fn main() -> momento_test_util::DoctestResult {
+    /// # momento_test_util::doctest(|cache_name, auth_token| async move {
+    /// use std::time::Duration;
+    /// use momento::{CollectionTtl, SimpleCacheClientBuilder};
+    ///
+    /// let ttl = CollectionTtl::default();
+    /// let mut momento = SimpleCacheClientBuilder::new(auth_token, Duration::from_secs(30))?
+    ///     .build();
+    ///
+    /// momento.list_set(&cache_name, "list", ["a", "b"], ttl).await?;
+    ///
+    /// assert!(matches!(
+    ///     momento.list_pop_front(&cache_name, "list").await?,
+    ///     Some(v) if v == b"a"
+    /// ));
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
     pub async fn list_pop_front(
         &mut self,
         cache_name: &str,


### PR DESCRIPTION
As in the title. I have included documentation and an example for each one. The one operation I implemented which was not in the protocol was `list_set` as a wrapper around `list_concat_front` since it made all the doctests much easier to understand.