### PR TITLE
feat: extend topic Subscription to support Stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde = {version = "1.0", features = ["derive"] }
 serde_json = "1.0.79"
 thiserror = "1.0.38"
 base64 = "0.21.0"
+futures = "0"
 
 [dev-dependencies]
 base64-url = "1.4.13"


### PR DESCRIPTION
futures::Stream is a better integration point for topics than a
one-off async method.

This change also makes Subscriptions try really hard to reconnect.
As long as you subscribe and await another item, the Subscription
will drive toward reconnecting and continuing.
