### PR TITLE
feat: add a configuration object for the cache client

### DIFF
--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -56,7 +56,7 @@ impl CacheClient {
     ///
     /// let cache_client = momento::CacheClient::new(
     ///    credential_provider,
-    ///    configurations::laptop::LATEST,
+    ///    configurations::laptop::latest(),
     ///    Duration::from_secs(5),
     ///)?;
     ///
@@ -93,7 +93,7 @@ impl CacheClient {
     ///
     /// let cache_client = momento::CacheClient::new(
     ///    credential_provider,
-    ///    configurations::laptop::LATEST,
+    ///    configurations::laptop::latest(),
     ///    Duration::from_secs(5),
     ///)?;
     ///

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -1,3 +1,4 @@
+use crate::config::configuration::Configuration;
 use crate::grpc::header_interceptor::HeaderInterceptor;
 use crate::requests::cache::set_add_elements::{SetAddElements, SetAddElementsRequest};
 use crate::requests::cache::MomentoRequest;
@@ -11,6 +12,7 @@ use tonic::transport::Channel;
 
 pub struct CacheClient {
     pub(crate) data_client: ScsClient<InterceptedService<Channel, HeaderInterceptor>>,
+    pub(crate) configuration: Configuration,
     item_default_ttl: Duration,
 }
 
@@ -18,9 +20,13 @@ impl CacheClient {
     /* constructor */
     pub fn new(
         credential_provider: CredentialProvider,
+        configuration: Configuration,
         default_ttl: Duration,
     ) -> MomentoResult<Self> {
-        let data_channel = utils::connect_channel_lazily(&credential_provider.cache_endpoint)?;
+        let data_channel = utils::connect_channel_lazily_configurable(
+            &credential_provider.cache_endpoint,
+            configuration.transport_strategy.grpc_configuration.clone(),
+        )?;
 
         let data_interceptor = InterceptedService::new(
             data_channel,
@@ -29,6 +35,7 @@ impl CacheClient {
         let data_client = ScsClient::new(data_interceptor);
         Ok(CacheClient {
             data_client,
+            configuration,
             item_default_ttl: default_ttl,
         })
     }
@@ -39,14 +46,19 @@ impl CacheClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # tokio_test::block_on(async {
     /// use std::time::Duration;
-    /// use momento::{CredentialProviderBuilder};
+    /// use momento::config::configurations;
+    /// use momento::CredentialProviderBuilder;
     /// use momento::requests::cache::set_add_elements::SetAddElements;
     ///
     /// let credential_provider = CredentialProviderBuilder::from_environment_variable("MOMENTO_API_KEY".to_string())
     ///     .build()?;
     /// let cache_name = "cache";
     ///
-    /// let cache_client = momento::CacheClient::new(credential_provider, Duration::from_secs(5))?;
+    /// let cache_client = momento::CacheClient::new(
+    ///    credential_provider,
+    ///    configurations::laptop::LATEST,
+    ///    Duration::from_secs(5),
+    ///)?;
     ///
     /// let set_add_elements_response = cache_client.set_add_elements(cache_name.to_string(), "set", vec!["element1", "element2"]).await?;
     /// assert_eq!(set_add_elements_response, SetAddElements {});
@@ -71,14 +83,19 @@ impl CacheClient {
     /// use momento::requests::cache::set_add_elements::SetAddElementsRequest;
     /// tokio_test::block_on(async {
     /// use std::time::Duration;
-    /// use momento::{CredentialProviderBuilder};
+    /// use momento::config::configurations;
+    /// use momento::CredentialProviderBuilder;
     /// use momento::requests::cache::set_add_elements::SetAddElements;
     ///
     /// let credential_provider = CredentialProviderBuilder::from_environment_variable("MOMENTO_API_KEY".to_string())
     ///     .build()?;
     /// let cache_name = "cache";
     ///
-    /// let cache_client = momento::CacheClient::new(credential_provider, Duration::from_secs(5))?;
+    /// let cache_client = momento::CacheClient::new(
+    ///    credential_provider,
+    ///    configurations::laptop::LATEST,
+    ///    Duration::from_secs(5),
+    ///)?;
     ///
     /// let set_add_elements_response = cache_client.send_request(
     ///     SetAddElementsRequest::new(cache_name.to_string(), "set", vec!["element1", "element2"])

--- a/src/config/configuration.rs
+++ b/src/config/configuration.rs
@@ -1,6 +1,6 @@
-use crate::config::grpc_configuration::GrpcConfiguration;
-use crate::config::transport_strategy::TransportStrategy;
 use std::time::Duration;
+
+use crate::config::transport_strategy::TransportStrategy;
 
 /// Configuration for a Momento cache client.
 ///
@@ -9,25 +9,21 @@ use std::time::Duration;
 /// use momento::config::configurations;
 ///
 /// /// Use laptop for local development
-/// let developer_config = configurations::laptop::LATEST;
+/// let developer_config = configurations::laptop::latest();
 /// /// Use in_region for a typical server environment
-/// let server_config = configurations::in_region::V1;
+/// let server_config = configurations::in_region::v1();
 /// ```
 /// If you have specific requirements, configurations can also be constructed manually:
 /// ```
 /// use std::time::Duration;
 /// use momento::config::configuration::Configuration;
-/// use momento::config::grpc_configuration::GrpcConfiguration;
+/// use momento::config::grpc_configuration::GrpcConfigurationBuilder;
 /// use momento::config::transport_strategy::TransportStrategy;
 ///
 /// let config = Configuration {
 ///             transport_strategy: TransportStrategy {
-///                 grpc_configuration: GrpcConfiguration {
-///                     deadline_millis: Duration::from_millis(1000),
-///                     keep_alive_while_idle: true,
-///                     keep_alive_interval: Duration::from_secs(5000),
-///                     keep_alive_timeout: Duration::from_secs(1000),
-///                 },
+///                 grpc_configuration: GrpcConfigurationBuilder::new(Duration::from_millis(1000))
+///                     .build(),
 ///             },
 ///         };
 #[derive(Clone)]
@@ -37,26 +33,12 @@ pub struct Configuration {
 }
 
 impl Configuration {
-    pub fn new(
-        deadline_millis: Duration,
-        keep_alive_while_idle: bool,
-        keep_alive_interval: Duration,
-        keep_alive_timeout: Duration,
-    ) -> Self {
-        Configuration {
-            transport_strategy: TransportStrategy {
-                grpc_configuration: GrpcConfiguration {
-                    deadline_millis,
-                    keep_alive_while_idle,
-                    keep_alive_interval,
-                    keep_alive_timeout,
-                },
-            },
-        }
+    pub fn new(transport_strategy: TransportStrategy) -> Self {
+        Configuration { transport_strategy }
     }
 
     /// Returns the duration the client will wait before terminating an RPC with a DeadlineExceeded error.
     pub fn deadline_millis(&self) -> Duration {
-        self.transport_strategy.grpc_configuration.deadline_millis
+        self.transport_strategy.grpc_configuration.deadline
     }
 }

--- a/src/config/configuration.rs
+++ b/src/config/configuration.rs
@@ -1,0 +1,62 @@
+use crate::config::grpc_configuration::GrpcConfiguration;
+use crate::config::transport_strategy::TransportStrategy;
+use std::time::Duration;
+
+/// Configuration for a Momento cache client.
+///
+/// Static, versioned configurations are provided for different environments:
+/// ```
+/// use momento::config::configurations;
+///
+/// /// Use laptop for local development
+/// let developer_config = configurations::laptop::LATEST;
+/// /// Use in_region for a typical server environment
+/// let server_config = configurations::in_region::V1;
+/// ```
+/// If you have specific requirements, configurations can also be constructed manually:
+/// ```
+/// use std::time::Duration;
+/// use momento::config::configuration::Configuration;
+/// use momento::config::grpc_configuration::GrpcConfiguration;
+/// use momento::config::transport_strategy::TransportStrategy;
+///
+/// let config = Configuration {
+///             transport_strategy: TransportStrategy {
+///                 grpc_configuration: GrpcConfiguration {
+///                     deadline_millis: Duration::from_millis(1000),
+///                     keep_alive_while_idle: true,
+///                     keep_alive_interval: Duration::from_secs(5000),
+///                     keep_alive_timeout: Duration::from_secs(1000),
+///                 },
+///             },
+///         };
+#[derive(Clone)]
+pub struct Configuration {
+    /// Low-level options for network interactions with Momento.
+    pub transport_strategy: TransportStrategy,
+}
+
+impl Configuration {
+    pub fn new(
+        deadline_millis: Duration,
+        keep_alive_while_idle: bool,
+        keep_alive_interval: Duration,
+        keep_alive_timeout: Duration,
+    ) -> Self {
+        Configuration {
+            transport_strategy: TransportStrategy {
+                grpc_configuration: GrpcConfiguration {
+                    deadline_millis,
+                    keep_alive_while_idle,
+                    keep_alive_interval,
+                    keep_alive_timeout,
+                },
+            },
+        }
+    }
+
+    /// Returns the duration the client will wait before terminating an RPC with a DeadlineExceeded error.
+    pub fn deadline_millis(&self) -> Duration {
+        self.transport_strategy.grpc_configuration.deadline_millis
+    }
+}

--- a/src/config/configuration.rs
+++ b/src/config/configuration.rs
@@ -17,28 +17,46 @@ use crate::config::transport_strategy::TransportStrategy;
 /// ```
 /// use std::time::Duration;
 /// use momento::config::configuration::Configuration;
-/// use momento::config::grpc_configuration::GrpcConfigurationBuilder;
+/// use momento::config::grpc_configuration::{GrpcConfiguration, GrpcConfigurationBuilder};
 /// use momento::config::transport_strategy::TransportStrategy;
 ///
-/// let config = Configuration {
-///             transport_strategy: TransportStrategy {
-///                 grpc_configuration: GrpcConfigurationBuilder::new(Duration::from_millis(1000))
-///                     .build(),
-///             },
-///         };
+/// let config = Configuration::builder(
+///            TransportStrategy::builder(
+///                GrpcConfiguration::builder(Duration::from_millis(1000)).build(),
+///            )
+///            .build(),
+///        )
+///        .build();
 #[derive(Clone)]
 pub struct Configuration {
     /// Low-level options for network interactions with Momento.
-    pub transport_strategy: TransportStrategy,
+    pub(crate) transport_strategy: TransportStrategy,
 }
 
 impl Configuration {
-    pub fn new(transport_strategy: TransportStrategy) -> Self {
-        Configuration { transport_strategy }
+    pub fn builder(transport_strategy: TransportStrategy) -> ConfigurationBuilder {
+        ConfigurationBuilder { transport_strategy }
     }
 
     /// Returns the duration the client will wait before terminating an RPC with a DeadlineExceeded error.
     pub fn deadline_millis(&self) -> Duration {
         self.transport_strategy.grpc_configuration.deadline
+    }
+}
+
+pub struct ConfigurationBuilder {
+    transport_strategy: TransportStrategy,
+}
+
+impl ConfigurationBuilder {
+    pub fn with_transport_strategy(mut self, transport_strategy: TransportStrategy) -> Self {
+        self.transport_strategy = transport_strategy;
+        self
+    }
+
+    pub fn build(self) -> Configuration {
+        Configuration {
+            transport_strategy: self.transport_strategy,
+        }
     }
 }

--- a/src/config/configurations.rs
+++ b/src/config/configurations.rs
@@ -1,0 +1,116 @@
+/// Provides defaults suitable for a medium-to-high-latency dev environment. Permissive timeouts
+/// and relaxed latency and throughput targets.
+pub mod laptop {
+    use crate::config::configuration::Configuration;
+    use crate::config::grpc_configuration::GrpcConfiguration;
+    use crate::config::transport_strategy::TransportStrategy;
+    use std::time::Duration;
+
+    /// Latest recommended config for a laptop development environment.
+    ///
+    /// NOTE: this config may change in future releases to take advantage of improvements
+    /// we identify for default configurations.
+    pub const LATEST: Configuration = V1;
+
+    /// V1 config for a laptop development environment.
+    ///
+    /// This config is guaranteed not to change in future releases of the Momento Rust SDK.
+    pub const V1: Configuration = Configuration {
+        transport_strategy: TransportStrategy {
+            grpc_configuration: GrpcConfiguration {
+                deadline_millis: Duration::from_millis(5000),
+                keep_alive_while_idle: true,
+                keep_alive_interval: Duration::from_secs(5000),
+                keep_alive_timeout: Duration::from_secs(1000),
+            },
+        },
+    };
+}
+
+/// Provides defaults suitable for an environment where your client is running in the same
+/// region as the Momento service. It has more aggressive timeouts than the laptop config.
+pub mod in_region {
+    use crate::config::configuration::Configuration;
+    use crate::config::grpc_configuration::GrpcConfiguration;
+    use crate::config::transport_strategy::TransportStrategy;
+    use std::time::Duration;
+
+    /// Latest recommended config for a typical in-region environment.
+    ///
+    /// NOTE: this config may change in future releases to take advantage of improvements
+    /// we identify for default configurations.
+    pub const LATEST: Configuration = V1;
+
+    /// V1 config for a typical in-region environment.
+    ///
+    /// This config is guaranteed not to change in future releases of the Momento Rust SDK.
+    pub const V1: Configuration = Configuration {
+        transport_strategy: TransportStrategy {
+            grpc_configuration: GrpcConfiguration {
+                deadline_millis: Duration::from_millis(1100),
+                keep_alive_while_idle: true,
+                keep_alive_interval: Duration::from_secs(5000),
+                keep_alive_timeout: Duration::from_secs(1000),
+            },
+        },
+    };
+}
+
+/// This config prioritizes keeping p99.9 latencies as low as possible, potentially sacrificing
+/// some throughput to achieve this. Use this config if low latency is more important in
+/// your application than cache availability.
+pub mod low_latency {
+    use crate::config::configuration::Configuration;
+    use crate::config::grpc_configuration::GrpcConfiguration;
+    use crate::config::transport_strategy::TransportStrategy;
+    use std::time::Duration;
+
+    /// Latest recommended config for a low-latency environment.
+    ///
+    /// NOTE: this config may change in future releases to take advantage of improvements
+    /// we identify for default configurations.
+    pub const LATEST: Configuration = V1;
+
+    /// V1 config for a low-latency environment.
+    ///
+    /// This config is guaranteed not to change in future releases of the Momento Rust SDK.
+    pub const V1: Configuration = Configuration {
+        transport_strategy: TransportStrategy {
+            grpc_configuration: GrpcConfiguration {
+                deadline_millis: Duration::from_millis(500),
+                keep_alive_while_idle: true,
+                keep_alive_interval: Duration::from_secs(5000),
+                keep_alive_timeout: Duration::from_secs(1000),
+            },
+        },
+    };
+}
+
+/// Provides defaults suitable for a typical lambda environment. It has more aggressive timeouts
+/// than the laptop config and does not check connection health with a keep-alive.
+pub mod lambda {
+    use crate::config::configuration::Configuration;
+    use crate::config::grpc_configuration::GrpcConfiguration;
+    use crate::config::transport_strategy::TransportStrategy;
+    use std::time::Duration;
+
+    /// Latest recommended config for a typical lambda environment.
+    ///
+    /// NOTE: this config may change in future releases to take advantage of improvements
+    /// we identify for default configurations.
+    pub const LATEST: Configuration = V1;
+
+    /// V1 config for a typical lambda environment.
+    ///
+    /// This config is guaranteed not to change in future releases of the Momento Rust SDK.
+    pub const V1: Configuration = Configuration {
+        transport_strategy: TransportStrategy {
+            grpc_configuration: GrpcConfiguration {
+                deadline_millis: Duration::from_millis(1100),
+                keep_alive_while_idle: false,
+                keep_alive_interval: Duration::MAX,
+                keep_alive_timeout: Duration::MAX,
+            },
+        },
+    };
+}

--- a/src/config/configurations.rs
+++ b/src/config/configurations.rs
@@ -4,7 +4,7 @@ pub mod laptop {
     use std::time::Duration;
 
     use crate::config::configuration::Configuration;
-    use crate::config::grpc_configuration::GrpcConfigurationBuilder;
+    use crate::config::grpc_configuration::GrpcConfiguration;
     use crate::config::transport_strategy::TransportStrategy;
 
     /// Latest recommended config for a laptop development environment.
@@ -19,15 +19,17 @@ pub mod laptop {
     ///
     /// This config is guaranteed not to change in future releases of the Momento Rust SDK.
     pub fn v1() -> Configuration {
-        Configuration {
-            transport_strategy: TransportStrategy {
-                grpc_configuration: GrpcConfigurationBuilder::new(Duration::from_millis(15000))
+        Configuration::builder(
+            TransportStrategy::builder(
+                GrpcConfiguration::builder(Duration::from_millis(15000))
                     .with_keep_alive_while_idle(true)
                     .with_keep_alive_interval(Duration::from_secs(5000))
                     .with_keep_alive_timeout(Duration::from_secs(1000))
                     .build(),
-            },
-        }
+            )
+            .build(),
+        )
+        .build()
     }
 }
 
@@ -37,7 +39,7 @@ pub mod in_region {
     use std::time::Duration;
 
     use crate::config::configuration::Configuration;
-    use crate::config::grpc_configuration::GrpcConfigurationBuilder;
+    use crate::config::grpc_configuration::GrpcConfiguration;
     use crate::config::transport_strategy::TransportStrategy;
 
     /// Latest recommended config for a typical in-region environment.
@@ -52,15 +54,17 @@ pub mod in_region {
     ///
     /// This config is guaranteed not to change in future releases of the Momento Rust SDK.
     pub fn v1() -> Configuration {
-        Configuration {
-            transport_strategy: TransportStrategy {
-                grpc_configuration: GrpcConfigurationBuilder::new(Duration::from_millis(1100))
+        Configuration::builder(
+            TransportStrategy::builder(
+                GrpcConfiguration::builder(Duration::from_millis(1100))
                     .with_keep_alive_while_idle(true)
                     .with_keep_alive_interval(Duration::from_secs(5000))
                     .with_keep_alive_timeout(Duration::from_secs(1000))
                     .build(),
-            },
-        }
+            )
+            .build(),
+        )
+        .build()
     }
 }
 
@@ -71,7 +75,7 @@ pub mod low_latency {
     use std::time::Duration;
 
     use crate::config::configuration::Configuration;
-    use crate::config::grpc_configuration::GrpcConfigurationBuilder;
+    use crate::config::grpc_configuration::GrpcConfiguration;
     use crate::config::transport_strategy::TransportStrategy;
 
     /// Latest recommended config for a low-latency environment.
@@ -86,15 +90,17 @@ pub mod low_latency {
     ///
     /// This config is guaranteed not to change in future releases of the Momento Rust SDK.
     pub fn v1() -> Configuration {
-        Configuration {
-            transport_strategy: TransportStrategy {
-                grpc_configuration: GrpcConfigurationBuilder::new(Duration::from_millis(500))
+        Configuration::builder(
+            TransportStrategy::builder(
+                GrpcConfiguration::builder(Duration::from_millis(500))
                     .with_keep_alive_while_idle(true)
                     .with_keep_alive_interval(Duration::from_secs(5000))
                     .with_keep_alive_timeout(Duration::from_secs(1000))
                     .build(),
-            },
-        }
+            )
+            .build(),
+        )
+        .build()
     }
 }
 
@@ -104,7 +110,7 @@ pub mod lambda {
     use std::time::Duration;
 
     use crate::config::configuration::Configuration;
-    use crate::config::grpc_configuration::GrpcConfigurationBuilder;
+    use crate::config::grpc_configuration::GrpcConfiguration;
     use crate::config::transport_strategy::TransportStrategy;
 
     /// Latest recommended config for a typical lambda environment.
@@ -119,12 +125,14 @@ pub mod lambda {
     ///
     /// This config is guaranteed not to change in future releases of the Momento Rust SDK.
     pub fn v1() -> Configuration {
-        Configuration {
-            transport_strategy: TransportStrategy {
-                grpc_configuration: GrpcConfigurationBuilder::new(Duration::from_millis(1100))
+        Configuration::builder(
+            TransportStrategy::builder(
+                GrpcConfiguration::builder(Duration::from_millis(1100))
                     .with_keep_alive_while_idle(false)
                     .build(),
-            },
-        }
+            )
+            .build(),
+        )
+        .build()
     }
 }

--- a/src/config/configurations.rs
+++ b/src/config/configurations.rs
@@ -1,116 +1,130 @@
 /// Provides defaults suitable for a medium-to-high-latency dev environment. Permissive timeouts
 /// and relaxed latency and throughput targets.
 pub mod laptop {
-    use crate::config::configuration::Configuration;
-    use crate::config::grpc_configuration::GrpcConfiguration;
-    use crate::config::transport_strategy::TransportStrategy;
     use std::time::Duration;
+
+    use crate::config::configuration::Configuration;
+    use crate::config::grpc_configuration::GrpcConfigurationBuilder;
+    use crate::config::transport_strategy::TransportStrategy;
 
     /// Latest recommended config for a laptop development environment.
     ///
     /// NOTE: this config may change in future releases to take advantage of improvements
     /// we identify for default configurations.
-    pub const LATEST: Configuration = V1;
+    pub fn latest() -> Configuration {
+        v1()
+    }
 
     /// V1 config for a laptop development environment.
     ///
     /// This config is guaranteed not to change in future releases of the Momento Rust SDK.
-    pub const V1: Configuration = Configuration {
-        transport_strategy: TransportStrategy {
-            grpc_configuration: GrpcConfiguration {
-                deadline_millis: Duration::from_millis(5000),
-                keep_alive_while_idle: true,
-                keep_alive_interval: Duration::from_secs(5000),
-                keep_alive_timeout: Duration::from_secs(1000),
+    pub fn v1() -> Configuration {
+        Configuration {
+            transport_strategy: TransportStrategy {
+                grpc_configuration: GrpcConfigurationBuilder::new(Duration::from_millis(15000))
+                    .with_keep_alive_while_idle(true)
+                    .with_keep_alive_interval(Duration::from_secs(5000))
+                    .with_keep_alive_timeout(Duration::from_secs(1000))
+                    .build(),
             },
-        },
-    };
+        }
+    }
 }
 
 /// Provides defaults suitable for an environment where your client is running in the same
 /// region as the Momento service. It has more aggressive timeouts than the laptop config.
 pub mod in_region {
-    use crate::config::configuration::Configuration;
-    use crate::config::grpc_configuration::GrpcConfiguration;
-    use crate::config::transport_strategy::TransportStrategy;
     use std::time::Duration;
+
+    use crate::config::configuration::Configuration;
+    use crate::config::grpc_configuration::GrpcConfigurationBuilder;
+    use crate::config::transport_strategy::TransportStrategy;
 
     /// Latest recommended config for a typical in-region environment.
     ///
     /// NOTE: this config may change in future releases to take advantage of improvements
     /// we identify for default configurations.
-    pub const LATEST: Configuration = V1;
+    pub fn latest() -> Configuration {
+        v1()
+    }
 
     /// V1 config for a typical in-region environment.
     ///
     /// This config is guaranteed not to change in future releases of the Momento Rust SDK.
-    pub const V1: Configuration = Configuration {
-        transport_strategy: TransportStrategy {
-            grpc_configuration: GrpcConfiguration {
-                deadline_millis: Duration::from_millis(1100),
-                keep_alive_while_idle: true,
-                keep_alive_interval: Duration::from_secs(5000),
-                keep_alive_timeout: Duration::from_secs(1000),
+    pub fn v1() -> Configuration {
+        Configuration {
+            transport_strategy: TransportStrategy {
+                grpc_configuration: GrpcConfigurationBuilder::new(Duration::from_millis(1100))
+                    .with_keep_alive_while_idle(true)
+                    .with_keep_alive_interval(Duration::from_secs(5000))
+                    .with_keep_alive_timeout(Duration::from_secs(1000))
+                    .build(),
             },
-        },
-    };
+        }
+    }
 }
 
 /// This config prioritizes keeping p99.9 latencies as low as possible, potentially sacrificing
 /// some throughput to achieve this. Use this config if low latency is more important in
 /// your application than cache availability.
 pub mod low_latency {
-    use crate::config::configuration::Configuration;
-    use crate::config::grpc_configuration::GrpcConfiguration;
-    use crate::config::transport_strategy::TransportStrategy;
     use std::time::Duration;
+
+    use crate::config::configuration::Configuration;
+    use crate::config::grpc_configuration::GrpcConfigurationBuilder;
+    use crate::config::transport_strategy::TransportStrategy;
 
     /// Latest recommended config for a low-latency environment.
     ///
     /// NOTE: this config may change in future releases to take advantage of improvements
     /// we identify for default configurations.
-    pub const LATEST: Configuration = V1;
+    pub fn latest() -> Configuration {
+        v1()
+    }
 
     /// V1 config for a low-latency environment.
     ///
     /// This config is guaranteed not to change in future releases of the Momento Rust SDK.
-    pub const V1: Configuration = Configuration {
-        transport_strategy: TransportStrategy {
-            grpc_configuration: GrpcConfiguration {
-                deadline_millis: Duration::from_millis(500),
-                keep_alive_while_idle: true,
-                keep_alive_interval: Duration::from_secs(5000),
-                keep_alive_timeout: Duration::from_secs(1000),
+    pub fn v1() -> Configuration {
+        Configuration {
+            transport_strategy: TransportStrategy {
+                grpc_configuration: GrpcConfigurationBuilder::new(Duration::from_millis(500))
+                    .with_keep_alive_while_idle(true)
+                    .with_keep_alive_interval(Duration::from_secs(5000))
+                    .with_keep_alive_timeout(Duration::from_secs(1000))
+                    .build(),
             },
-        },
-    };
+        }
+    }
 }
 
 /// Provides defaults suitable for a typical lambda environment. It has more aggressive timeouts
 /// than the laptop config and does not check connection health with a keep-alive.
 pub mod lambda {
-    use crate::config::configuration::Configuration;
-    use crate::config::grpc_configuration::GrpcConfiguration;
-    use crate::config::transport_strategy::TransportStrategy;
     use std::time::Duration;
+
+    use crate::config::configuration::Configuration;
+    use crate::config::grpc_configuration::GrpcConfigurationBuilder;
+    use crate::config::transport_strategy::TransportStrategy;
 
     /// Latest recommended config for a typical lambda environment.
     ///
     /// NOTE: this config may change in future releases to take advantage of improvements
     /// we identify for default configurations.
-    pub const LATEST: Configuration = V1;
+    pub fn latest() -> Configuration {
+        v1()
+    }
 
     /// V1 config for a typical lambda environment.
     ///
     /// This config is guaranteed not to change in future releases of the Momento Rust SDK.
-    pub const V1: Configuration = Configuration {
-        transport_strategy: TransportStrategy {
-            grpc_configuration: GrpcConfiguration {
-                deadline_millis: Duration::from_millis(1100),
-                keep_alive_while_idle: false,
-                keep_alive_interval: Duration::MAX,
-                keep_alive_timeout: Duration::MAX,
+    pub fn v1() -> Configuration {
+        Configuration {
+            transport_strategy: TransportStrategy {
+                grpc_configuration: GrpcConfigurationBuilder::new(Duration::from_millis(1100))
+                    .with_keep_alive_while_idle(false)
+                    .build(),
             },
-        },
-    };
+        }
+    }
 }

--- a/src/config/grpc_configuration.rs
+++ b/src/config/grpc_configuration.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 pub struct GrpcConfiguration {
     /// The duration the client is willing to wait for an RPC to complete before it is terminated
     /// with a DeadlineExceeded error.
-    pub deadline_millis: Duration,
+    pub deadline: Duration,
     /// Indicates whether the client should send keep-alive pings.
     ///
     /// NOTE: keep-alives are very important for long-lived server environments where there may be
@@ -20,4 +20,68 @@ pub struct GrpcConfiguration {
     /// The duration the client is willing to wait for a keep-alive ping to be acknowledged before
     /// closing the connection.
     pub keep_alive_timeout: Duration,
+}
+
+impl GrpcConfiguration {
+    pub fn new(
+        deadline_millis: Duration,
+        keep_alive_while_idle: bool,
+        keep_alive_interval: Duration,
+        keep_alive_timeout: Duration,
+    ) -> Self {
+        GrpcConfiguration {
+            deadline: deadline_millis,
+            keep_alive_while_idle,
+            keep_alive_interval,
+            keep_alive_timeout,
+        }
+    }
+}
+
+/// Builder for `GrpcConfiguration`.
+pub struct GrpcConfigurationBuilder {
+    deadline: Duration,
+    keep_alive_while_idle: bool,
+    keep_alive_interval: Duration,
+    keep_alive_timeout: Duration,
+}
+
+impl GrpcConfigurationBuilder {
+    pub fn new(deadline: Duration) -> Self {
+        GrpcConfigurationBuilder {
+            deadline,
+            keep_alive_while_idle: true,
+            keep_alive_interval: Duration::from_secs(5000),
+            keep_alive_timeout: Duration::from_secs(1000),
+        }
+    }
+
+    pub fn with_deadline(mut self, deadline: Duration) -> Self {
+        self.deadline = deadline;
+        self
+    }
+
+    pub fn with_keep_alive_while_idle(mut self, keep_alive_while_idle: bool) -> Self {
+        self.keep_alive_while_idle = keep_alive_while_idle;
+        self
+    }
+
+    pub fn with_keep_alive_interval(mut self, keep_alive_interval: Duration) -> Self {
+        self.keep_alive_interval = keep_alive_interval;
+        self
+    }
+
+    pub fn with_keep_alive_timeout(mut self, keep_alive_timeout: Duration) -> Self {
+        self.keep_alive_timeout = keep_alive_timeout;
+        self
+    }
+
+    pub fn build(self) -> GrpcConfiguration {
+        GrpcConfiguration {
+            deadline: self.deadline,
+            keep_alive_while_idle: self.keep_alive_while_idle,
+            keep_alive_interval: self.keep_alive_interval,
+            keep_alive_timeout: self.keep_alive_timeout,
+        }
+    }
 }

--- a/src/config/grpc_configuration.rs
+++ b/src/config/grpc_configuration.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 pub struct GrpcConfiguration {
     /// The duration the client is willing to wait for an RPC to complete before it is terminated
     /// with a DeadlineExceeded error.
-    pub deadline: Duration,
+    pub(crate) deadline: Duration,
     /// Indicates whether the client should send keep-alive pings.
     ///
     /// NOTE: keep-alives are very important for long-lived server environments where there may be
@@ -14,26 +14,21 @@ pub struct GrpcConfiguration {
     /// lambda may be frozen before the "ACK" is received from the server. This can cause the
     /// keep-alive to timeout even though the connection is completely healthy. Therefore,
     /// keep-alives should be disabled in lambda and similar environments.
-    pub keep_alive_while_idle: bool,
+    pub(crate) keep_alive_while_idle: bool,
     /// The interval at which keep-alive pings are sent.
-    pub keep_alive_interval: Duration,
+    pub(crate) keep_alive_interval: Duration,
     /// The duration the client is willing to wait for a keep-alive ping to be acknowledged before
     /// closing the connection.
-    pub keep_alive_timeout: Duration,
+    pub(crate) keep_alive_timeout: Duration,
 }
 
 impl GrpcConfiguration {
-    pub fn new(
-        deadline_millis: Duration,
-        keep_alive_while_idle: bool,
-        keep_alive_interval: Duration,
-        keep_alive_timeout: Duration,
-    ) -> Self {
-        GrpcConfiguration {
-            deadline: deadline_millis,
-            keep_alive_while_idle,
-            keep_alive_interval,
-            keep_alive_timeout,
+    pub fn builder(deadline: Duration) -> GrpcConfigurationBuilder {
+        GrpcConfigurationBuilder {
+            deadline,
+            keep_alive_while_idle: true,
+            keep_alive_interval: Duration::from_secs(5000),
+            keep_alive_timeout: Duration::from_secs(1000),
         }
     }
 }
@@ -47,15 +42,6 @@ pub struct GrpcConfigurationBuilder {
 }
 
 impl GrpcConfigurationBuilder {
-    pub fn new(deadline: Duration) -> Self {
-        GrpcConfigurationBuilder {
-            deadline,
-            keep_alive_while_idle: true,
-            keep_alive_interval: Duration::from_secs(5000),
-            keep_alive_timeout: Duration::from_secs(1000),
-        }
-    }
-
     pub fn with_deadline(mut self, deadline: Duration) -> Self {
         self.deadline = deadline;
         self

--- a/src/config/grpc_configuration.rs
+++ b/src/config/grpc_configuration.rs
@@ -1,0 +1,23 @@
+use std::time::Duration;
+
+/// Low-level gRPC settings for communicating with Momento.
+#[derive(Clone)]
+pub struct GrpcConfiguration {
+    /// The duration the client is willing to wait for an RPC to complete before it is terminated
+    /// with a DeadlineExceeded error.
+    pub deadline_millis: Duration,
+    /// Indicates whether the client should send keep-alive pings.
+    ///
+    /// NOTE: keep-alives are very important for long-lived server environments where there may be
+    /// periods of time when the connection is idle. However, they are very problematic for lambda
+    /// environments where the lambda runtime is continuously frozen and unfrozen, because the
+    /// lambda may be frozen before the "ACK" is received from the server. This can cause the
+    /// keep-alive to timeout even though the connection is completely healthy. Therefore,
+    /// keep-alives should be disabled in lambda and similar environments.
+    pub keep_alive_while_idle: bool,
+    /// The interval at which keep-alive pings are sent.
+    pub keep_alive_interval: Duration,
+    /// The duration the client is willing to wait for a keep-alive ping to be acknowledged before
+    /// closing the connection.
+    pub keep_alive_timeout: Duration,
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,8 @@
+/// Configuration for the Momento cache client.
+pub mod configuration;
+/// Pre-built configurations for the Momento cache client.
+pub mod configurations;
+/// Low-level gRPC settings for communicating with Momento.
+pub mod grpc_configuration;
+/// Low-level settings for communicating with Momento.
+pub mod transport_strategy;

--- a/src/config/transport_strategy.rs
+++ b/src/config/transport_strategy.rs
@@ -6,3 +6,9 @@ pub struct TransportStrategy {
     /// Low-level gRPC settings for communicating with Momento.
     pub grpc_configuration: GrpcConfiguration,
 }
+
+impl TransportStrategy {
+    pub fn new(grpc_configuration: GrpcConfiguration) -> Self {
+        TransportStrategy { grpc_configuration }
+    }
+}

--- a/src/config/transport_strategy.rs
+++ b/src/config/transport_strategy.rs
@@ -1,0 +1,8 @@
+use crate::config::grpc_configuration::GrpcConfiguration;
+
+/// Low-level settings for communicating with Momento.
+#[derive(Clone)]
+pub struct TransportStrategy {
+    /// Low-level gRPC settings for communicating with Momento.
+    pub grpc_configuration: GrpcConfiguration,
+}

--- a/src/config/transport_strategy.rs
+++ b/src/config/transport_strategy.rs
@@ -4,11 +4,28 @@ use crate::config::grpc_configuration::GrpcConfiguration;
 #[derive(Clone)]
 pub struct TransportStrategy {
     /// Low-level gRPC settings for communicating with Momento.
-    pub grpc_configuration: GrpcConfiguration,
+    pub(crate) grpc_configuration: GrpcConfiguration,
 }
 
 impl TransportStrategy {
-    pub fn new(grpc_configuration: GrpcConfiguration) -> Self {
-        TransportStrategy { grpc_configuration }
+    pub fn builder(grpc_configuration: GrpcConfiguration) -> TransportStrategyBuilder {
+        TransportStrategyBuilder { grpc_configuration }
+    }
+}
+
+pub struct TransportStrategyBuilder {
+    grpc_configuration: GrpcConfiguration,
+}
+
+impl TransportStrategyBuilder {
+    pub fn with_grpc_configuration(mut self, grpc_configuration: GrpcConfiguration) -> Self {
+        self.grpc_configuration = grpc_configuration;
+        self
+    }
+
+    pub fn build(self) -> TransportStrategy {
+        TransportStrategy {
+            grpc_configuration: self.grpc_configuration,
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod auth;
+/// Configuration structs for the Momento clients.
+pub mod config;
 pub mod preview;
 pub mod requests;
 pub mod response;

--- a/src/requests/cache/set_add_elements.rs
+++ b/src/requests/cache/set_add_elements.rs
@@ -1,6 +1,6 @@
 use crate::cache_client::CacheClient;
 use crate::requests::cache::MomentoRequest;
-use crate::simple_cache_client::prep_request;
+use crate::simple_cache_client::prep_request_with_timeout;
 use crate::{CollectionTtl, IntoBytes, MomentoResult};
 use momento_protos::cache_client::SetUnionRequest;
 
@@ -10,12 +10,13 @@ use momento_protos::cache_client::SetUnionRequest;
 /// use std::time::Duration;
 /// use momento::{CredentialProviderBuilder};
 /// use momento::requests::cache::set_add_elements::SetAddElements;
+/// use momento::config::configurations;
 ///
 /// let credential_provider = CredentialProviderBuilder::from_environment_variable("MOMENTO_API_KEY".to_string())
 ///     .build()?;
 /// let cache_name = "cache";
 ///
-/// let cache_client = momento::CacheClient::new(credential_provider, Duration::from_secs(5))?;
+/// let cache_client = momento::CacheClient::new(credential_provider, configurations::laptop::LATEST, Duration::from_secs(5))?;
 ///
 /// let set_add_elements_response = cache_client.set_add_elements(cache_name.to_string(), "set", vec!["element1", "element2"]).await?;
 /// assert_eq!(set_add_elements_response, SetAddElements {});
@@ -51,8 +52,9 @@ impl<S: IntoBytes, E: IntoBytes> MomentoRequest for SetAddElementsRequest<S, E> 
         let elements = self.elements.into_iter().map(|e| e.into_bytes()).collect();
         let set_name = self.set_name.into_bytes();
         let cache_name = &self.cache_name;
-        let request = prep_request(
+        let request = prep_request_with_timeout(
             cache_name,
+            cache_client.configuration.deadline_millis(),
             SetUnionRequest {
                 set_name,
                 elements,

--- a/src/requests/cache/set_add_elements.rs
+++ b/src/requests/cache/set_add_elements.rs
@@ -16,7 +16,7 @@ use momento_protos::cache_client::SetUnionRequest;
 ///     .build()?;
 /// let cache_name = "cache";
 ///
-/// let cache_client = momento::CacheClient::new(credential_provider, configurations::laptop::LATEST, Duration::from_secs(5))?;
+/// let cache_client = momento::CacheClient::new(credential_provider, configurations::laptop::latest(), Duration::from_secs(5))?;
 ///
 /// let set_add_elements_response = cache_client.set_add_elements(cache_name.to_string(), "set", vec!["element1", "element2"]).await?;
 /// assert_eq!(set_add_elements_response, SetAddElements {});

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -2714,6 +2714,19 @@ pub(crate) fn prep_request<R>(cache_name: &str, request: R) -> MomentoResult<ton
     Ok(request)
 }
 
+pub(crate) fn prep_request_with_timeout<R>(
+    cache_name: &str,
+    timeout: Duration,
+    request: R,
+) -> MomentoResult<Request<R>> {
+    utils::is_cache_name_valid(cache_name)?;
+
+    let mut request = Request::new(request);
+    request_meta_data(&mut request, cache_name)?;
+    request.set_timeout(timeout);
+    Ok(request)
+}
+
 /// An enum that is used to indicate if an operation should apply to all fields
 /// or just some fields of a dictionary.
 pub enum Fields<K> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,11 +86,17 @@ pub(crate) fn connect_channel_lazily_configurable(
     grpc_config: GrpcConfiguration,
 ) -> Result<Channel, ChannelConnectError> {
     let uri = Uri::try_from(uri_string)?;
-    let endpoint = Channel::builder(uri)
-        .keep_alive_while_idle(grpc_config.keep_alive_while_idle)
-        .http2_keep_alive_interval(grpc_config.keep_alive_interval)
-        .keep_alive_timeout(grpc_config.keep_alive_timeout)
-        .tls_config(ClientTlsConfig::default())?;
+    let endpoint = if grpc_config.keep_alive_while_idle {
+        Channel::builder(uri)
+            .keep_alive_while_idle(true)
+            .http2_keep_alive_interval(grpc_config.keep_alive_interval)
+            .keep_alive_timeout(grpc_config.keep_alive_timeout)
+            .tls_config(ClientTlsConfig::default())?
+    } else {
+        Channel::builder(uri)
+            .keep_alive_while_idle(false)
+            .tls_config(ClientTlsConfig::default())?
+    };
     Ok(endpoint.connect_lazy())
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,6 +4,7 @@ use tonic::{
     transport::{Channel, ClientTlsConfig, Uri},
 };
 
+use crate::config::grpc_configuration::GrpcConfiguration;
 use crate::response::MomentoError;
 use crate::MomentoResult;
 use std::convert::TryFrom;
@@ -76,6 +77,19 @@ pub(crate) fn connect_channel_lazily(uri_string: &str) -> Result<Channel, Channe
     let endpoint = Channel::builder(uri)
         .keep_alive_while_idle(true)
         .http2_keep_alive_interval(time::Duration::from_secs(30))
+        .tls_config(ClientTlsConfig::default())?;
+    Ok(endpoint.connect_lazy())
+}
+
+pub(crate) fn connect_channel_lazily_configurable(
+    uri_string: &str,
+    grpc_config: GrpcConfiguration,
+) -> Result<Channel, ChannelConnectError> {
+    let uri = Uri::try_from(uri_string)?;
+    let endpoint = Channel::builder(uri)
+        .keep_alive_while_idle(grpc_config.keep_alive_while_idle)
+        .http2_keep_alive_interval(grpc_config.keep_alive_interval)
+        .keep_alive_timeout(grpc_config.keep_alive_timeout)
         .tls_config(ClientTlsConfig::default())?;
     Ok(endpoint.connect_lazy())
 }


### PR DESCRIPTION
Add a nested configuration object in the style of the other SDKs.

Add pre-built configurations for different environments.

Plumb the config object into the client, connection, and existing call.