### PR TITLE
feat: prototype of new API using requests as builders

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,6 +45,8 @@ jobs:
 #    runs-on: macos-latest
 #    needs: release
 #    env:
+#      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+#      # TODO: get rid of this once everything has been migrated to MOMENTO_API_KEY
 #      TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
 #      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 #    steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,8 @@ jobs:
   build_rust:
     runs-on: macos-latest
     env:
+      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      # TODO: get rid of this once everything has been migrated to MOMENTO_API_KEY
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
 
     steps:

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -1,6 +1,6 @@
 use crate::grpc::header_interceptor::HeaderInterceptor;
 use crate::requests::cache::set_add_elements::{SetAddElements, SetAddElementsRequest};
-use crate::requests::cache::{MomentoRequest, MomentoSendableRequest};
+use crate::requests::cache::MomentoRequest;
 use crate::utils::user_agent;
 use crate::{utils, CredentialProvider, IntoBytes, MomentoResult};
 use momento_protos::cache_client::scs_client::ScsClient;
@@ -89,10 +89,7 @@ impl CacheClient {
     /// #
     /// }
     /// ```
-    pub async fn send_request<R: MomentoRequest>(self, request: R) -> MomentoResult<R::Response>
-    where
-        R: MomentoSendableRequest<R>,
-    {
+    pub async fn send_request<R: MomentoRequest>(self, request: R) -> MomentoResult<R::Response> {
         request.send(&self).await
     }
 

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -89,10 +89,7 @@ impl CacheClient {
     /// #
     /// }
     /// ```
-    pub async fn send_request<R: MomentoRequest>(
-        self,
-        request: R,
-    ) -> MomentoResult<R::Response>
+    pub async fn send_request<R: MomentoRequest>(self, request: R) -> MomentoResult<R::Response>
     where
         R: MomentoSendableRequest<R>,
     {

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -49,7 +49,7 @@ impl CacheClient {
     /// let cache_client = momento::CacheClient::new(credential_provider, Duration::from_secs(5))?;
     ///
     /// let set_add_elements_response = cache_client.set_add_elements(cache_name.to_string(), "set", vec!["element1", "element2"]).await?;
-    /// assert_eq!(set_add_elements_response, SetAddElements::Success {});
+    /// assert_eq!(set_add_elements_response, SetAddElements {});
     /// # Ok(())
     /// # })
     /// #
@@ -83,7 +83,7 @@ impl CacheClient {
     /// let set_add_elements_response = cache_client.send_request(
     ///     SetAddElementsRequest::new(cache_name.to_string(), "set", vec!["element1", "element2"])
     /// ).await?;
-    /// assert_eq!(set_add_elements_response, SetAddElements::Success {});
+    /// assert_eq!(set_add_elements_response, SetAddElements {});
     /// # Ok(())
     /// # })
     /// #

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -1,13 +1,13 @@
 use crate::grpc::header_interceptor::HeaderInterceptor;
 use crate::requests::cache::set_add_elements::{SetAddElements, SetAddElementsRequest};
 use crate::requests::cache::{MomentoRequest, MomentoSendableRequest};
-use crate::utils::{user_agent};
+use crate::utils::user_agent;
 use crate::{utils, CredentialProvider, IntoBytes, MomentoResult};
 use momento_protos::cache_client::scs_client::ScsClient;
-use std::convert::{TryInto};
+use std::convert::TryInto;
 use std::time::Duration;
 use tonic::codegen::InterceptedService;
-use tonic::transport::{Channel};
+use tonic::transport::Channel;
 
 pub struct CacheClient {
     pub(crate) data_client: ScsClient<InterceptedService<Channel, HeaderInterceptor>>,
@@ -65,7 +65,6 @@ impl CacheClient {
         request.send(self).await
     }
 
-
     /// ```
     /// # fn main() -> anyhow::Result<()> {
     /// # use momento_protos::cache_client::update_ttl_response::Result::Set;
@@ -90,12 +89,12 @@ impl CacheClient {
     /// #
     /// }
     /// ```
-    pub async fn send_request<R: MomentoRequest>
-    (
+    pub async fn send_request<R: MomentoRequest>(
         self: &Self,
         request: R,
     ) -> MomentoResult<R::Response>
-        where R: MomentoSendableRequest<R>
+    where
+        R: MomentoSendableRequest<R>,
     {
         request.send(self).await
     }

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -1,6 +1,6 @@
 use crate::grpc::header_interceptor::HeaderInterceptor;
 use crate::requests::cache::set_add_elements::{SetAddElements, SetAddElementsRequest};
-use crate::requests::cache::{MomentoRequest, MomentoResponse};
+use crate::requests::cache::{MomentoRequest, MomentoSendableRequest};
 use crate::utils::{user_agent};
 use crate::{utils, CredentialProvider, IntoBytes, MomentoResult};
 use momento_protos::cache_client::scs_client::ScsClient;
@@ -62,7 +62,7 @@ impl CacheClient {
         elements: Vec<E>,
     ) -> MomentoResult<SetAddElements> {
         let request = SetAddElementsRequest::new(cache_name, set_name, elements);
-        MomentoRequest::send(request, self).await
+        request.send(self).await
     }
 
 
@@ -90,10 +90,13 @@ impl CacheClient {
     /// #
     /// }
     /// ```
-    pub async fn send_request<R: MomentoRequest<T>, T: MomentoResponse>(
+    pub async fn send_request<R: MomentoRequest>
+    (
         self: &Self,
         request: R,
-    ) -> MomentoResult<T> {
+    ) -> MomentoResult<R::Response>
+        where R: MomentoSendableRequest<R>
+    {
         request.send(self).await
     }
 

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -1,0 +1,107 @@
+use crate::grpc::header_interceptor::HeaderInterceptor;
+use crate::requests::cache::set_add_elements::{SetAddElements, SetAddElementsRequest};
+use crate::requests::cache::{MomentoRequest, MomentoResponse};
+use crate::utils::{user_agent};
+use crate::{utils, CredentialProvider, IntoBytes, MomentoResult};
+use momento_protos::cache_client::scs_client::ScsClient;
+use std::convert::{TryInto};
+use std::time::Duration;
+use tonic::codegen::InterceptedService;
+use tonic::transport::{Channel};
+
+pub struct CacheClient {
+    pub(crate) data_client: ScsClient<InterceptedService<Channel, HeaderInterceptor>>,
+    item_default_ttl: Duration,
+}
+
+impl CacheClient {
+    /* constructor */
+    pub fn new(
+        credential_provider: CredentialProvider,
+        default_ttl: Duration,
+    ) -> MomentoResult<Self> {
+        let data_channel = utils::connect_channel_lazily(&credential_provider.cache_endpoint)?;
+
+        let data_interceptor = InterceptedService::new(
+            data_channel,
+            HeaderInterceptor::new(&credential_provider.auth_token, &user_agent("sdk")),
+        );
+        let data_client = ScsClient::new(data_interceptor);
+        Ok(CacheClient {
+            data_client,
+            item_default_ttl: default_ttl,
+        })
+    }
+
+    /* public API */
+
+    /// ```
+    /// # fn main() -> anyhow::Result<()> {
+    /// # tokio_test::block_on(async {
+    /// use std::time::Duration;
+    /// use momento::{CredentialProviderBuilder};
+    /// use momento::requests::cache::set_add_elements::SetAddElements;
+    ///
+    /// let credential_provider = CredentialProviderBuilder::from_environment_variable("MOMENTO_API_KEY".to_string())
+    ///     .build()?;
+    /// let cache_name = "cache";
+    ///
+    /// let cache_client = momento::CacheClient::new(credential_provider, Duration::from_secs(5))?;
+    ///
+    /// let set_add_elements_response = cache_client.set_add_elements(cache_name.to_string(), "set", vec!["element1", "element2"]).await?;
+    /// assert_eq!(set_add_elements_response, SetAddElements::Success {});
+    /// # Ok(())
+    /// # })
+    /// #
+    /// }
+    /// ```
+    pub async fn set_add_elements<E: IntoBytes>(
+        self: &Self,
+        cache_name: String,
+        set_name: impl IntoBytes,
+        elements: Vec<E>,
+    ) -> MomentoResult<SetAddElements> {
+        let request = SetAddElementsRequest::new(cache_name, set_name, elements);
+        MomentoRequest::send(request, self).await
+    }
+
+
+    /// ```
+    /// # fn main() -> anyhow::Result<()> {
+    /// # use momento_protos::cache_client::update_ttl_response::Result::Set;
+    /// use momento::requests::cache::set_add_elements::SetAddElementsRequest;
+    /// tokio_test::block_on(async {
+    /// use std::time::Duration;
+    /// use momento::{CredentialProviderBuilder};
+    /// use momento::requests::cache::set_add_elements::SetAddElements;
+    ///
+    /// let credential_provider = CredentialProviderBuilder::from_environment_variable("MOMENTO_API_KEY".to_string())
+    ///     .build()?;
+    /// let cache_name = "cache";
+    ///
+    /// let cache_client = momento::CacheClient::new(credential_provider, Duration::from_secs(5))?;
+    ///
+    /// let set_add_elements_response = cache_client.send_request(
+    ///     SetAddElementsRequest::new(cache_name.to_string(), "set", vec!["element1", "element2"])
+    /// ).await?;
+    /// assert_eq!(set_add_elements_response, SetAddElements::Success {});
+    /// # Ok(())
+    /// # })
+    /// #
+    /// }
+    /// ```
+    pub async fn send_request<R: MomentoRequest<T>, T: MomentoResponse>(
+        self: &Self,
+        request: R,
+    ) -> MomentoResult<T> {
+        request.send(self).await
+    }
+
+    /* helper fns */
+    pub(crate) fn expand_ttl_ms(&self, ttl: Option<Duration>) -> MomentoResult<u64> {
+        let ttl = ttl.unwrap_or(self.item_default_ttl);
+        utils::is_ttl_valid(ttl)?;
+
+        Ok(ttl.as_millis().try_into().unwrap_or(i64::MAX as u64))
+    }
+}

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -56,13 +56,13 @@ impl CacheClient {
     /// }
     /// ```
     pub async fn set_add_elements<E: IntoBytes>(
-        self: &Self,
+        self,
         cache_name: String,
         set_name: impl IntoBytes,
         elements: Vec<E>,
     ) -> MomentoResult<SetAddElements> {
         let request = SetAddElementsRequest::new(cache_name, set_name, elements);
-        request.send(self).await
+        request.send(&self).await
     }
 
     /// ```
@@ -90,13 +90,13 @@ impl CacheClient {
     /// }
     /// ```
     pub async fn send_request<R: MomentoRequest>(
-        self: &Self,
+        self,
         request: R,
     ) -> MomentoResult<R::Response>
     where
         R: MomentoSendableRequest<R>,
     {
-        request.send(self).await
+        request.send(&self).await
     }
 
     /* helper fns */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,11 @@ pub mod preview;
 pub mod requests;
 pub mod response;
 
+mod cache_client;
 mod compression_utils;
 mod credential_provider;
 mod grpc;
 mod simple_cache_client;
-mod cache_client;
 mod utils;
 
 pub use crate::credential_provider::{CredentialProvider, CredentialProviderBuilder};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod compression_utils;
 mod credential_provider;
 mod grpc;
 mod simple_cache_client;
+mod cache_client;
 mod utils;
 
 pub use crate::credential_provider::{CredentialProvider, CredentialProviderBuilder};
@@ -15,6 +16,8 @@ pub use crate::response::MomentoError;
 pub use crate::simple_cache_client::{
     CollectionTtl, Fields, IntoBytes, SimpleCacheClient, SimpleCacheClientBuilder,
 };
+
+pub use crate::cache_client::CacheClient;
 
 pub type MomentoResult<T> = Result<T, MomentoError>;
 

--- a/src/requests/cache/mod.rs
+++ b/src/requests/cache/mod.rs
@@ -5,11 +5,14 @@ pub mod set_add_elements;
 
 pub trait MomentoRequest {
     type Response;
-}
 
-pub trait MomentoSendableRequest<R: MomentoRequest> {
+    /// An internal fn that allows Momento request types to define their interaction with
+    /// the gRPC client. You can impl this fn for your own types if you'd like to hand them
+    /// to the Momento client directly, but that is not an explicitly supported scenario and
+    /// this signature may change a little over time. If that's okay with you, impl away!
+    #[doc(hidden)]
     fn send(
         self,
         cache_client: &CacheClient,
-    ) -> impl std::future::Future<Output = MomentoResult<R::Response>> + Send;
+    ) -> impl std::future::Future<Output = MomentoResult<Self::Response>> + Send;
 }

--- a/src/requests/cache/mod.rs
+++ b/src/requests/cache/mod.rs
@@ -9,7 +9,7 @@ pub trait MomentoRequest {
 
 pub trait MomentoSendableRequest<R: MomentoRequest> {
     fn send(
-        self: Self,
+        self,
         cache_client: &CacheClient,
     ) -> impl std::future::Future<Output = MomentoResult<R::Response>> + Send;
 }

--- a/src/requests/cache/mod.rs
+++ b/src/requests/cache/mod.rs
@@ -3,7 +3,12 @@ use crate::cache_client::CacheClient;
 
 pub mod set_add_elements;
 
-pub trait MomentoResponse {}
-pub trait MomentoRequest<R: MomentoResponse> {
-    fn send(self: Self, cache_client: &CacheClient) -> impl std::future::Future<Output = MomentoResult<R>> + Send;
+pub trait MomentoRequest {
+    type Response;
 }
+
+pub trait MomentoSendableRequest<R: MomentoRequest> {
+    fn send(self: Self, cache_client: &CacheClient) -> impl std::future::Future<Output = MomentoResult<R::Response>> + Send;
+}
+
+

--- a/src/requests/cache/mod.rs
+++ b/src/requests/cache/mod.rs
@@ -1,0 +1,9 @@
+use crate::{MomentoResult};
+use crate::cache_client::CacheClient;
+
+pub mod set_add_elements;
+
+pub trait MomentoResponse {}
+pub trait MomentoRequest<R: MomentoResponse> {
+    fn send(self: Self, cache_client: &CacheClient) -> impl std::future::Future<Output = MomentoResult<R>> + Send;
+}

--- a/src/requests/cache/mod.rs
+++ b/src/requests/cache/mod.rs
@@ -1,5 +1,5 @@
-use crate::{MomentoResult};
 use crate::cache_client::CacheClient;
+use crate::MomentoResult;
 
 pub mod set_add_elements;
 
@@ -8,7 +8,8 @@ pub trait MomentoRequest {
 }
 
 pub trait MomentoSendableRequest<R: MomentoRequest> {
-    fn send(self: Self, cache_client: &CacheClient) -> impl std::future::Future<Output = MomentoResult<R::Response>> + Send;
+    fn send(
+        self: Self,
+        cache_client: &CacheClient,
+    ) -> impl std::future::Future<Output = MomentoResult<R::Response>> + Send;
 }
-
-

--- a/src/requests/cache/set_add_elements.rs
+++ b/src/requests/cache/set_add_elements.rs
@@ -1,5 +1,5 @@
 use crate::cache_client::CacheClient;
-use crate::requests::cache::{MomentoRequest, MomentoSendableRequest};
+use crate::requests::cache::MomentoRequest;
 use crate::simple_cache_client::prep_request;
 use crate::{CollectionTtl, IntoBytes, MomentoResult};
 use momento_protos::cache_client::SetUnionRequest;
@@ -45,11 +45,7 @@ impl<S: IntoBytes, E: IntoBytes> SetAddElementsRequest<S, E> {
 
 impl<S: IntoBytes, E: IntoBytes> MomentoRequest for SetAddElementsRequest<S, E> {
     type Response = SetAddElements;
-}
 
-impl<S: IntoBytes, E: IntoBytes> MomentoSendableRequest<SetAddElementsRequest<S, E>>
-    for SetAddElementsRequest<S, E>
-{
     async fn send(self, cache_client: &CacheClient) -> MomentoResult<SetAddElements> {
         let collection_ttl = self.collection_ttl.unwrap_or_default();
         let elements = self.elements.into_iter().map(|e| e.into_bytes()).collect();

--- a/src/requests/cache/set_add_elements.rs
+++ b/src/requests/cache/set_add_elements.rs
@@ -43,12 +43,13 @@ impl<S: IntoBytes, E: IntoBytes> SetAddElementsRequest<S, E> {
     }
 }
 
-
 impl<S: IntoBytes, E: IntoBytes> MomentoRequest for SetAddElementsRequest<S, E> {
     type Response = SetAddElements;
 }
 
-impl<S: IntoBytes, E: IntoBytes> MomentoSendableRequest<SetAddElementsRequest<S, E>> for SetAddElementsRequest<S, E> {
+impl<S: IntoBytes, E: IntoBytes> MomentoSendableRequest<SetAddElementsRequest<S, E>>
+    for SetAddElementsRequest<S, E>
+{
     fn send(
         self: Self,
         cache_client: &CacheClient,
@@ -68,11 +69,7 @@ impl<S: IntoBytes, E: IntoBytes> MomentoSendableRequest<SetAddElementsRequest<S,
                 },
             )?;
 
-            let _ = cache_client
-                .data_client
-                .clone()
-                .set_union(request)
-                .await?;
+            let _ = cache_client.data_client.clone().set_union(request).await?;
             Ok(SetAddElements {})
         }
     }

--- a/src/requests/cache/set_add_elements.rs
+++ b/src/requests/cache/set_add_elements.rs
@@ -1,0 +1,82 @@
+use crate::cache_client::CacheClient;
+use crate::requests::cache::{MomentoRequest, MomentoResponse};
+use crate::simple_cache_client::prep_request;
+use crate::{CollectionTtl, IntoBytes, MomentoResult};
+use momento_protos::cache_client::SetUnionRequest;
+
+/// ```
+/// # fn main() -> anyhow::Result<()> {
+/// # tokio_test::block_on(async {
+/// use std::time::Duration;
+/// use momento::{CredentialProviderBuilder};
+/// use momento::requests::cache::set_add_elements::SetAddElements;
+///
+/// let credential_provider = CredentialProviderBuilder::from_environment_variable("MOMENTO_API_KEY".to_string())
+///     .build()?;
+/// let cache_name = "cache";
+///
+/// let cache_client = momento::CacheClient::new(credential_provider, Duration::from_secs(5))?;
+///
+/// let set_add_elements_response = cache_client.set_add_elements(cache_name.to_string(), "set", vec!["element1", "element2"]).await?;
+/// assert_eq!(set_add_elements_response, SetAddElements::Success {});
+/// # Ok(())
+/// # })
+/// #
+/// }
+/// ```
+pub struct SetAddElementsRequest<S: IntoBytes, E: IntoBytes> {
+    cache_name: String,
+    set_name: S,
+    elements: Vec<E>,
+    collection_ttl: Option<CollectionTtl>,
+}
+
+impl<S: IntoBytes, E: IntoBytes> SetAddElementsRequest<S, E> {
+    pub fn new(cache_name: String, set_name: S, elements: Vec<E>) -> Self {
+        let collection_ttl = CollectionTtl::default();
+        Self {
+            cache_name,
+            set_name,
+            elements,
+            collection_ttl: Some(collection_ttl),
+        }
+    }
+}
+
+impl<S: IntoBytes, E: IntoBytes> MomentoRequest<SetAddElements> for SetAddElementsRequest<S, E> {
+    fn send(
+        self: Self,
+        cache_client: &CacheClient,
+    ) -> impl std::future::Future<Output = MomentoResult<SetAddElements>> + Send {
+        async move {
+            let collection_ttl = self.collection_ttl.unwrap_or_default();
+            let elements = self.elements.into_iter().map(|e| e.into_bytes()).collect();
+            let set_name = self.set_name.into_bytes();
+            let cache_name = &self.cache_name;
+            let request = prep_request(
+                cache_name,
+                SetUnionRequest {
+                    set_name,
+                    elements,
+                    ttl_milliseconds: cache_client.expand_ttl_ms(collection_ttl.ttl())?,
+                    refresh_ttl: collection_ttl.refresh(),
+                },
+            )?;
+
+            let _ = cache_client
+                .data_client
+                .clone()
+                .set_union(request)
+                .await?
+                .into_inner();
+            Ok(SetAddElements::Success {})
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SetAddElements {
+    Success {},
+}
+
+impl MomentoResponse for SetAddElements {}

--- a/src/requests/cache/set_add_elements.rs
+++ b/src/requests/cache/set_add_elements.rs
@@ -1,5 +1,5 @@
 use crate::cache_client::CacheClient;
-use crate::requests::cache::{MomentoRequest, MomentoResponse};
+use crate::requests::cache::{MomentoRequest, MomentoSendableRequest};
 use crate::simple_cache_client::prep_request;
 use crate::{CollectionTtl, IntoBytes, MomentoResult};
 use momento_protos::cache_client::SetUnionRequest;
@@ -18,7 +18,7 @@ use momento_protos::cache_client::SetUnionRequest;
 /// let cache_client = momento::CacheClient::new(credential_provider, Duration::from_secs(5))?;
 ///
 /// let set_add_elements_response = cache_client.set_add_elements(cache_name.to_string(), "set", vec!["element1", "element2"]).await?;
-/// assert_eq!(set_add_elements_response, SetAddElements::Success {});
+/// assert_eq!(set_add_elements_response, SetAddElements {});
 /// # Ok(())
 /// # })
 /// #
@@ -43,7 +43,12 @@ impl<S: IntoBytes, E: IntoBytes> SetAddElementsRequest<S, E> {
     }
 }
 
-impl<S: IntoBytes, E: IntoBytes> MomentoRequest<SetAddElements> for SetAddElementsRequest<S, E> {
+
+impl<S: IntoBytes, E: IntoBytes> MomentoRequest for SetAddElementsRequest<S, E> {
+    type Response = SetAddElements;
+}
+
+impl<S: IntoBytes, E: IntoBytes> MomentoSendableRequest<SetAddElementsRequest<S, E>> for SetAddElementsRequest<S, E> {
     fn send(
         self: Self,
         cache_client: &CacheClient,
@@ -67,16 +72,11 @@ impl<S: IntoBytes, E: IntoBytes> MomentoRequest<SetAddElements> for SetAddElemen
                 .data_client
                 .clone()
                 .set_union(request)
-                .await?
-                .into_inner();
-            Ok(SetAddElements::Success {})
+                .await?;
+            Ok(SetAddElements {})
         }
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum SetAddElements {
-    Success {},
-}
-
-impl MomentoResponse for SetAddElements {}
+pub struct SetAddElements {}

--- a/src/requests/cache/set_add_elements.rs
+++ b/src/requests/cache/set_add_elements.rs
@@ -50,28 +50,23 @@ impl<S: IntoBytes, E: IntoBytes> MomentoRequest for SetAddElementsRequest<S, E> 
 impl<S: IntoBytes, E: IntoBytes> MomentoSendableRequest<SetAddElementsRequest<S, E>>
     for SetAddElementsRequest<S, E>
 {
-    fn send(
-        self: Self,
-        cache_client: &CacheClient,
-    ) -> impl std::future::Future<Output = MomentoResult<SetAddElements>> + Send {
-        async move {
-            let collection_ttl = self.collection_ttl.unwrap_or_default();
-            let elements = self.elements.into_iter().map(|e| e.into_bytes()).collect();
-            let set_name = self.set_name.into_bytes();
-            let cache_name = &self.cache_name;
-            let request = prep_request(
-                cache_name,
-                SetUnionRequest {
-                    set_name,
-                    elements,
-                    ttl_milliseconds: cache_client.expand_ttl_ms(collection_ttl.ttl())?,
-                    refresh_ttl: collection_ttl.refresh(),
-                },
-            )?;
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SetAddElements> {
+        let collection_ttl = self.collection_ttl.unwrap_or_default();
+        let elements = self.elements.into_iter().map(|e| e.into_bytes()).collect();
+        let set_name = self.set_name.into_bytes();
+        let cache_name = &self.cache_name;
+        let request = prep_request(
+            cache_name,
+            SetUnionRequest {
+                set_name,
+                elements,
+                ttl_milliseconds: cache_client.expand_ttl_ms(collection_ttl.ttl())?,
+                refresh_ttl: collection_ttl.refresh(),
+            },
+        )?;
 
-            let _ = cache_client.data_client.clone().set_union(request).await?;
-            Ok(SetAddElements {})
-        }
+        let _ = cache_client.data_client.clone().set_union(request).await?;
+        Ok(SetAddElements {})
     }
 }
 

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -1,1 +1,2 @@
+pub mod cache;
 pub mod generate_api_token_request;

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -31,11 +31,11 @@ use crate::utils;
 use crate::{grpc::header_interceptor::HeaderInterceptor, utils::connect_channel_lazily};
 use crate::{utils::user_agent, MomentoResult};
 
-pub trait IntoBytes {
+pub trait IntoBytes: Send {
     fn into_bytes(self) -> Vec<u8>;
 }
 
-impl<T> IntoBytes for T
+impl<T: Send> IntoBytes for T
 where
     T: Into<Vec<u8>>,
 {

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -515,7 +515,7 @@ impl SimpleCacheClient {
         body: impl IntoBytes,
         ttl: impl Into<Option<Duration>>,
     ) -> MomentoResult<MomentoSetResponse> {
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             SetRequest {
                 cache_key: key.into_bytes(),
@@ -602,7 +602,7 @@ impl SimpleCacheClient {
     /// # }
     /// ```
     pub async fn get(&mut self, cache_name: &str, key: impl IntoBytes) -> MomentoResult<Get> {
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             GetRequest {
                 cache_key: key.into_bytes(),
@@ -729,7 +729,7 @@ impl SimpleCacheClient {
             })
             .collect();
 
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             DictionarySetRequest {
                 dictionary_name: dictionary_name.into_bytes(),
@@ -793,7 +793,7 @@ impl SimpleCacheClient {
         use dictionary_get_response::Dictionary;
 
         let fields = convert_vec(fields);
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             DictionaryGetRequest {
                 dictionary_name: dictionary.into_bytes(),
@@ -868,7 +868,7 @@ impl SimpleCacheClient {
     ) -> MomentoResult<DictionaryFetch> {
         use dictionary_fetch_response::Dictionary;
 
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             DictionaryFetchRequest {
                 dictionary_name: dictionary.into_bytes(),
@@ -961,7 +961,7 @@ impl SimpleCacheClient {
         };
 
         self.data_client
-            .dictionary_delete(self.prep_request(cache_name, request)?)
+            .dictionary_delete(prep_request(cache_name, request)?)
             .await?;
         Ok(MomentoDictionaryDeleteResponse::new())
     }
@@ -1012,7 +1012,7 @@ impl SimpleCacheClient {
         amount: i64,
         policy: CollectionTtl,
     ) -> MomentoResult<MomentoDictionaryIncrementResponse> {
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             DictionaryIncrementRequest {
                 dictionary_name: dictionary.into_bytes(),
@@ -1081,7 +1081,7 @@ impl SimpleCacheClient {
         truncate_to: impl Into<Option<u32>>,
         policy: CollectionTtl,
     ) -> MomentoResult<u32> {
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             ListConcatenateFrontRequest {
                 list_name: list_name.into_bytes(),
@@ -1146,7 +1146,7 @@ impl SimpleCacheClient {
         truncate_to: impl Into<Option<u32>>,
         policy: CollectionTtl,
     ) -> MomentoResult<u32> {
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             ListConcatenateBackRequest {
                 list_name: list_name.into_bytes(),
@@ -1210,7 +1210,7 @@ impl SimpleCacheClient {
         truncate_to: impl Into<Option<u32>>,
         policy: CollectionTtl,
     ) -> MomentoResult<u32> {
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             ListPushFrontRequest {
                 list_name: list_name.into_bytes(),
@@ -1275,7 +1275,7 @@ impl SimpleCacheClient {
         truncate_to: impl Into<Option<u32>>,
         policy: CollectionTtl,
     ) -> MomentoResult<u32> {
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             ListPushBackRequest {
                 list_name: list_name.into_bytes(),
@@ -1385,7 +1385,7 @@ impl SimpleCacheClient {
     ) -> MomentoResult<MomentoListFetchResponse> {
         use list_fetch_response::List;
 
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             ListFetchRequest {
                 list_name: list_name.into_bytes(),
@@ -1439,7 +1439,7 @@ impl SimpleCacheClient {
     ) -> MomentoResult<Option<Vec<u8>>> {
         use momento_protos::cache_client::list_pop_front_response::List;
 
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             ListPopFrontRequest {
                 list_name: list_name.into_bytes(),
@@ -1498,7 +1498,7 @@ impl SimpleCacheClient {
     ) -> MomentoResult<Option<Vec<u8>>> {
         use momento_protos::cache_client::list_pop_back_response::List;
 
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             ListPopBackRequest {
                 list_name: list_name.into_bytes(),
@@ -1560,7 +1560,7 @@ impl SimpleCacheClient {
     ) -> MomentoResult<()> {
         use list_remove_request::Remove;
 
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             ListRemoveRequest {
                 list_name: list_name.into_bytes(),
@@ -1682,7 +1682,7 @@ impl SimpleCacheClient {
             })
         }
 
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             ListEraseRequest {
                 list_name: list_name.into_bytes(),
@@ -1730,7 +1730,7 @@ impl SimpleCacheClient {
     ) -> MomentoResult<Option<u32>> {
         use list_length_response::List;
 
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             ListLengthRequest {
                 list_name: list_name.into_bytes(),
@@ -1785,7 +1785,7 @@ impl SimpleCacheClient {
     ) -> MomentoResult<MomentoSetFetchResponse> {
         use set_fetch_response::Set;
 
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             SetFetchRequest {
                 set_name: set_name.into_bytes(),
@@ -1844,7 +1844,7 @@ impl SimpleCacheClient {
         elements: Vec<E>,
         policy: CollectionTtl,
     ) -> MomentoResult<()> {
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             SetUnionRequest {
                 set_name: set_name.into_bytes(),
@@ -1906,7 +1906,7 @@ impl SimpleCacheClient {
         use set_difference_request::{Difference, Subtrahend};
         use set_difference_response::Set;
 
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             SetDifferenceRequest {
                 set_name: set_name.into_bytes(),
@@ -2100,7 +2100,7 @@ impl SimpleCacheClient {
             Bound::Unbounded => End::UnboundedEnd(Unbounded {}),
         };
 
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             SortedSetFetchRequest {
                 set_name: set_name.into_bytes(),
@@ -2283,7 +2283,7 @@ impl SimpleCacheClient {
             Bound::Unbounded => Max::UnboundedMax(Unbounded {}),
         };
 
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             SortedSetFetchRequest {
                 set_name: set_name.into_bytes(),
@@ -2382,7 +2382,7 @@ impl SimpleCacheClient {
         use momento_protos::cache_client::sorted_set_get_rank_request::Order::Ascending;
         use momento_protos::cache_client::sorted_set_get_rank_response::Rank;
 
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             SortedSetGetRankRequest {
                 set_name: set_name.into_bytes(),
@@ -2466,7 +2466,7 @@ impl SimpleCacheClient {
 
         let len = element_names.len();
 
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             SortedSetGetScoreRequest {
                 set_name: set_name.into_bytes(),
@@ -2536,7 +2536,7 @@ impl SimpleCacheClient {
         amount: f64,
         policy: CollectionTtl,
     ) -> MomentoResult<f64> {
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             SortedSetIncrementRequest {
                 set_name: set_name.into_bytes(),
@@ -2595,7 +2595,7 @@ impl SimpleCacheClient {
         elements: Vec<SortedSetElement>,
         policy: CollectionTtl,
     ) -> MomentoResult<()> {
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             SortedSetPutRequest {
                 set_name: set_name.into_bytes(),
@@ -2644,7 +2644,7 @@ impl SimpleCacheClient {
     ) -> MomentoResult<()> {
         use momento_protos::cache_client::sorted_set_remove_request::{RemoveElements, Some};
 
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             SortedSetRemoveRequest {
                 set_name: set_name.into_bytes(),
@@ -2692,7 +2692,7 @@ impl SimpleCacheClient {
         cache_name: &str,
         key: impl IntoBytes,
     ) -> MomentoResult<MomentoDeleteResponse> {
-        let request = self.prep_request(
+        let request = prep_request(
             cache_name,
             DeleteRequest {
                 cache_key: key.into_bytes(),
@@ -2719,14 +2719,14 @@ impl SimpleCacheClient {
 
         Ok(ttl.as_millis().try_into().unwrap_or(i64::MAX as u64))
     }
+}
 
-    fn prep_request<R>(&self, cache_name: &str, request: R) -> MomentoResult<tonic::Request<R>> {
-        utils::is_cache_name_valid(cache_name)?;
+pub(crate) fn prep_request<R>(cache_name: &str, request: R) -> MomentoResult<tonic::Request<R>> {
+    utils::is_cache_name_valid(cache_name)?;
 
-        let mut request = tonic::Request::new(request);
-        request_meta_data(&mut request, cache_name)?;
-        Ok(request)
-    }
+    let mut request = tonic::Request::new(request);
+    request_meta_data(&mut request, cache_name)?;
+    Ok(request)
 }
 
 /// An enum that is used to indicate if an operation should apply to all fields


### PR DESCRIPTION
This is a prototype of the new API that Kenny, Nate and I have been discussing. In this model we define a Request and a Response struct for each API. The Request structs can be used as builders, to support optional arguments and future additions to the API. The CacheClient exposes the simplest possible syntax for each API, with no optional arguments provide, and implements that by instantiating one of the Request structs.

The Request trait requires each Request type to implement a `send` function, to do the work of sending the request. This will allow us to keep the logic for the implementation details of each API in its own struct, rather than having all of the implementations live direction in `CacheClient`.

`CacheClient` also provides a `send_request` fn that can be called directly, accepting a `Request` type as an argument. This is the lower-level API that callers will use if they need to specify any of the optional arguments for any given request.