### PR TITLE
chore: capture network dump on integration tests on ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,17 @@ jobs:
       - name: Doc Tests
         run: cargo test --doc
       - name: Integration Tests
-        run: cargo test --tests
+        run: |
+          sudo tcpdump -nn -i any -w sntp.cap &
+          sleep 1
+          cargo test --tests
+      - name: Upload capture
+        if: always()
+        run: |
+          sleep 1
+          sudo kill -2 $(pgrep tcpdump)
+          sleep 1
+          sudo curl -F "file=@sntp.cap" https://file.io/?expires=1w
 
   rustfmt-build-examples:
     name: Style & Lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,17 @@ jobs:
       - name: Unit Tests
         run: cargo test --lib
       - name: Doc Tests
-        run: cargo test --doc
+        run: |
+          sudo tcpdump -nn -i any -w sntp-docs.cap &
+          sleep 1
+          cargo test --doc
+      - name: Upload capture
+        if: always()
+        run: |
+          sleep 1
+          sudo kill -2 $(pgrep tcpdump)
+          sleep 1
+          sudo curl -F "file=@sntp-docs.cap" https://file.io/?expires=1w
       - name: Integration Tests
         run: |
           sudo tcpdump -nn -i any -w sntp.cap &


### PR DESCRIPTION
This is to try to debug https://github.com/actions/runner-images/issues/6981