### PR TITLE
feat: add sorted_set_fetch_by_index

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,5 +19,7 @@ pub type MomentoResult<T> = Result<T, MomentoError>;
 
 pub mod sorted_set {
     pub use momento_protos::cache_client::sorted_set_fetch_request::{Order, Range};
+    pub use momento_protos::cache_client::sorted_set_fetch_response::found::Elements;
+    pub use momento_protos::cache_client::sorted_set_fetch_response::SortedSet;
     pub use momento_protos::cache_client::SortedSetElement;
 }

--- a/src/response/cache_sorted_set_fetch_response.rs
+++ b/src/response/cache_sorted_set_fetch_response.rs
@@ -1,7 +1,7 @@
-use momento_protos::cache_client::SortedSetElement;
+use momento_protos::cache_client::sorted_set_fetch_response::SortedSet;
 
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct MomentoSortedSetFetchResponse {
-    pub value: Option<Vec<SortedSetElement>>,
+    pub value: Option<SortedSet>,
 }

--- a/src/response/cache_sorted_set_fetch_response.rs
+++ b/src/response/cache_sorted_set_fetch_response.rs
@@ -1,7 +1,147 @@
+use crate::sorted_set::Elements;
+use crate::MomentoError;
+use core::convert::TryFrom;
 use momento_protos::cache_client::sorted_set_fetch_response::SortedSet;
 
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct MomentoSortedSetFetchResponse {
     pub value: Option<SortedSet>,
+}
+
+pub enum SortedSetFetch {
+    Found { elements: Elements },
+    Missing,
+}
+
+impl TryFrom<SortedSetFetch> for Vec<(Vec<u8>, f64)> {
+    type Error = MomentoError;
+
+    fn try_from(value: SortedSetFetch) -> Result<Self, Self::Error> {
+        match value {
+            SortedSetFetch::Found { elements } => match elements {
+                Elements::ValuesWithScores(mut values) => {
+                    let result: Vec<(Vec<u8>, f64)> = values
+                        .elements
+                        .drain(..)
+                        .map(|e| (e.value, e.score))
+                        .collect();
+                    Ok(result)
+                }
+                Elements::Values(_) => Err(MomentoError::TypeError {
+                    description: std::borrow::Cow::Borrowed(
+                        "response did not contain element scores",
+                    ),
+                    source: Box::new(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "element did not contain a score",
+                    )),
+                }),
+            },
+            SortedSetFetch::Missing => Err(MomentoError::Miss {
+                description: std::borrow::Cow::Borrowed("sorted set was not found"),
+            }),
+        }
+    }
+}
+
+impl TryFrom<SortedSetFetch> for Vec<Vec<u8>> {
+    type Error = MomentoError;
+
+    fn try_from(value: SortedSetFetch) -> Result<Self, Self::Error> {
+        match value {
+            SortedSetFetch::Found { elements } => match elements {
+                Elements::ValuesWithScores(mut values) => {
+                    let result: Vec<Vec<u8>> = values.elements.drain(..).map(|e| e.value).collect();
+                    Ok(result)
+                }
+                Elements::Values(values) => Ok(values.values),
+            },
+            SortedSetFetch::Missing => Err(MomentoError::Miss {
+                description: std::borrow::Cow::Borrowed("sorted set was not found"),
+            }),
+        }
+    }
+}
+
+impl TryFrom<SortedSetFetch> for Vec<(String, f64)> {
+    type Error = MomentoError;
+
+    fn try_from(value: SortedSetFetch) -> Result<Self, Self::Error> {
+        match value {
+            SortedSetFetch::Found { elements } => match elements {
+                Elements::ValuesWithScores(mut values) => {
+                    let mut result = Vec::with_capacity(values.elements.len());
+                    for element in values.elements.drain(..) {
+                        let value = String::from_utf8(element.value).map_err(|e| {
+                            return Err::<Self, Self::Error>(MomentoError::TypeError {
+                                description: std::borrow::Cow::Borrowed(
+                                    "element value was not a valid utf-8 string",
+                                ),
+                                source: Box::new(e),
+                            });
+                        });
+                        result.push((value.unwrap(), element.score));
+                    }
+                    Ok(result)
+                }
+                Elements::Values(_) => Err(MomentoError::TypeError {
+                    description: std::borrow::Cow::Borrowed(
+                        "response did not contain element scores",
+                    ),
+                    source: Box::new(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "element did not contain a score",
+                    )),
+                }),
+            },
+            SortedSetFetch::Missing => Err(MomentoError::Miss {
+                description: std::borrow::Cow::Borrowed("sorted set was not found"),
+            }),
+        }
+    }
+}
+
+impl TryFrom<SortedSetFetch> for Vec<String> {
+    type Error = MomentoError;
+
+    fn try_from(value: SortedSetFetch) -> Result<Self, Self::Error> {
+        match value {
+            SortedSetFetch::Found { elements } => match elements {
+                Elements::ValuesWithScores(mut values) => {
+                    let mut result = Vec::with_capacity(values.elements.len());
+                    for element in values.elements.drain(..) {
+                        let value = String::from_utf8(element.value).map_err(|e| {
+                            return Err::<Self, Self::Error>(MomentoError::TypeError {
+                                description: std::borrow::Cow::Borrowed(
+                                    "element value was not a valid utf-8 string",
+                                ),
+                                source: Box::new(e),
+                            });
+                        });
+                        result.push(value.unwrap());
+                    }
+                    Ok(result)
+                }
+                Elements::Values(mut values) => {
+                    let mut result = Vec::with_capacity(values.values.len());
+                    for value in values.values.drain(..) {
+                        let value = String::from_utf8(value).map_err(|e| {
+                            return Err::<Self, Self::Error>(MomentoError::TypeError {
+                                description: std::borrow::Cow::Borrowed(
+                                    "element value was not a valid utf-8 string",
+                                ),
+                                source: Box::new(e),
+                            });
+                        });
+                        result.push(value.unwrap());
+                    }
+                    Ok(result)
+                }
+            },
+            SortedSetFetch::Missing => Err(MomentoError::Miss {
+                description: std::borrow::Cow::Borrowed("sorted set was not found"),
+            }),
+        }
+    }
 }

