### PR TITLE
feat: add support for flush cache API

### DIFF
--- a/src/response/flush_cache_response.rs
+++ b/src/response/flush_cache_response.rs
@@ -1,0 +1,3 @@
+/// The result of a cache flush operation.
+#[derive(Debug)]
+pub struct MomentoFlushCacheResponse {}

--- a/src/response/list_cache_response.rs
+++ b/src/response/list_cache_response.rs
@@ -7,7 +7,7 @@ pub struct MomentoCache {
 
 /// The result of a cache list operation.
 #[derive(Debug)]
-pub struct MomentoListCacheResult {
+pub struct MomentoListCacheResponse {
     /// Vector of cache information defined in MomentoCache.
     pub caches: Vec<MomentoCache>,
     /// Next Page Token returned by Simple Cache Service along with the list of caches.

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -5,6 +5,7 @@ mod cache_get_response;
 mod cache_set_fetch_response;
 mod create_signing_key_response;
 mod error;
+mod flush_cache_response;
 mod list_cache_response;
 mod list_signing_keys_response;
 
@@ -15,6 +16,7 @@ pub use self::cache_get_response::*;
 pub use self::cache_set_fetch_response::*;
 pub use self::create_signing_key_response::*;
 pub use self::error::*;
+pub use self::flush_cache_response::*;
 pub use self::list_cache_response::*;
 pub use self::list_signing_keys_response::*;
 

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1,3 +1,4 @@
+use momento_protos::control_client::FlushCacheRequest;
 use momento_protos::{
     cache_client::scs_client::*,
     cache_client::*,
@@ -24,9 +25,10 @@ use crate::response::{
     ListCacheEntry, MomentoCache, MomentoCreateSigningKeyResponse, MomentoDeleteResponse,
     MomentoDictionaryDeleteResponse, MomentoDictionaryFetchResponse, MomentoDictionaryFetchStatus,
     MomentoDictionaryGetResponse, MomentoDictionaryGetStatus, MomentoDictionaryIncrementResponse,
-    MomentoDictionarySetResponse, MomentoError, MomentoGetResponse, MomentoGetStatus,
-    MomentoListCacheResult, MomentoListFetchResponse, MomentoListSigningKeyResult,
-    MomentoSetDifferenceResponse, MomentoSetFetchResponse, MomentoSetResponse, MomentoSigningKey,
+    MomentoDictionarySetResponse, MomentoError, MomentoFlushCacheResponse, MomentoGetResponse,
+    MomentoGetStatus, MomentoListCacheResponse, MomentoListFetchResponse,
+    MomentoListSigningKeyResult, MomentoSetDifferenceResponse, MomentoSetFetchResponse,
+    MomentoSetResponse, MomentoSigningKey,
 };
 use crate::utils;
 
@@ -346,7 +348,7 @@ impl SimpleCacheClient {
     pub async fn list_caches(
         &mut self,
         next_token: Option<String>,
-    ) -> MomentoResult<MomentoListCacheResult> {
+    ) -> MomentoResult<MomentoListCacheResponse> {
         let request = Request::new(ListCachesRequest {
             next_token: next_token.unwrap_or_default(),
         });
@@ -358,13 +360,25 @@ impl SimpleCacheClient {
                 cache_name: cache.cache_name.to_string(),
             })
             .collect();
-        let response = MomentoListCacheResult {
+        let response = MomentoListCacheResponse {
             caches,
             next_token: match res.next_token.is_empty() {
                 true => None,
                 false => Some(res.next_token),
             },
         };
+        Ok(response)
+    }
+
+    pub async fn flush_cache(
+        &mut self,
+        cache_name: &str,
+    ) -> MomentoResult<MomentoFlushCacheResponse> {
+        let request = Request::new(FlushCacheRequest {
+            cache_name: cache_name.to_string(),
+        });
+        self.control_client.flush_cache(request).await?;
+        let response = MomentoFlushCacheResponse {};
         Ok(response)
     }
 


### PR DESCRIPTION
I have some thoughts on tweaking some of the APIs in this repo a bit before 1.0 now that I have gotten to look at them a bit, so this might not be the final API for flush cache; but this unblocks us for getting it into the CLI, which is something customers are wanting / needing, so I would like to move forward with this API for now.