### PR TITLE
chore: update protos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,26 +18,26 @@ members = [
 exclude = [ "example" ]
 
 [dependencies]
-momento-protos = { version = "0.49.1" }
-log = "0.4.17"
+momento-protos = { version = "0.84.1" }
+log = "0.4"
 hyper = { version = "0.14" }
 h2 = { version = "0.3" }
-tonic = { version = "0.8", features = ["tls", "tls-roots", "tls-webpki-roots"] }
-jsonwebtoken = "8.0.1"
+tonic = { version = "0.10", features = ["tls", "tls-roots", "tls-webpki-roots"] }
+jsonwebtoken = "8.3"
 rand = "0.8.5"
 serde = {version = "1.0", features = ["derive"] }
-serde_json = "1.0.79"
-thiserror = "1.0.38"
-base64 = "0.21.0"
+serde_json = "1.0"
+thiserror = "1.0"
+base64 = "0.21"
 futures = "0"
 zstd = "0.12.4"
 
 [dev-dependencies]
-base64-url = "1.4.13"
-env_logger = "0.9.0"
-tokio = { version = "1.26.0", features = ["full"] }
-tokio-test = "0.4.2"
-uuid = { version = "1.2.2", features = ["v4"] }
-futures = "0.3.25"
-anyhow = "1.0.68"
+base64-url = "2"
+env_logger = "0"
+tokio = { version = "1", features = ["full"] }
+tokio-test = "0"
+uuid = { version = "1", features = ["v4"] }
+futures = "0"
+anyhow = "1"
 momento-test-util = { path = "test-util" }

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -1,12 +1,10 @@
 use core::num::NonZeroU32;
-use momento_protos::control_client::generate_api_token_request::Expiry;
-use momento_protos::control_client::{FlushCacheRequest, GenerateApiTokenRequest};
 use momento_protos::{
     cache_client::scs_client::*,
     cache_client::*,
     control_client::{
         scs_control_client::ScsControlClient, CreateCacheRequest, CreateSigningKeyRequest,
-        DeleteCacheRequest, ListCachesRequest, ListSigningKeysRequest, RevokeSigningKeyRequest,
+        DeleteCacheRequest, ListCachesRequest, ListSigningKeysRequest, RevokeSigningKeyRequest, FlushCacheRequest,
     },
 };
 use serde_json::Value;
@@ -19,18 +17,17 @@ use tonic::{codegen::InterceptedService, transport::Channel, Request};
 
 use crate::compression_utils::{compress_json, decompress_json};
 use crate::credential_provider::CredentialProvider;
-use crate::requests::generate_api_token_request::TokenExpiry;
 use crate::response::{
-    ApiToken, DictionaryFetch, DictionaryGet, DictionaryPairs, Get, GetValue, ListCacheEntry,
+    DictionaryFetch, DictionaryGet, DictionaryPairs, Get, GetValue, ListCacheEntry,
     MomentoCache, MomentoCreateSigningKeyResponse, MomentoDeleteResponse,
     MomentoDictionaryDeleteResponse, MomentoDictionaryIncrementResponse,
     MomentoDictionarySetResponse, MomentoError, MomentoFlushCacheResponse,
-    MomentoGenerateApiTokenResponse, MomentoListCacheResponse, MomentoListFetchResponse,
+    MomentoListCacheResponse, MomentoListFetchResponse,
     MomentoListSigningKeyResult, MomentoSetDifferenceResponse, MomentoSetFetchResponse,
     MomentoSetResponse, MomentoSigningKey, MomentoSortedSetFetchResponse, SortedSetFetch,
 };
 use crate::sorted_set;
-use crate::utils::{self, base64_encode};
+use crate::utils;
 use crate::{grpc::header_interceptor::HeaderInterceptor, utils::connect_channel_lazily};
 use crate::{utils::user_agent, MomentoResult};
 
@@ -2707,43 +2704,14 @@ impl SimpleCacheClient {
 
     /// Generates an api token for Momento
     ///
-    /// # Arguments
+    /// todo: Rework to match the latest proto
     ///
     /// * `token_expiry` - when should the token expire, can be set to Never to never expire
-    pub async fn generate_api_token(
-        &mut self,
-        token_expiry: TokenExpiry,
-    ) -> MomentoResult<MomentoGenerateApiTokenResponse> {
-        let expiry = match token_expiry {
-            TokenExpiry::Never => {
-                Expiry::Never(momento_protos::control_client::generate_api_token_request::Never {})
-            }
-            TokenExpiry::Expires { valid_for_seconds } => Expiry::Expires(
-                momento_protos::control_client::generate_api_token_request::Expires {
-                    valid_for_seconds,
-                },
-            ),
-        };
-        let request = GenerateApiTokenRequest {
-            expiry: Some(expiry),
-        };
-        let resp = self
-            .control_client
-            .generate_api_token(request)
-            .await?
-            .into_inner();
-
-        let api_key_with_endpoint = ApiToken {
-            api_key: resp.api_key,
-            endpoint: resp.endpoint,
-        };
-
-        Ok(MomentoGenerateApiTokenResponse {
-            api_token: base64_encode(api_key_with_endpoint),
-            refresh_token: resp.refresh_token,
-            valid_until: UNIX_EPOCH + Duration::from_secs(resp.valid_until),
-        })
-    }
+    // pub async fn generate_api_token(
+    //     &mut self,
+    //     token_expiry: TokenExpiry,
+    // ) -> MomentoResult<MomentoGenerateApiTokenResponse> {
+    // }
 
     fn expand_ttl_ms(&self, ttl: Option<Duration>) -> MomentoResult<u64> {
         let ttl = ttl.unwrap_or(self.item_default_ttl);

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -4,7 +4,8 @@ use momento_protos::{
     cache_client::*,
     control_client::{
         scs_control_client::ScsControlClient, CreateCacheRequest, CreateSigningKeyRequest,
-        DeleteCacheRequest, ListCachesRequest, ListSigningKeysRequest, RevokeSigningKeyRequest, FlushCacheRequest,
+        DeleteCacheRequest, FlushCacheRequest, ListCachesRequest, ListSigningKeysRequest,
+        RevokeSigningKeyRequest,
     },
 };
 use serde_json::Value;
@@ -18,11 +19,10 @@ use tonic::{codegen::InterceptedService, transport::Channel, Request};
 use crate::compression_utils::{compress_json, decompress_json};
 use crate::credential_provider::CredentialProvider;
 use crate::response::{
-    DictionaryFetch, DictionaryGet, DictionaryPairs, Get, GetValue, ListCacheEntry,
-    MomentoCache, MomentoCreateSigningKeyResponse, MomentoDeleteResponse,
-    MomentoDictionaryDeleteResponse, MomentoDictionaryIncrementResponse,
-    MomentoDictionarySetResponse, MomentoError, MomentoFlushCacheResponse,
-    MomentoListCacheResponse, MomentoListFetchResponse,
+    DictionaryFetch, DictionaryGet, DictionaryPairs, Get, GetValue, ListCacheEntry, MomentoCache,
+    MomentoCreateSigningKeyResponse, MomentoDeleteResponse, MomentoDictionaryDeleteResponse,
+    MomentoDictionaryIncrementResponse, MomentoDictionarySetResponse, MomentoError,
+    MomentoFlushCacheResponse, MomentoListCacheResponse, MomentoListFetchResponse,
     MomentoListSigningKeyResult, MomentoSetDifferenceResponse, MomentoSetFetchResponse,
     MomentoSetResponse, MomentoSigningKey, MomentoSortedSetFetchResponse, SortedSetFetch,
 };

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,3 @@
-use base64::{engine::general_purpose, Engine as _};
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tonic::{
     codegen::http::uri::InvalidUri,
@@ -84,12 +82,4 @@ pub(crate) fn connect_channel_lazily(uri_string: &str) -> Result<Channel, Channe
 
 pub fn user_agent(user_agent_name: &str) -> String {
     format!("rust-{user_agent_name}:{VERSION}")
-}
-
-pub fn base64_encode<T>(o: T) -> String
-where
-    for<'a> T: Serialize + Deserialize<'a>,
-{
-    let s = serde_json::to_string(&o).expect("failed to encode json to string");
-    general_purpose::STANDARD.encode(s.as_str())
 }


### PR DESCRIPTION
Also removes generate_api_token temporarily, as it is currently not
supported in the way this sdk has it.