--- a/src/response/cache_sorted_set_fetch_response.rs
+++ b/src/response/cache_sorted_set_fetch_response.rs
@@ -1,17 +1,16 @@
-use crate::sorted_set::Elements;
+use crate::sorted_set::SortedSetElement;
 use crate::MomentoError;
 use core::convert::TryFrom;
-use momento_protos::cache_client::sorted_set_fetch_response::SortedSet;
 
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct MomentoSortedSetFetchResponse {
-    pub value: Option<SortedSet>,
+    pub value: Option<Vec<SortedSetElement>>,
 }
 
 pub enum SortedSetFetch {
-    Found { elements: Elements },
-    Missing,
+    Hit { elements: Vec<SortedSetElement> },
+    Miss,
 }
 
 impl TryFrom<SortedSetFetch> for Vec<(Vec<u8>, f64)> {
@@ -19,45 +18,12 @@ impl TryFrom<SortedSetFetch> for Vec<(Vec<u8>, f64)> {
 
     fn try_from(value: SortedSetFetch) -> Result<Self, Self::Error> {
         match value {
-            SortedSetFetch::Found { elements } => match elements {
-                Elements::ValuesWithScores(mut values) => {
-                    let result: Vec<(Vec<u8>, f64)> = values
-                        .elements
-                        .drain(..)
-                        .map(|e| (e.value, e.score))
-                        .collect();
-                    Ok(result)
-                }
-                Elements::Values(_) => Err(MomentoError::TypeError {
-                    description: std::borrow::Cow::Borrowed(
-                        "response did not contain element scores",
-                    ),
-                    source: Box::new(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "element did not contain a score",
-                    )),
-                }),
-            },
-            SortedSetFetch::Missing => Err(MomentoError::Miss {
-                description: std::borrow::Cow::Borrowed("sorted set was not found"),
-            }),
-        }
-    }
-}
-
-impl TryFrom<SortedSetFetch> for Vec<Vec<u8>> {
-    type Error = MomentoError;
-
-    fn try_from(value: SortedSetFetch) -> Result<Self, Self::Error> {
-        match value {
-            SortedSetFetch::Found { elements } => match elements {
-                Elements::ValuesWithScores(mut values) => {
-                    let result: Vec<Vec<u8>> = values.elements.drain(..).map(|e| e.value).collect();
-                    Ok(result)
-                }
-                Elements::Values(values) => Ok(values.values),
-            },
-            SortedSetFetch::Missing => Err(MomentoError::Miss {
+            SortedSetFetch::Hit { mut elements } => {
+                let result: Vec<(Vec<u8>, f64)> =
+                    elements.drain(..).map(|e| (e.value, e.score)).collect();
+                Ok(result)
+            }
+            SortedSetFetch::Miss => Err(MomentoError::Miss {
                 description: std::borrow::Cow::Borrowed("sorted set was not found"),
             }),
         }
@@ -69,89 +35,26 @@ impl TryFrom<SortedSetFetch> for Vec<(String, f64)> {
 
     fn try_from(value: SortedSetFetch) -> Result<Self, Self::Error> {
         match value {
-            SortedSetFetch::Found { elements } => match elements {
-                Elements::ValuesWithScores(mut values) => {
-                    let mut result = Vec::with_capacity(values.elements.len());
-                    for element in values.elements.drain(..) {
-                        match String::from_utf8(element.value) {
-                            Ok(value) => {
-                                result.push((value, element.score));
-                            }
-                            Err(e) => {
-                                return Err::<Self, Self::Error>(MomentoError::TypeError {
-                                    description: std::borrow::Cow::Borrowed(
-                                        "element value was not a valid utf-8 string",
-                                    ),
-                                    source: Box::new(e),
-                                })
-                            }
+            SortedSetFetch::Hit { mut elements } => {
+                let mut result = Vec::with_capacity(elements.len());
+                for element in elements.drain(..) {
+                    match String::from_utf8(element.value) {
+                        Ok(value) => {
+                            result.push((value, element.score));
+                        }
+                        Err(e) => {
+                            return Err::<Self, Self::Error>(MomentoError::TypeError {
+                                description: std::borrow::Cow::Borrowed(
+                                    "element value was not a valid utf-8 string",
+                                ),
+                                source: Box::new(e),
+                            })
                         }
                     }
-                    Ok(result)
                 }
-                Elements::Values(_) => Err(MomentoError::TypeError {
-                    description: std::borrow::Cow::Borrowed(
-                        "response did not contain element scores",
-                    ),
-                    source: Box::new(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "element did not contain a score",
-                    )),
-                }),
-            },
-            SortedSetFetch::Missing => Err(MomentoError::Miss {
-                description: std::borrow::Cow::Borrowed("sorted set was not found"),
-            }),
-        }
-    }
-}
-
-impl TryFrom<SortedSetFetch> for Vec<String> {
-    type Error = MomentoError;
-
-    fn try_from(value: SortedSetFetch) -> Result<Self, Self::Error> {
-        match value {
-            SortedSetFetch::Found { elements } => match elements {
-                Elements::ValuesWithScores(mut values) => {
-                    let mut result = Vec::with_capacity(values.elements.len());
-                    for element in values.elements.drain(..) {
-                        match String::from_utf8(element.value) {
-                            Ok(value) => {
-                                result.push(value);
-                            }
-                            Err(e) => {
-                                return Err::<Self, Self::Error>(MomentoError::TypeError {
-                                    description: std::borrow::Cow::Borrowed(
-                                        "element value was not a valid utf-8 string",
-                                    ),
-                                    source: Box::new(e),
-                                })
-                            }
-                        }
-                    }
-                    Ok(result)
-                }
-                Elements::Values(mut values) => {
-                    let mut result = Vec::with_capacity(values.values.len());
-                    for value in values.values.drain(..) {
-                        match String::from_utf8(value) {
-                            Ok(value) => {
-                                result.push(value);
-                            }
-                            Err(e) => {
-                                return Err::<Self, Self::Error>(MomentoError::TypeError {
-                                    description: std::borrow::Cow::Borrowed(
-                                        "element value was not a valid utf-8 string",
-                                    ),
-                                    source: Box::new(e),
-                                })
-                            }
-                        }
-                    }
-                    Ok(result)
-                }
-            },
-            SortedSetFetch::Missing => Err(MomentoError::Miss {
+                Ok(result)
+            }
+            SortedSetFetch::Miss => Err(MomentoError::Miss {
                 description: std::borrow::Cow::Borrowed("sorted set was not found"),
             }),
         }

--- a/src/response/cache_sorted_set_fetch_response.rs
+++ b/src/response/cache_sorted_set_fetch_response.rs
@@ -73,15 +73,19 @@ impl TryFrom<SortedSetFetch> for Vec<(String, f64)> {
                 Elements::ValuesWithScores(mut values) => {
                     let mut result = Vec::with_capacity(values.elements.len());
                     for element in values.elements.drain(..) {
-                        let value = String::from_utf8(element.value).map_err(|e| {
-                            return Err::<Self, Self::Error>(MomentoError::TypeError {
-                                description: std::borrow::Cow::Borrowed(
-                                    "element value was not a valid utf-8 string",
-                                ),
-                                source: Box::new(e),
-                            });
-                        });
-                        result.push((value.unwrap(), element.score));
+                        match String::from_utf8(element.value) {
+                            Ok(value) => {
+                                result.push((value, element.score));
+                            }
+                            Err(e) => {
+                                return Err::<Self, Self::Error>(MomentoError::TypeError {
+                                    description: std::borrow::Cow::Borrowed(
+                                        "element value was not a valid utf-8 string",
+                                    ),
+                                    source: Box::new(e),
+                                })
+                            }
+                        }
                     }
                     Ok(result)
                 }
@@ -111,30 +115,38 @@ impl TryFrom<SortedSetFetch> for Vec<String> {
                 Elements::ValuesWithScores(mut values) => {
                     let mut result = Vec::with_capacity(values.elements.len());
                     for element in values.elements.drain(..) {
-                        let value = String::from_utf8(element.value).map_err(|e| {
-                            return Err::<Self, Self::Error>(MomentoError::TypeError {
-                                description: std::borrow::Cow::Borrowed(
-                                    "element value was not a valid utf-8 string",
-                                ),
-                                source: Box::new(e),
-                            });
-                        });
-                        result.push(value.unwrap());
+                        match String::from_utf8(element.value) {
+                            Ok(value) => {
+                                result.push(value);
+                            }
+                            Err(e) => {
+                                return Err::<Self, Self::Error>(MomentoError::TypeError {
+                                    description: std::borrow::Cow::Borrowed(
+                                        "element value was not a valid utf-8 string",
+                                    ),
+                                    source: Box::new(e),
+                                })
+                            }
+                        }
                     }
                     Ok(result)
                 }
                 Elements::Values(mut values) => {
                     let mut result = Vec::with_capacity(values.values.len());
                     for value in values.values.drain(..) {
-                        let value = String::from_utf8(value).map_err(|e| {
-                            return Err::<Self, Self::Error>(MomentoError::TypeError {
-                                description: std::borrow::Cow::Borrowed(
-                                    "element value was not a valid utf-8 string",
-                                ),
-                                source: Box::new(e),
-                            });
-                        });
-                        result.push(value.unwrap());
+                        match String::from_utf8(value) {
+                            Ok(value) => {
+                                result.push(value);
+                            }
+                            Err(e) => {
+                                return Err::<Self, Self::Error>(MomentoError::TypeError {
+                                    description: std::borrow::Cow::Borrowed(
+                                        "element value was not a valid utf-8 string",
+                                    ),
+                                    source: Box::new(e),
+                                })
+                            }
+                        }
                     }
                     Ok(result)
                 }

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1988,6 +1988,10 @@ impl SimpleCacheClient {
             .await?
             .into_inner();
 
+        // this flattens the response returning a None for both a missing sorted
+        // set and for a request that returns Found with elements being None and
+        // converting the SortedSet enum into the interior collection of
+        // elements.
         match response.sorted_set {
             Some(crate::sorted_set::SortedSet::Found(elements)) => match elements.elements {
                 Some(elements) => Ok(Some(elements)),

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -2029,9 +2029,16 @@ impl SimpleCacheClient {
                         elements: elements.elements,
                     }),
                     Elements::Values(_) => {
-                        // since with_scores is hardcoded to true, we should
-                        // never reach this.
-                        unreachable!()
+                        return Err(MomentoError::ClientSdkError {
+                            description: std::borrow::Cow::Borrowed(
+                                "sorted_set_fetch_by_index response included elements without values"
+                            ),
+                            source: crate::response::ErrorSource::Unknown(
+                                std::io::Error::new(
+                                    std::io::ErrorKind::InvalidData,
+                                    "unexpected response"
+                            ).into()),
+                        });
                     }
                 },
                 None => Ok(SortedSetFetch::Hit {


### PR DESCRIPTION
Adds a function to the simple cache client to fetch elements of a sorted set selecting them by index (rank).