### PR TITLE
chore: remove next token from list_caches and list_signing_keys

### DIFF
--- a/src/response/list_cache_response.rs
+++ b/src/response/list_cache_response.rs
@@ -10,6 +10,4 @@ pub struct MomentoCache {
 pub struct MomentoListCacheResponse {
     /// Vector of cache information defined in MomentoCache.
     pub caches: Vec<MomentoCache>,
-    /// Next Page Token returned by Simple Cache Service along with the list of caches.
-    pub next_token: Option<String>,
 }

--- a/src/response/list_signing_keys_response.rs
+++ b/src/response/list_signing_keys_response.rs
@@ -14,6 +14,4 @@ pub struct MomentoSigningKey {
 pub struct MomentoListSigningKeyResult {
     /// Vector of signing key information defined in MomentoSigningKey.
     pub signing_keys: Vec<MomentoSigningKey>,
-    /// Next Page Token returned by Simple Cache Service along with the list of signing keys.
-    pub next_token: String,
 }

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -327,7 +327,7 @@ impl SimpleCacheClient {
     ///
     /// momento.create_cache(&cache_name).await?;
     /// # let result = std::panic::AssertUnwindSafe(async {
-    /// let resp = momento.list_caches(None).await?;
+    /// let resp = momento.list_caches().await?;
     ///
     /// assert!(resp.caches.iter().any(|cache| cache.cache_name == cache_name));
     /// # Ok(())
@@ -339,10 +339,9 @@ impl SimpleCacheClient {
     /// ```
     pub async fn list_caches(
         &mut self,
-        next_token: Option<String>,
     ) -> MomentoResult<MomentoListCacheResponse> {
         let request = Request::new(ListCachesRequest {
-            next_token: next_token.unwrap_or_default(),
+            next_token: String::new(),
         });
         let res = self.control_client.list_caches(request).await?.into_inner();
         let caches = res
@@ -354,10 +353,6 @@ impl SimpleCacheClient {
             .collect();
         let response = MomentoListCacheResponse {
             caches,
-            next_token: match res.next_token.is_empty() {
-                true => None,
-                false => Some(res.next_token),
-            },
         };
         Ok(response)
     }
@@ -441,7 +436,7 @@ impl SimpleCacheClient {
     ///
     /// let key = momento.create_signing_key(ttl_minutes).await?;
     /// # let result = std::panic::AssertUnwindSafe(async {
-    /// let list = momento.list_signing_keys(None).await?.signing_keys;
+    /// let list = momento.list_signing_keys().await?.signing_keys;
     /// assert!(list.iter().any(|sk| sk.key_id == key.key_id));
     /// # Ok(())
     /// # }).catch_unwind().await;
@@ -453,10 +448,9 @@ impl SimpleCacheClient {
     /// ```
     pub async fn list_signing_keys(
         &mut self,
-        next_token: Option<&str>,
     ) -> MomentoResult<MomentoListSigningKeyResult> {
         let request = Request::new(ListSigningKeysRequest {
-            next_token: next_token.unwrap_or_default().to_string(),
+            next_token: String::new(),
         });
         let res = self
             .control_client
@@ -474,7 +468,6 @@ impl SimpleCacheClient {
             .collect();
         let response = MomentoListSigningKeyResult {
             signing_keys,
-            next_token: res.next_token,
         };
         Ok(response)
     }

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -337,9 +337,7 @@ impl SimpleCacheClient {
     /// # })
     /// # }
     /// ```
-    pub async fn list_caches(
-        &mut self,
-    ) -> MomentoResult<MomentoListCacheResponse> {
+    pub async fn list_caches(&mut self) -> MomentoResult<MomentoListCacheResponse> {
         let request = Request::new(ListCachesRequest {
             next_token: String::new(),
         });
@@ -351,9 +349,7 @@ impl SimpleCacheClient {
                 cache_name: cache.cache_name.to_string(),
             })
             .collect();
-        let response = MomentoListCacheResponse {
-            caches,
-        };
+        let response = MomentoListCacheResponse { caches };
         Ok(response)
     }
 
@@ -446,9 +442,7 @@ impl SimpleCacheClient {
     /// # })
     /// # }
     /// ```
-    pub async fn list_signing_keys(
-        &mut self,
-    ) -> MomentoResult<MomentoListSigningKeyResult> {
+    pub async fn list_signing_keys(&mut self) -> MomentoResult<MomentoListSigningKeyResult> {
         let request = Request::new(ListSigningKeysRequest {
             next_token: String::new(),
         });
@@ -466,9 +460,7 @@ impl SimpleCacheClient {
                 endpoint: self.data_endpoint.clone(),
             })
             .collect();
-        let response = MomentoListSigningKeyResult {
-            signing_keys,
-        };
+        let response = MomentoListSigningKeyResult { signing_keys };
         Ok(response)
     }
 
@@ -1660,7 +1652,7 @@ impl SimpleCacheClient {
             };
             let count = match range.end_bound() {
                 Bound::Unbounded if start == 0 => {
-                    return self.delete(cache_name, list_name).await.map(|_| ())
+                    return self.delete(cache_name, list_name).await.map(|_| ());
                 }
                 Bound::Unbounded => u32::MAX - start,
                 Bound::Included(&end) if end < start => return Ok(()),
@@ -1764,7 +1756,7 @@ impl SimpleCacheClient {
     ///         for entry in &set {
     ///             println!("{:?}", entry);
     ///         }
-    ///     },
+    ///     }
     ///     None => println!("set not found!"),
     /// }
     /// # Ok(())
@@ -2130,8 +2122,8 @@ impl SimpleCacheClient {
                             source: crate::response::ErrorSource::Unknown(
                                 std::io::Error::new(
                                     std::io::ErrorKind::InvalidData,
-                                    "unexpected response"
-                            ).into()),
+                                    "unexpected response",
+                                ).into()),
                         });
                     }
                 },
@@ -2315,8 +2307,8 @@ impl SimpleCacheClient {
                             source: crate::response::ErrorSource::Unknown(
                                 std::io::Error::new(
                                     std::io::ErrorKind::InvalidData,
-                                    "unexpected response"
-                            ).into()),
+                                    "unexpected response",
+                                ).into()),
                         });
                     }
                 },
@@ -2359,7 +2351,7 @@ impl SimpleCacheClient {
     /// match momento.sorted_set_get_rank(&cache_name, "test sorted set", "element a").await? {
     ///     Some(rank) => {
     ///         println!("element has rank: {rank}");
-    ///     },
+    ///     }
     ///     None => println!("sorted set or element not found!"),
     /// }
     /// # Ok(())

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -174,7 +174,7 @@ mod tests {
 
         let list_cache_result = mm.list_caches().await.expect("failed to list caches");
 
-        assert!(list_cache_result.caches.len() > 0);
+        assert!(!list_cache_result.caches.is_empty());
         mm.delete_cache(&cache_name)
             .await
             .expect("failed to delete cache");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -172,21 +172,9 @@ mod tests {
             .await
             .expect("failed to create cache");
 
-        let mut next_token: Option<String> = None;
-        let mut num_pages = 0;
-        loop {
-            let list_cache_result = mm
-                .list_caches(next_token)
-                .await
-                .expect("failed to list caches");
-            num_pages += 1;
-            next_token = list_cache_result.next_token;
-            if next_token.is_none() {
-                break;
-            }
-        }
+        let list_cache_result = mm.list_caches().await.expect("failed to list caches");
 
-        assert_eq!(1, num_pages, "we expect a single page of caches to list");
+        assert!(list_cache_result.caches.len() > 0);
         mm.delete_cache(&cache_name)
             .await
             .expect("failed to delete cache");
@@ -247,6 +235,10 @@ mod tests {
             .await
             .expect("failed to get second key");
         assert_eq!(second_key_get2, Get::Miss);
+        client
+            .delete_cache(&cache_name)
+            .await
+            .expect("failed to delete cache");
     }
 
     #[tokio::test]
@@ -267,7 +259,7 @@ mod tests {
         );
 
         let list_response = mm
-            .list_signing_keys(None)
+            .list_signing_keys()
             .await
             .expect("couldn't list signing keys");
         assert!(


### PR DESCRIPTION
Remove the next_token argument from list_caches and list_signing_keys. It isn't used by the back end and clutters the function signature.

Add a delete_cache to an integration test that was missing one. The tests may still leak caches if the tests fail before getting to the delete cache statement at the end. More comprehensive protection will follow.