### PR TITLE
feat: Add sorted set put and fetch functions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,7 @@ jobs:
       - name: Cargo Check
         run: cargo check
       - name: Test Setup
+        # This script relies on dev dependencies such as Tokio, so we run it with the --example flag
         run: cargo run --example test-setup
       - name: Unit Tests
         run: cargo test --lib
@@ -59,7 +60,9 @@ jobs:
       - name: Integration Tests
         run: cargo test --tests
       - name: Test Teardown
+        # We want the teardown to execute even if an earlier step fails, hence the `always()` condition
         if: always()
+        # This script relies on dev dependencies such as Tokio, so we run it with the --example flag
         run: cargo run --example test-teardown
 
   rustfmt-build-examples:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,6 @@ jobs:
     runs-on: macos-latest
     env:
       MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
-      TEST_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       # TODO: get rid of this once everything has been migrated to MOMENTO_API_KEY
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  TEST_CACHE_NAME: rust-integration-test-ci-${{ github.sha }}
 
 jobs:
   rustfmt:
@@ -33,6 +34,7 @@ jobs:
     runs-on: macos-latest
     env:
       MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      TEST_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       # TODO: get rid of this once everything has been migrated to MOMENTO_API_KEY
       TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
 
@@ -48,12 +50,17 @@ jobs:
         run: cargo build --verbose
       - name: Cargo Check
         run: cargo check
+      - name: Test Setup
+        run: cargo run --example test-setup
       - name: Unit Tests
         run: cargo test --lib
       - name: Doc Tests
         run: cargo test --doc
       - name: Integration Tests
         run: cargo test --tests
+      - name: Test Teardown
+        if: always()
+        run: cargo run --example test-teardown
 
   rustfmt-build-examples:
     name: Style & Lint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,25 @@ homepage = "https://gomomento.com/"
 
 [workspace]
 members = [
-  ".",
-  "test-util"
+    ".",
+    "test-util"
 ]
 
-exclude = [ "example" ]
+# This is marked as an example so it can access dev-dependencies
+[[example]]
+name = "test-setup"
+path = "scripts/test-setup.rs"
+test = false
+doc = false
+
+# This is marked as an example so it can access dev-dependencies
+[[example]]
+name = "test-teardown"
+path = "scripts/test-teardown.rs"
+test = false
+doc = false
+
+exclude = ["example"]
 
 [dependencies]
 momento-protos = { version = "0.84.1" }
@@ -25,7 +39,7 @@ h2 = { version = "0.3" }
 tonic = { version = "0.10", features = ["tls", "tls-roots", "tls-webpki-roots"] }
 jsonwebtoken = "8.3"
 rand = "0.8.5"
-serde = {version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 base64 = "0.21"
@@ -41,3 +55,4 @@ uuid = { version = "1", features = ["v4"] }
 futures = "0"
 anyhow = "1"
 momento-test-util = { path = "test-util" }
+once_cell = "1.19.0"

--- a/scripts/test-setup.rs
+++ b/scripts/test-setup.rs
@@ -1,8 +1,6 @@
 use std::env;
 use std::time::Duration;
 
-use tokio;
-
 use momento::config::configurations;
 use momento::{CacheClient, CredentialProviderBuilder};
 

--- a/scripts/test-setup.rs
+++ b/scripts/test-setup.rs
@@ -1,8 +1,7 @@
-use std::env;
 use std::time::Duration;
 
 use momento::config::configurations;
-use momento::{CacheClient, CredentialProviderBuilder};
+use momento::{CacheClient};
 use momento_test_util::{get_test_cache_name, get_test_credential_provider};
 
 #[tokio::main]

--- a/scripts/test-setup.rs
+++ b/scripts/test-setup.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use momento::config::configurations;
-use momento::{CacheClient};
+use momento::CacheClient;
 use momento_test_util::{get_test_cache_name, get_test_credential_provider};
 
 #[tokio::main]

--- a/scripts/test-setup.rs
+++ b/scripts/test-setup.rs
@@ -1,0 +1,31 @@
+use std::env;
+use std::time::Duration;
+
+use tokio;
+
+use momento::config::configurations;
+use momento::{CacheClient, CredentialProviderBuilder};
+
+#[tokio::main]
+async fn main() {
+    let cache_name =
+        env::var("TEST_CACHE_NAME").expect("environment variable TEST_CACHE_NAME should be set");
+
+    let credential_provider =
+        CredentialProviderBuilder::from_environment_variable("TEST_API_KEY".to_string())
+            .build()
+            .expect("auth token should be valid");
+
+    let cache_client = CacheClient::new(
+        credential_provider,
+        configurations::laptop::latest(),
+        Duration::from_secs(5),
+    )
+    .expect("cache client cannot be created");
+
+    println!("Creating cache {}", cache_name.clone());
+    cache_client
+        .create_cache(cache_name.clone())
+        .await
+        .expect("cache cannot be created");
+}

--- a/scripts/test-setup.rs
+++ b/scripts/test-setup.rs
@@ -3,16 +3,13 @@ use std::time::Duration;
 
 use momento::config::configurations;
 use momento::{CacheClient, CredentialProviderBuilder};
+use momento_test_util::{get_test_cache_name, get_test_credential_provider};
 
 #[tokio::main]
 async fn main() {
-    let cache_name =
-        env::var("TEST_CACHE_NAME").expect("environment variable TEST_CACHE_NAME should be set");
+    let cache_name = get_test_cache_name();
 
-    let credential_provider =
-        CredentialProviderBuilder::from_environment_variable("TEST_API_KEY".to_string())
-            .build()
-            .expect("auth token should be valid");
+    let credential_provider = get_test_credential_provider();
 
     let cache_client = CacheClient::new(
         credential_provider,

--- a/scripts/test-teardown.rs
+++ b/scripts/test-teardown.rs
@@ -1,8 +1,6 @@
 use std::env;
 use std::time::Duration;
 
-use tokio;
-
 use momento::config::configurations;
 use momento::{CacheClient, CredentialProviderBuilder};
 

--- a/scripts/test-teardown.rs
+++ b/scripts/test-teardown.rs
@@ -1,8 +1,7 @@
-use std::env;
 use std::time::Duration;
 
 use momento::config::configurations;
-use momento::{CacheClient, CredentialProviderBuilder};
+use momento::{CacheClient};
 use momento_test_util::{get_test_cache_name, get_test_credential_provider};
 
 #[tokio::main]

--- a/scripts/test-teardown.rs
+++ b/scripts/test-teardown.rs
@@ -1,0 +1,31 @@
+use std::env;
+use std::time::Duration;
+
+use tokio;
+
+use momento::config::configurations;
+use momento::{CacheClient, CredentialProviderBuilder};
+
+#[tokio::main]
+async fn main() {
+    let cache_name =
+        env::var("TEST_CACHE_NAME").expect("environment variable TEST_CACHE_NAME should be set");
+
+    let credential_provider =
+        CredentialProviderBuilder::from_environment_variable("TEST_API_KEY".to_string())
+            .build()
+            .expect("auth token should be valid");
+
+    let cache_client = CacheClient::new(
+        credential_provider,
+        configurations::laptop::latest(),
+        Duration::from_secs(5),
+    )
+    .expect("cache client cannot be created");
+
+    println!("Deleting cache {}", cache_name.clone());
+    cache_client
+        .delete_cache(cache_name.clone())
+        .await
+        .expect("cache cannot be deleted");
+}

--- a/scripts/test-teardown.rs
+++ b/scripts/test-teardown.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use momento::config::configurations;
-use momento::{CacheClient};
+use momento::CacheClient;
 use momento_test_util::{get_test_cache_name, get_test_credential_provider};
 
 #[tokio::main]

--- a/scripts/test-teardown.rs
+++ b/scripts/test-teardown.rs
@@ -3,16 +3,12 @@ use std::time::Duration;
 
 use momento::config::configurations;
 use momento::{CacheClient, CredentialProviderBuilder};
+use momento_test_util::{get_test_cache_name, get_test_credential_provider};
 
 #[tokio::main]
 async fn main() {
-    let cache_name =
-        env::var("TEST_CACHE_NAME").expect("environment variable TEST_CACHE_NAME should be set");
-
-    let credential_provider =
-        CredentialProviderBuilder::from_environment_variable("TEST_API_KEY".to_string())
-            .build()
-            .expect("auth token should be valid");
+    let cache_name = get_test_cache_name();
+    let credential_provider = get_test_credential_provider();
 
     let cache_client = CacheClient::new(
         credential_provider,

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -181,6 +181,7 @@ impl CacheClient {
     ///
     /// let set_add_elements_response = cache_client.set_add_elements(cache_name.to_string(), "set", vec!["element1", "element2"]).await?;
     /// assert_eq!(set_add_elements_response, SetAddElements {});
+    /// assert_eq!(true, false);
     /// # Ok(())
     /// # })
     /// #

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -1,17 +1,33 @@
-use crate::config::configuration::Configuration;
-use crate::grpc::header_interceptor::HeaderInterceptor;
-use crate::requests::cache::set_add_elements::{SetAddElements, SetAddElementsRequest};
-use crate::requests::cache::MomentoRequest;
-use crate::utils::user_agent;
-use crate::{utils, CredentialProvider, IntoBytes, MomentoResult};
-use momento_protos::cache_client::scs_client::ScsClient;
 use std::convert::TryInto;
 use std::time::Duration;
+
+use momento_protos::cache_client::scs_client::ScsClient;
+use momento_protos::control_client::scs_control_client::ScsControlClient;
 use tonic::codegen::InterceptedService;
 use tonic::transport::Channel;
 
+use crate::config::configuration::Configuration;
+use crate::grpc::header_interceptor::HeaderInterceptor;
+use crate::requests::cache::create_cache::{CreateCache, CreateCacheRequest};
+use crate::requests::cache::delete_cache::{DeleteCache, DeleteCacheRequest};
+use crate::requests::cache::set_add_elements::{SetAddElements, SetAddElementsRequest};
+use crate::requests::cache::sorted_set_fetch_by_rank::{SortOrder, SortedSetFetchByRankRequest};
+use crate::requests::cache::sorted_set_fetch_by_score::SortedSetFetchByScoreRequest;
+use crate::requests::cache::sorted_set_put_element::{
+    SortedSetPutElement, SortedSetPutElementRequest,
+};
+use crate::requests::cache::sorted_set_put_elements::{
+    SortedSetPutElements, SortedSetPutElementsRequest,
+};
+use crate::requests::cache::MomentoRequest;
+use crate::response::cache::sorted_set_fetch::SortedSetFetch;
+use crate::utils::user_agent;
+use crate::{utils, CredentialProvider, IntoBytes, MomentoResult};
+
+#[derive(Clone)]
 pub struct CacheClient {
     pub(crate) data_client: ScsClient<InterceptedService<Channel, HeaderInterceptor>>,
+    pub(crate) control_client: ScsControlClient<InterceptedService<Channel, HeaderInterceptor>>,
     pub(crate) configuration: Configuration,
     item_default_ttl: Duration,
 }
@@ -23,24 +39,48 @@ impl CacheClient {
         configuration: Configuration,
         default_ttl: Duration,
     ) -> MomentoResult<Self> {
+        let agent_value = &user_agent("sdk");
+
         let data_channel = utils::connect_channel_lazily_configurable(
             &credential_provider.cache_endpoint,
+            configuration.transport_strategy.grpc_configuration.clone(),
+        )?;
+        let control_channel = utils::connect_channel_lazily_configurable(
+            &credential_provider.control_endpoint,
             configuration.transport_strategy.grpc_configuration.clone(),
         )?;
 
         let data_interceptor = InterceptedService::new(
             data_channel,
-            HeaderInterceptor::new(&credential_provider.auth_token, &user_agent("sdk")),
+            HeaderInterceptor::new(&credential_provider.auth_token, &agent_value),
         );
+        let control_interceptor = InterceptedService::new(
+            control_channel,
+            HeaderInterceptor::new(&credential_provider.auth_token, &agent_value),
+        );
+
         let data_client = ScsClient::new(data_interceptor);
+        let control_client = ScsControlClient::new(control_interceptor);
+
         Ok(CacheClient {
             data_client,
+            control_client,
             configuration,
             item_default_ttl: default_ttl,
         })
     }
 
     /* public API */
+
+    pub async fn create_cache(&self, cache_name: String) -> MomentoResult<CreateCache> {
+        let request = CreateCacheRequest::new(cache_name);
+        request.send(self).await
+    }
+
+    pub async fn delete_cache(&self, cache_name: String) -> MomentoResult<DeleteCache> {
+        let request = DeleteCacheRequest::new(cache_name);
+        request.send(self).await
+    }
 
     /// ```
     /// # fn main() -> anyhow::Result<()> {
@@ -68,13 +108,56 @@ impl CacheClient {
     /// }
     /// ```
     pub async fn set_add_elements<E: IntoBytes>(
-        self,
+        &self,
         cache_name: String,
         set_name: impl IntoBytes,
         elements: Vec<E>,
     ) -> MomentoResult<SetAddElements> {
         let request = SetAddElementsRequest::new(cache_name, set_name, elements);
-        request.send(&self).await
+        request.send(self).await
+    }
+
+    pub async fn sorted_set_put_element<E: IntoBytes>(
+        &self,
+        cache_name: String,
+        sorted_set_name: impl IntoBytes,
+        value: E,
+        score: f64,
+    ) -> MomentoResult<SortedSetPutElement> {
+        let request = SortedSetPutElementRequest::new(cache_name, sorted_set_name, value, score);
+        request.send(self).await
+    }
+
+    pub async fn sorted_set_put_elements<E: IntoBytes>(
+        &self,
+        cache_name: String,
+        sorted_set_name: impl IntoBytes,
+        elements: Vec<(E, f64)>,
+    ) -> MomentoResult<SortedSetPutElements> {
+        let request = SortedSetPutElementsRequest::new(cache_name, sorted_set_name, elements);
+        request.send(self).await
+    }
+
+    pub async fn sorted_set_fetch_by_rank<S: IntoBytes>(
+        &self,
+        cache_name: String,
+        sorted_set_name: S,
+        order: SortOrder,
+    ) -> MomentoResult<SortedSetFetch> {
+        let request =
+            SortedSetFetchByRankRequest::new(cache_name, sorted_set_name).with_order(order);
+        request.send(self).await
+    }
+
+    pub async fn sorted_set_fetch_by_score<S: IntoBytes>(
+        &self,
+        cache_name: String,
+        sorted_set_name: S,
+        order: SortOrder,
+    ) -> MomentoResult<SortedSetFetch> {
+        let request =
+            SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name).with_order(order);
+        request.send(self).await
     }
 
     /// ```
@@ -106,8 +189,8 @@ impl CacheClient {
     /// #
     /// }
     /// ```
-    pub async fn send_request<R: MomentoRequest>(self, request: R) -> MomentoResult<R::Response> {
-        request.send(&self).await
+    pub async fn send_request<R: MomentoRequest>(&self, request: R) -> MomentoResult<R::Response> {
+        request.send(self).await
     }
 
     /* helper fns */

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -181,7 +181,6 @@ impl CacheClient {
     ///
     /// let set_add_elements_response = cache_client.set_add_elements(cache_name.to_string(), "set", vec!["element1", "element2"]).await?;
     /// assert_eq!(set_add_elements_response, SetAddElements {});
-    /// assert_eq!(true, false);
     /// # Ok(())
     /// # })
     /// #

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -52,11 +52,11 @@ impl CacheClient {
 
         let data_interceptor = InterceptedService::new(
             data_channel,
-            HeaderInterceptor::new(&credential_provider.auth_token, &agent_value),
+            HeaderInterceptor::new(&credential_provider.auth_token, agent_value),
         );
         let control_interceptor = InterceptedService::new(
             control_channel,
-            HeaderInterceptor::new(&credential_provider.auth_token, &agent_value),
+            HeaderInterceptor::new(&credential_provider.auth_token, agent_value),
         );
 
         let data_client = ScsClient::new(data_interceptor);

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -24,6 +24,7 @@ use crate::response::cache::sorted_set_fetch::SortedSetFetch;
 use crate::utils::user_agent;
 use crate::{utils, CredentialProvider, IntoBytes, MomentoResult};
 
+/// Client to perform operations on a Momento cache.
 #[derive(Clone)]
 pub struct CacheClient {
     pub(crate) data_client: ScsClient<InterceptedService<Channel, HeaderInterceptor>>,
@@ -72,11 +73,89 @@ impl CacheClient {
 
     /* public API */
 
+    /// Creates a cache with the given name.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the cache to be created.
+    ///
+    /// # Examples
+    /// Assumes that a CacheClient named `cache_client` has been created and is available.
+    /// ```no_run
+    /// # fn main() -> anyhow::Result<()> {
+    /// # use momento_test_util::create_doctest_client;
+    /// # tokio_test::block_on(async {
+    /// use momento::requests::cache::create_cache::CreateCache;
+    /// # let (cache_client, cache_name) = create_doctest_client();
+    ///
+    /// let create_cache_response = cache_client.create_cache(cache_name.to_string()).await?;
+    ///
+    /// assert_eq!(create_cache_response, CreateCache {});
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
+    /// You can also use the [send_request](CacheClient::send_request) method to create a cache using a [CreateCacheRequest]:
+    /// ```no_run
+    /// # fn main() -> anyhow::Result<()> {
+    /// # use momento_test_util::create_doctest_client;
+    /// # tokio_test::block_on(async {
+    /// use momento::requests::cache::create_cache::CreateCache;
+    /// use momento::requests::cache::create_cache::CreateCacheRequest;
+    /// # let (cache_client, cache_name) = create_doctest_client();
+    ///
+    /// let create_cache_request = CreateCacheRequest::new(cache_name.to_string());
+    ///
+    /// let create_cache_response = cache_client.send_request(create_cache_request).await?;
+    ///
+    /// assert_eq!(create_cache_response, CreateCache {});
+    /// # Ok(())
+    /// # })
+    /// # }
     pub async fn create_cache(&self, cache_name: String) -> MomentoResult<CreateCache> {
         let request = CreateCacheRequest::new(cache_name);
         request.send(self).await
     }
 
+    /// Deletes the cache with the given name.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the cache to be deleted.
+    ///
+    /// # Examples
+    /// Assumes that a CacheClient named `cache_client` has been created and is available.
+    /// ```no_run
+    /// # fn main() -> anyhow::Result<()> {
+    /// # use momento_test_util::create_doctest_client;
+    /// # tokio_test::block_on(async {
+    /// use momento::requests::cache::delete_cache::DeleteCache;
+    /// # let (cache_client, cache_name) = create_doctest_client();
+    ///
+    /// let delete_cache_response = cache_client.delete_cache(cache_name.to_string()).await?;
+    ///
+    /// assert_eq!(delete_cache_response, DeleteCache {});
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
+    /// You can also use the [send_request](CacheClient::send_request) method to delete a cache using a [DeleteCacheRequest]:
+    /// ```no_run
+    /// # fn main() -> anyhow::Result<()> {
+    /// # use momento_test_util::create_doctest_client;
+    /// # tokio_test::block_on(async {
+    /// use momento::requests::cache::delete_cache::DeleteCache;
+    /// use momento::requests::cache::delete_cache::DeleteCacheRequest;
+    /// # let (cache_client, cache_name) = create_doctest_client();
+    ///
+    /// let delete_cache_request = DeleteCacheRequest::new(cache_name.to_string());
+    ///
+    /// let delete_cache_response = cache_client.send_request(delete_cache_request).await?;
+    ///
+    /// assert_eq!(delete_cache_response, DeleteCache {});
+    /// # Ok(())
+    /// # })
+    /// # }
     pub async fn delete_cache(&self, cache_name: String) -> MomentoResult<DeleteCache> {
         let request = DeleteCacheRequest::new(cache_name);
         request.send(self).await
@@ -117,6 +196,68 @@ impl CacheClient {
         request.send(self).await
     }
 
+    /// Adds an element to the given sorted set. If the element already exists, its score is updated.
+    /// Creates the sorted set if it does not exist.
+    ///
+    /// # Arguments
+    ///
+    /// * `cache_name` - The name of the cache containing the sorted set.
+    /// * `sorted_set_name` - The name of the sorted set to add an element to.
+    /// * `value` - The value of the element to add. Must be able to be converted to a Vec<u8>.
+    /// * `score` - The score of the element to add.
+    ///
+    /// # Optional Arguments
+    /// If you use [send_request](CacheClient::send_request) to add an element using a
+    /// [SortedSetPutElementRequest], you can also provide the following optional arguments:
+    ///
+    /// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
+    ///
+    /// # Examples
+    /// Assumes that a CacheClient named `cache_client` has been created and is available.
+    /// ```
+    /// # fn main() -> anyhow::Result<()> {
+    /// # use momento_test_util::create_doctest_client;
+    /// # tokio_test::block_on(async {
+    /// use momento::requests::cache::sorted_set_put_element::SortedSetPutElement;
+    /// # let (cache_client, cache_name) = create_doctest_client();
+    /// let sorted_set_name = "sorted_set";
+    ///
+    /// let put_element_response = cache_client.sorted_set_put_element(
+    ///     cache_name.to_string(),
+    ///     sorted_set_name.to_string(),
+    ///     "value",
+    ///     1.0
+    /// ).await?;
+    ///
+    /// assert_eq!(put_element_response, SortedSetPutElement {});
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
+    /// You can also use the [send_request](CacheClient::send_request) method to create a cache using a [SortedSetPutElementRequest]:
+    /// ```
+    /// # fn main() -> anyhow::Result<()> {
+    /// # use momento_test_util::create_doctest_client;
+    /// # tokio_test::block_on(async {
+    /// use momento::CollectionTtl;
+    /// use momento::requests::cache::sorted_set_put_element::SortedSetPutElement;
+    /// use momento::requests::cache::sorted_set_put_element::SortedSetPutElementRequest;
+    /// # let (cache_client, cache_name) = create_doctest_client();
+    /// let sorted_set_name = "sorted_set";
+    ///
+    /// let put_element_request = SortedSetPutElementRequest::new(
+    ///     cache_name.to_string(),
+    ///     sorted_set_name.to_string(),
+    ///     "value",
+    ///     1.0
+    /// ).with_ttl(CollectionTtl::default());
+    ///
+    /// let put_element_response = cache_client.send_request(put_element_request).await?;
+    ///
+    /// assert_eq!(put_element_response, SortedSetPutElement {});
+    /// # Ok(())
+    /// # })
+    /// # }
     pub async fn sorted_set_put_element<E: IntoBytes>(
         &self,
         cache_name: String,
@@ -128,6 +269,65 @@ impl CacheClient {
         request.send(self).await
     }
 
+    /// Adds elements to the given sorted set. If an element already exists, its score is updated.
+    /// Creates the sorted set if it does not exist.
+    ///
+    /// # Arguments
+    ///
+    /// * `cache_name` - The name of the cache containing the sorted set.
+    /// * `sorted_set_name` - The name of the sorted set to add an element to.
+    /// * `elements` - The values and scores to add. The values must be able to be converted to a Vec<u8>.
+    ///
+    /// # Optional Arguments
+    /// If you use [send_request](CacheClient::send_request) to add elements using a
+    /// [SortedSetPutElementsRequest], you can also provide the following optional arguments:
+    ///
+    /// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
+    ///
+    /// # Examples
+    /// Assumes that a CacheClient named `cache_client` has been created and is available.
+    /// ```
+    /// # fn main() -> anyhow::Result<()> {
+    /// # use momento_test_util::create_doctest_client;
+    /// # tokio_test::block_on(async {
+    /// use momento::requests::cache::sorted_set_put_elements::SortedSetPutElements;
+    /// # let (cache_client, cache_name) = create_doctest_client();
+    /// let sorted_set_name = "sorted_set";
+    ///
+    /// let put_element_response = cache_client.sorted_set_put_elements(
+    ///     cache_name.to_string(),
+    ///     sorted_set_name.to_string(),
+    ///     vec![("value1", 1.0), ("value2", 2.0)]
+    /// ).await?;
+    ///
+    /// assert_eq!(put_element_response, SortedSetPutElements {});
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
+    /// You can also use the [send_request](CacheClient::send_request) method to create a cache using a [SortedSetPutElementsRequest]:
+    /// ```
+    /// # fn main() -> anyhow::Result<()> {
+    /// # use momento_test_util::create_doctest_client;
+    /// # tokio_test::block_on(async {
+    /// use momento::CollectionTtl;
+    /// use momento::requests::cache::sorted_set_put_elements::SortedSetPutElements;
+    /// use momento::requests::cache::sorted_set_put_elements::SortedSetPutElementsRequest;
+    /// # let (cache_client, cache_name) = create_doctest_client();
+    /// let sorted_set_name = "sorted_set";
+    ///
+    /// let put_elements_request = SortedSetPutElementsRequest::new(
+    ///     cache_name.to_string(),
+    ///     sorted_set_name.to_string(),
+    ///     vec![("value1", 1.0), ("value2", 2.0)]
+    /// ).with_ttl(CollectionTtl::default());
+    ///
+    /// let put_elements_response = cache_client.send_request(put_elements_request).await?;
+    ///
+    /// assert_eq!(put_elements_response, SortedSetPutElements {});
+    /// # Ok(())
+    /// # })
+    /// # }
     pub async fn sorted_set_put_elements<E: IntoBytes>(
         &self,
         cache_name: String,
@@ -138,6 +338,90 @@ impl CacheClient {
         request.send(self).await
     }
 
+    /// Fetch the elements in the given sorted set by their rank.
+    ///
+    /// # Arguments
+    ///
+    /// * `cache_name` - The name of the cache containing the sorted set.
+    /// * `sorted_set_name` - The name of the sorted set to add an element to.
+    /// * `order` - The order to sort the elements by. [SortOrder::Ascending] or [SortOrder::Descending].
+    ///
+    /// # Optional Arguments
+    /// If you use [send_request](CacheClient::send_request) to fetch elements using a
+    /// [SortedSetFetchByRankRequest], you can also provide the following optional arguments:
+    ///
+    /// * `start_rank` - The rank of the first element to fetch. Defaults to 0. This rank is
+    /// inclusive, i.e. the element at this rank will be fetched.
+    /// * `end_rank` - The rank of the last element to fetch. This rank is exclusive, i.e. the
+    /// element at this rank will not be fetched. Defaults to -1, which fetches up until and
+    /// including the last element.
+    ///
+    /// # Examples
+    /// Assumes that a CacheClient named `cache_client` has been created and is available.
+    /// ```
+    /// # fn main() -> anyhow::Result<()> {
+    /// # use momento::MomentoResult;
+    /// # use momento_test_util::create_doctest_client;
+    /// # tokio_test::block_on(async {
+    /// use momento::requests::cache::sorted_set_fetch_by_rank::SortOrder;
+    /// use momento::response::cache::sorted_set_fetch::SortedSetFetch;
+    /// # let (cache_client, cache_name) = create_doctest_client();
+    /// let sorted_set_name = "sorted_set";
+    ///
+    /// let fetch_response = cache_client.sorted_set_fetch_by_rank(
+    ///     cache_name.to_string(),
+    ///     sorted_set_name.to_string(),
+    ///     SortOrder::Ascending
+    /// ).await?;
+    ///
+    /// match fetch_response {
+    ///     SortedSetFetch::Hit{ elements } => {
+    ///         match elements.into_strings() {
+    ///             Ok(vec) => {
+    ///                 println!("{:?}", vec);
+    ///             }
+    ///             Err(error) => {
+    ///                 eprintln!("Error: {}", error);
+    ///             }
+    ///         }
+    ///     }
+    ///     SortedSetFetch::Miss => {}
+    /// }
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
+    /// You can also use the [send_request](CacheClient::send_request) method to create a cache using a [SortedSetFetchByRankRequest]:
+    /// ```
+    /// # fn main() -> anyhow::Result<()> {
+    /// # use std::convert::TryInto;
+    /// # use momento_test_util::create_doctest_client;
+    /// # tokio_test::block_on(async {
+    /// use momento::requests::cache::sorted_set_fetch_by_rank::SortOrder;
+    /// use momento::requests::cache::sorted_set_fetch_by_rank::SortedSetFetchByRankRequest;
+    /// use momento::response::cache::sorted_set_fetch::SortedSetFetch;
+    /// # let (cache_client, cache_name) = create_doctest_client();
+    /// let sorted_set_name = "sorted_set";
+    ///
+    /// let put_element_response = cache_client.sorted_set_put_elements(
+    ///     cache_name.to_string(),
+    ///     sorted_set_name.to_string(),
+    ///     vec![("value1", 1.0), ("value2", 2.0), ("value3", 3.0), ("value4", 4.0)]
+    /// ).await?;
+    ///
+    /// let fetch_request = SortedSetFetchByRankRequest::new(cache_name, sorted_set_name)
+    ///     .with_order(SortOrder::Ascending)
+    ///     .with_start_rank(1)
+    ///     .with_end_rank(3);
+    ///
+    /// let fetch_response = cache_client.send_request(fetch_request).await?;
+    ///
+    /// let returned_elements: Vec<(String, f64)> = fetch_response.try_into()
+    ///     .expect("elements 2 and 3 should be returned");
+    /// println!("{:?}", returned_elements);
+    /// # Ok(())
+    /// # })
+    /// # }
     pub async fn sorted_set_fetch_by_rank<S: IntoBytes>(
         &self,
         cache_name: String,
@@ -149,6 +433,93 @@ impl CacheClient {
         request.send(self).await
     }
 
+    /// Fetch the elements in the given sorted set by their score.
+    ///
+    /// # Arguments
+    ///
+    /// * `cache_name` - The name of the cache containing the sorted set.
+    /// * `sorted_set_name` - The name of the sorted set to add an element to.
+    /// * `order` - The order to sort the elements by. [SortOrder::Ascending] or [SortOrder::Descending].
+    ///
+    /// # Optional Arguments
+    /// If you use [send_request](CacheClient::send_request) to fetch elements using a
+    /// [SortedSetFetchByScoreRequest], you can also provide the following optional arguments:
+    ///
+    /// * `min_score` - The minimum score (inclusive) of the elements to fetch. Defaults to negative
+    /// infinity.
+    /// * `max_score` - The maximum score (inclusive) of the elements to fetch. Defaults to positive
+    /// infinity.
+    /// * `offset` - The number of elements to skip before returning the first element. Defaults to
+    /// 0. Note: this is not the rank of the first element to return, but the number of elements of
+    /// the result set to skip before returning the first element.
+    /// * `count` - The maximum number of elements to return. Defaults to all elements.
+    ///
+    /// # Examples
+    /// Assumes that a CacheClient named `cache_client` has been created and is available.
+    /// ```
+    /// # fn main() -> anyhow::Result<()> {
+    /// # use momento::MomentoResult;
+    /// # use momento_test_util::create_doctest_client;
+    /// # tokio_test::block_on(async {
+    /// use momento::requests::cache::sorted_set_fetch_by_rank::SortOrder;
+    /// use momento::response::cache::sorted_set_fetch::SortedSetFetch;
+    /// # let (cache_client, cache_name) = create_doctest_client();
+    /// let sorted_set_name = "sorted_set";
+    ///
+    /// let fetch_response = cache_client.sorted_set_fetch_by_score(
+    ///     cache_name.to_string(),
+    ///     sorted_set_name.to_string(),
+    ///     SortOrder::Ascending
+    /// ).await?;
+    ///
+    /// match fetch_response {
+    ///     SortedSetFetch::Hit{ elements } => {
+    ///         match elements.into_strings() {
+    ///             Ok(vec) => {
+    ///                 println!("{:?}", vec);
+    ///             }
+    ///             Err(error) => {
+    ///                 eprintln!("Error: {}", error);
+    ///             }
+    ///         }
+    ///     }
+    ///     SortedSetFetch::Miss => {}
+    /// }
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
+    /// You can also use the [send_request](CacheClient::send_request) method to create a cache using a [SortedSetFetchByScoreRequest]:
+    /// ```
+    /// # fn main() -> anyhow::Result<()> {
+    /// # use std::convert::TryInto;
+    /// # use momento_test_util::create_doctest_client;
+    /// # tokio_test::block_on(async {
+    /// use momento::requests::cache::sorted_set_fetch_by_rank::SortOrder;
+    /// use momento::requests::cache::sorted_set_fetch_by_score::SortedSetFetchByScoreRequest;
+    /// use momento::response::cache::sorted_set_fetch::SortedSetFetch;
+    /// # let (cache_client, cache_name) = create_doctest_client();
+    /// let sorted_set_name = "sorted_set";
+    ///
+    /// let put_element_response = cache_client.sorted_set_put_elements(
+    ///     cache_name.to_string(),
+    ///     sorted_set_name.to_string(),
+    ///     vec![("value1", 1.0), ("value2", 2.0), ("value3", 3.0), ("value4", 4.0)]
+    /// ).await?;
+    ///
+    /// let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
+    ///     .with_order(SortOrder::Ascending)
+    ///     .with_min_score(2.0)
+    ///     .with_max_score(3.0);
+    ///
+    /// let fetch_response = cache_client.send_request(fetch_request).await?;
+    ///
+    /// let returned_elements: Vec<(String, f64)> = fetch_response.try_into()
+    ///     .expect("elements 2 and 3 should be returned");
+    /// println!("{:?}", returned_elements);
+    /// # Ok(())
+    /// # })
+    /// # }
     pub async fn sorted_set_fetch_by_score<S: IntoBytes>(
         &self,
         cache_name: String,

--- a/src/requests/cache/create_cache.rs
+++ b/src/requests/cache/create_cache.rs
@@ -4,6 +4,30 @@ use tonic::Request;
 use crate::requests::cache::MomentoRequest;
 use crate::{utils, CacheClient, MomentoResult};
 
+/// Request to create a cache.
+///
+/// # Arguments
+///
+/// * `cache_name` - The name of the cache to create.
+///
+/// # Example
+/// Assumes that a CacheClient named `cache_client` has been created and is available.
+/// ```no_run
+/// # fn main() -> anyhow::Result<()> {
+/// # use momento_test_util::create_doctest_client;
+/// # tokio_test::block_on(async {
+/// use momento::requests::cache::create_cache::CreateCache;
+/// use momento::requests::cache::create_cache::CreateCacheRequest;
+/// # let (cache_client, cache_name) = create_doctest_client();
+///
+/// let create_cache_request = CreateCacheRequest::new(cache_name.to_string());
+///
+/// let create_cache_response = cache_client.send_request(create_cache_request).await?;
+///
+/// assert_eq!(create_cache_response, CreateCache {});
+/// # Ok(())
+/// # })
+/// # }
 pub struct CreateCacheRequest {
     pub cache_name: String,
 }
@@ -34,4 +58,5 @@ impl MomentoRequest for CreateCacheRequest {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct CreateCache {}

--- a/src/requests/cache/create_cache.rs
+++ b/src/requests/cache/create_cache.rs
@@ -1,0 +1,37 @@
+use momento_protos::control_client;
+use tonic::Request;
+
+use crate::requests::cache::MomentoRequest;
+use crate::{utils, CacheClient, MomentoResult};
+
+pub struct CreateCacheRequest {
+    pub cache_name: String,
+}
+
+impl CreateCacheRequest {
+    pub fn new(cache_name: String) -> Self {
+        CreateCacheRequest { cache_name }
+    }
+}
+
+impl MomentoRequest for CreateCacheRequest {
+    type Response = CreateCache;
+
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<CreateCache> {
+        let cache_name = &self.cache_name;
+
+        utils::is_cache_name_valid(cache_name)?;
+        let request = Request::new(control_client::CreateCacheRequest {
+            cache_name: cache_name.to_string(),
+        });
+
+        let _ = cache_client
+            .control_client
+            .clone()
+            .create_cache(request)
+            .await?;
+        Ok(CreateCache {})
+    }
+}
+
+pub struct CreateCache {}

--- a/src/requests/cache/delete_cache.rs
+++ b/src/requests/cache/delete_cache.rs
@@ -4,6 +4,30 @@ use tonic::Request;
 use crate::requests::cache::MomentoRequest;
 use crate::{utils, CacheClient, MomentoResult};
 
+/// Request to delete a cache
+///
+/// # Arguments
+///
+/// * `name` - The name of the cache to be deleted.
+///
+/// # Examples
+/// Assumes that a CacheClient named `cache_client` has been created and is available.
+/// ```no_run
+/// # fn main() -> anyhow::Result<()> {
+/// # use momento_test_util::create_doctest_client;
+/// # tokio_test::block_on(async {
+/// use momento::requests::cache::delete_cache::DeleteCache;
+/// use momento::requests::cache::delete_cache::DeleteCacheRequest;
+/// # let (cache_client, cache_name) = create_doctest_client();
+///
+/// let delete_cache_request = DeleteCacheRequest::new(cache_name.to_string());
+///
+/// let delete_cache_response = cache_client.send_request(delete_cache_request).await?;
+///
+/// assert_eq!(delete_cache_response, DeleteCache {});
+/// # Ok(())
+/// # })
+/// # }
 pub struct DeleteCacheRequest {
     pub cache_name: String,
 }
@@ -34,4 +58,5 @@ impl MomentoRequest for DeleteCacheRequest {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct DeleteCache {}

--- a/src/requests/cache/delete_cache.rs
+++ b/src/requests/cache/delete_cache.rs
@@ -1,0 +1,37 @@
+use momento_protos::control_client;
+use tonic::Request;
+
+use crate::requests::cache::MomentoRequest;
+use crate::{utils, CacheClient, MomentoResult};
+
+pub struct DeleteCacheRequest {
+    pub cache_name: String,
+}
+
+impl DeleteCacheRequest {
+    pub fn new(cache_name: String) -> Self {
+        DeleteCacheRequest { cache_name }
+    }
+}
+
+impl MomentoRequest for DeleteCacheRequest {
+    type Response = DeleteCache;
+
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<DeleteCache> {
+        let cache_name = &self.cache_name;
+
+        utils::is_cache_name_valid(cache_name)?;
+        let request = Request::new(control_client::DeleteCacheRequest {
+            cache_name: cache_name.to_string(),
+        });
+
+        let _ = cache_client
+            .control_client
+            .clone()
+            .delete_cache(request)
+            .await?;
+        Ok(DeleteCache {})
+    }
+}
+
+pub struct DeleteCache {}

--- a/src/requests/cache/mod.rs
+++ b/src/requests/cache/mod.rs
@@ -1,7 +1,14 @@
 use crate::cache_client::CacheClient;
 use crate::MomentoResult;
 
+pub mod create_cache;
+pub mod delete_cache;
+
 pub mod set_add_elements;
+pub mod sorted_set_fetch_by_rank;
+pub mod sorted_set_fetch_by_score;
+pub mod sorted_set_put_element;
+pub mod sorted_set_put_elements;
 
 pub trait MomentoRequest {
     type Response;

--- a/src/requests/cache/set_add_elements.rs
+++ b/src/requests/cache/set_add_elements.rs
@@ -1,8 +1,9 @@
+use momento_protos::cache_client::SetUnionRequest;
+
 use crate::cache_client::CacheClient;
 use crate::requests::cache::MomentoRequest;
 use crate::simple_cache_client::prep_request_with_timeout;
 use crate::{CollectionTtl, IntoBytes, MomentoResult};
-use momento_protos::cache_client::SetUnionRequest;
 
 /// ```
 /// # fn main() -> anyhow::Result<()> {
@@ -41,6 +42,11 @@ impl<S: IntoBytes, E: IntoBytes> SetAddElementsRequest<S, E> {
             elements,
             collection_ttl: Some(collection_ttl),
         }
+    }
+
+    pub fn with_ttl(mut self, collection_ttl: CollectionTtl) -> Self {
+        self.collection_ttl = Some(collection_ttl);
+        self
     }
 }
 

--- a/src/requests/cache/sorted_set_fetch_by_rank.rs
+++ b/src/requests/cache/sorted_set_fetch_by_rank.rs
@@ -1,0 +1,93 @@
+use momento_protos::cache_client::sorted_set_fetch_request::{by_index, ByIndex, Range};
+use momento_protos::cache_client::{SortedSetFetchRequest, Unbounded};
+
+use crate::requests::cache::sorted_set_fetch_by_rank::SortOrder::Ascending;
+use crate::requests::cache::MomentoRequest;
+use crate::response::cache::sorted_set_fetch::SortedSetFetch;
+use crate::simple_cache_client::prep_request_with_timeout;
+use crate::{CacheClient, IntoBytes, MomentoResult};
+
+#[repr(i32)]
+pub enum SortOrder {
+    Ascending = 0,
+    Descending = 1,
+}
+
+pub struct SortedSetFetchByRankRequest<S: IntoBytes> {
+    cache_name: String,
+    sorted_set_name: S,
+    start_rank: Option<i32>,
+    end_rank: Option<i32>,
+    order: SortOrder,
+}
+
+impl<S: IntoBytes> SortedSetFetchByRankRequest<S> {
+    pub fn new(cache_name: String, sorted_set_name: S) -> Self {
+        Self {
+            cache_name,
+            sorted_set_name,
+            start_rank: None,
+            end_rank: None,
+            order: Ascending,
+        }
+    }
+
+    pub fn with_start_rank(mut self, start_rank: i32) -> Self {
+        self.start_rank = Some(start_rank);
+        self
+    }
+
+    pub fn with_end_rank(mut self, end_rank: i32) -> Self {
+        self.end_rank = Some(end_rank);
+        self
+    }
+
+    pub fn with_order(mut self, order: SortOrder) -> Self {
+        self.order = order;
+        self
+    }
+}
+
+impl<S: IntoBytes> MomentoRequest for SortedSetFetchByRankRequest<S> {
+    type Response = SortedSetFetch;
+
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetFetch> {
+        let set_name = self.sorted_set_name.into_bytes();
+        let cache_name = &self.cache_name;
+
+        let by_index = ByIndex {
+            start: if self.start_rank.is_some() {
+                Some(by_index::Start::InclusiveStartIndex(
+                    self.start_rank.unwrap(),
+                ))
+            } else {
+                Some(by_index::Start::UnboundedStart(Unbounded {}))
+            },
+            end: if self.end_rank.is_some() {
+                Some(by_index::End::ExclusiveEndIndex(self.end_rank.unwrap()))
+            } else {
+                Some(by_index::End::UnboundedEnd(Unbounded {}))
+            },
+        };
+
+        let request = prep_request_with_timeout(
+            cache_name,
+            cache_client.configuration.deadline_millis(),
+            SortedSetFetchRequest {
+                set_name,
+                order: self.order as i32,
+                with_scores: true,
+                range: Some(Range::ByIndex(by_index)),
+            },
+        )?;
+
+        let response = cache_client
+            .data_client
+            .clone()
+            .sorted_set_fetch(request)
+            .await?
+            .into_inner();
+
+        SortedSetFetch::from_fetch_response(response)
+    }
+}

--- a/src/requests/cache/sorted_set_fetch_by_rank.rs
+++ b/src/requests/cache/sorted_set_fetch_by_rank.rs
@@ -56,18 +56,16 @@ impl<S: IntoBytes> MomentoRequest for SortedSetFetchByRankRequest<S> {
         let cache_name = &self.cache_name;
 
         let by_index = ByIndex {
-            start: if self.start_rank.is_some() {
-                Some(by_index::Start::InclusiveStartIndex(
-                    self.start_rank.unwrap(),
-                ))
-            } else {
-                Some(by_index::Start::UnboundedStart(Unbounded {}))
-            },
-            end: if self.end_rank.is_some() {
-                Some(by_index::End::ExclusiveEndIndex(self.end_rank.unwrap()))
-            } else {
-                Some(by_index::End::UnboundedEnd(Unbounded {}))
-            },
+            start: Some(
+                self.start_rank
+                    .map(by_index::Start::InclusiveStartIndex)
+                    .unwrap_or_else(|| by_index::Start::UnboundedStart(Unbounded {})),
+            ),
+            end: Some(
+                self.end_rank
+                    .map(by_index::End::ExclusiveEndIndex)
+                    .unwrap_or_else(|| by_index::End::UnboundedEnd(Unbounded {})),
+            ),
         };
 
         let request = prep_request_with_timeout(

--- a/src/requests/cache/sorted_set_fetch_by_rank.rs
+++ b/src/requests/cache/sorted_set_fetch_by_rank.rs
@@ -13,6 +13,55 @@ pub enum SortOrder {
     Descending = 1,
 }
 
+/// Request to fetch the elements in a sorted set by their rank.
+///
+/// # Arguments
+///
+/// * `cache_name` - The name of the cache containing the sorted set.
+/// * `sorted_set_name` - The name of the sorted set to add an element to.
+///
+/// # Optional Arguments
+///
+/// * `order` - The order to sort the elements by. [SortOrder::Ascending] or [SortOrder::Descending].
+/// Defaults to Ascending.
+/// * `start_rank` - The rank of the first element to fetch. Defaults to 0. This rank is
+/// inclusive, i.e. the element at this rank will be fetched.
+/// * `end_rank` - The rank of the last element to fetch. This rank is exclusive, i.e. the
+/// element at this rank will not be fetched. Defaults to -1, which fetches up until and
+/// including the last element.
+///
+/// # Examples
+/// Assumes that a CacheClient named `cache_client` has been created and is available.
+/// ```
+/// # fn main() -> anyhow::Result<()> {
+/// # use std::convert::TryInto;
+/// # use momento_test_util::create_doctest_client;
+/// # tokio_test::block_on(async {
+/// use momento::requests::cache::sorted_set_fetch_by_rank::SortOrder;
+/// use momento::requests::cache::sorted_set_fetch_by_rank::SortedSetFetchByRankRequest;
+/// use momento::response::cache::sorted_set_fetch::SortedSetFetch;
+/// # let (cache_client, cache_name) = create_doctest_client();
+/// let sorted_set_name = "sorted_set";
+///
+/// let put_element_response = cache_client.sorted_set_put_elements(
+///     cache_name.to_string(),
+///     sorted_set_name.to_string(),
+///     vec![("value1", 1.0), ("value2", 2.0), ("value3", 3.0), ("value4", 4.0)]
+/// ).await?;
+///
+/// let fetch_request = SortedSetFetchByRankRequest::new(cache_name, sorted_set_name)
+///     .with_order(SortOrder::Ascending)
+///     .with_start_rank(1)
+///     .with_end_rank(3);
+///
+/// let fetch_response = cache_client.send_request(fetch_request).await?;
+///
+/// let returned_elements: Vec<(String, f64)> = fetch_response.try_into()
+///     .expect("elements 2 and 3 should be returned");
+/// println!("{:?}", returned_elements);
+/// # Ok(())
+/// # })
+/// # }
 pub struct SortedSetFetchByRankRequest<S: IntoBytes> {
     cache_name: String,
     sorted_set_name: S,
@@ -32,16 +81,19 @@ impl<S: IntoBytes> SortedSetFetchByRankRequest<S> {
         }
     }
 
+    /// Set the start rank of the request.
     pub fn with_start_rank(mut self, start_rank: i32) -> Self {
         self.start_rank = Some(start_rank);
         self
     }
 
+    /// Set the end rank of the request.
     pub fn with_end_rank(mut self, end_rank: i32) -> Self {
         self.end_rank = Some(end_rank);
         self
     }
 
+    /// Set the order of the request.
     pub fn with_order(mut self, order: SortOrder) -> Self {
         self.order = order;
         self

--- a/src/requests/cache/sorted_set_fetch_by_score.rs
+++ b/src/requests/cache/sorted_set_fetch_by_score.rs
@@ -1,0 +1,109 @@
+use momento_protos::cache_client::sorted_set_fetch_request::by_score::Score;
+use momento_protos::cache_client::sorted_set_fetch_request::{by_score, ByScore, Range};
+use momento_protos::cache_client::{SortedSetFetchRequest, Unbounded};
+
+use crate::requests::cache::sorted_set_fetch_by_rank::SortOrder;
+use crate::requests::cache::sorted_set_fetch_by_rank::SortOrder::Ascending;
+use crate::requests::cache::MomentoRequest;
+use crate::response::cache::sorted_set_fetch::SortedSetFetch;
+use crate::simple_cache_client::prep_request_with_timeout;
+use crate::{CacheClient, IntoBytes, MomentoResult};
+
+pub struct SortedSetFetchByScoreRequest<S: IntoBytes> {
+    cache_name: String,
+    sorted_set_name: S,
+    min_score: Option<f64>,
+    max_score: Option<f64>,
+    order: SortOrder,
+    offset: Option<u32>,
+    count: Option<i32>,
+}
+
+impl<S: IntoBytes> SortedSetFetchByScoreRequest<S> {
+    pub fn new(cache_name: String, sorted_set_name: S) -> Self {
+        Self {
+            cache_name,
+            sorted_set_name,
+            min_score: None,
+            max_score: None,
+            order: Ascending,
+            offset: None,
+            count: None,
+        }
+    }
+
+    pub fn with_min_score(mut self, min_score: f64) -> Self {
+        self.min_score = Some(min_score);
+        self
+    }
+
+    pub fn with_max_score(mut self, max_score: f64) -> Self {
+        self.max_score = Some(max_score);
+        self
+    }
+
+    pub fn with_order(mut self, order: SortOrder) -> Self {
+        self.order = order;
+        self
+    }
+
+    pub fn with_offset(mut self, offset: u32) -> Self {
+        self.offset = Some(offset);
+        self
+    }
+
+    pub fn with_count(mut self, count: i32) -> Self {
+        self.count = Some(count);
+        self
+    }
+}
+
+impl<S: IntoBytes> MomentoRequest for SortedSetFetchByScoreRequest<S> {
+    type Response = SortedSetFetch;
+
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetFetch> {
+        let set_name = self.sorted_set_name.into_bytes();
+        let cache_name = &self.cache_name;
+
+        let by_score = ByScore {
+            min: if self.min_score.is_some() {
+                Some(by_score::Min::MinScore(Score {
+                    score: self.min_score.unwrap(),
+                    exclusive: false,
+                }))
+            } else {
+                Some(by_score::Min::UnboundedMin(Unbounded {}))
+            },
+            max: if self.max_score.is_some() {
+                Some(by_score::Max::MaxScore(Score {
+                    score: self.max_score.unwrap(),
+                    exclusive: false,
+                }))
+            } else {
+                Some(by_score::Max::UnboundedMax(Unbounded {}))
+            },
+            offset: self.offset.unwrap_or(0),
+            count: self.count.unwrap_or(-1),
+        };
+
+        let request = prep_request_with_timeout(
+            cache_name,
+            cache_client.configuration.deadline_millis(),
+            SortedSetFetchRequest {
+                set_name,
+                order: self.order as i32,
+                with_scores: true,
+                range: Some(Range::ByScore(by_score)),
+            },
+        )?;
+
+        let response = cache_client
+            .data_client
+            .clone()
+            .sorted_set_fetch(request)
+            .await?
+            .into_inner();
+
+        SortedSetFetch::from_fetch_response(response)
+    }
+}

--- a/src/requests/cache/sorted_set_fetch_by_score.rs
+++ b/src/requests/cache/sorted_set_fetch_by_score.rs
@@ -9,6 +9,58 @@ use crate::response::cache::sorted_set_fetch::SortedSetFetch;
 use crate::simple_cache_client::prep_request_with_timeout;
 use crate::{CacheClient, IntoBytes, MomentoResult};
 
+/// Fetch the elements in the given sorted set by their score.
+///
+/// # Arguments
+///
+/// * `cache_name` - The name of the cache containing the sorted set.
+/// * `sorted_set_name` - The name of the sorted set to add an element to.
+///
+/// # Optional Arguments
+///
+/// * `order` - The order to sort the elements by. [SortOrder::Ascending] or [SortOrder::Descending].
+/// Defaults to Ascending.
+/// * `min_score` - The minimum score (inclusive) of the elements to fetch. Defaults to negative
+/// infinity.
+/// * `max_score` - The maximum score (inclusive) of the elements to fetch. Defaults to positive
+/// infinity.
+/// * `offset` - The number of elements to skip before returning the first element. Defaults to
+/// 0. Note: this is not the rank of the first element to return, but the number of elements of
+/// the result set to skip before returning the first element.
+/// * `count` - The maximum number of elements to return. Defaults to all elements.
+///
+/// # Examples
+/// Assumes that a CacheClient named `cache_client` has been created and is available.
+/// ```
+/// # fn main() -> anyhow::Result<()> {
+/// # use std::convert::TryInto;
+/// # use momento_test_util::create_doctest_client;
+/// # tokio_test::block_on(async {
+/// use momento::requests::cache::sorted_set_fetch_by_rank::SortOrder;
+/// use momento::requests::cache::sorted_set_fetch_by_score::SortedSetFetchByScoreRequest;
+/// use momento::response::cache::sorted_set_fetch::SortedSetFetch;
+/// # let (cache_client, cache_name) = create_doctest_client();
+/// let sorted_set_name = "sorted_set";
+///
+/// let put_element_response = cache_client.sorted_set_put_elements(
+///     cache_name.to_string(),
+///     sorted_set_name.to_string(),
+///     vec![("value1", 1.0), ("value2", 2.0), ("value3", 3.0), ("value4", 4.0)]
+/// ).await?;
+///
+/// let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
+///     .with_order(SortOrder::Ascending)
+///     .with_min_score(2.0)
+///     .with_max_score(3.0);
+///
+/// let fetch_response = cache_client.send_request(fetch_request).await?;
+///
+/// let returned_elements: Vec<(String, f64)> = fetch_response.try_into()
+///     .expect("elements 2 and 3 should be returned");
+/// println!("{:?}", returned_elements);
+/// # Ok(())
+/// # })
+/// # }
 pub struct SortedSetFetchByScoreRequest<S: IntoBytes> {
     cache_name: String,
     sorted_set_name: S,
@@ -32,26 +84,31 @@ impl<S: IntoBytes> SortedSetFetchByScoreRequest<S> {
         }
     }
 
+    /// Set the minimum score of the request.
     pub fn with_min_score(mut self, min_score: f64) -> Self {
         self.min_score = Some(min_score);
         self
     }
 
+    /// Set the maximum score of the request.
     pub fn with_max_score(mut self, max_score: f64) -> Self {
         self.max_score = Some(max_score);
         self
     }
 
+    /// Set the order of the request.
     pub fn with_order(mut self, order: SortOrder) -> Self {
         self.order = order;
         self
     }
 
+    /// Set the offset of the request.
     pub fn with_offset(mut self, offset: u32) -> Self {
         self.offset = Some(offset);
         self
     }
 
+    /// Set the count of the request.
     pub fn with_count(mut self, count: i32) -> Self {
         self.count = Some(count);
         self

--- a/src/requests/cache/sorted_set_fetch_by_score.rs
+++ b/src/requests/cache/sorted_set_fetch_by_score.rs
@@ -66,22 +66,26 @@ impl<S: IntoBytes> MomentoRequest for SortedSetFetchByScoreRequest<S> {
         let cache_name = &self.cache_name;
 
         let by_score = ByScore {
-            min: if self.min_score.is_some() {
-                Some(by_score::Min::MinScore(Score {
-                    score: self.min_score.unwrap(),
-                    exclusive: false,
-                }))
-            } else {
-                Some(by_score::Min::UnboundedMin(Unbounded {}))
-            },
-            max: if self.max_score.is_some() {
-                Some(by_score::Max::MaxScore(Score {
-                    score: self.max_score.unwrap(),
-                    exclusive: false,
-                }))
-            } else {
-                Some(by_score::Max::UnboundedMax(Unbounded {}))
-            },
+            min: Some(
+                self.min_score
+                    .map(|score| {
+                        by_score::Min::MinScore(Score {
+                            score,
+                            exclusive: false,
+                        })
+                    })
+                    .unwrap_or(by_score::Min::UnboundedMin(Unbounded {})),
+            ),
+            max: Some(
+                self.max_score
+                    .map(|score| {
+                        by_score::Max::MaxScore(Score {
+                            score,
+                            exclusive: false,
+                        })
+                    })
+                    .unwrap_or(by_score::Max::UnboundedMax(Unbounded {})),
+            ),
             offset: self.offset.unwrap_or(0),
             count: self.count.unwrap_or(-1),
         };

--- a/src/requests/cache/sorted_set_put_element.rs
+++ b/src/requests/cache/sorted_set_put_element.rs
@@ -1,0 +1,65 @@
+use momento_protos::cache_client::{SortedSetElement, SortedSetPutRequest};
+
+use crate::requests::cache::MomentoRequest;
+use crate::simple_cache_client::prep_request_with_timeout;
+use crate::{CacheClient, CollectionTtl, IntoBytes, MomentoResult};
+
+pub struct SortedSetPutElementRequest<S: IntoBytes, E: IntoBytes> {
+    cache_name: String,
+    sorted_set_name: S,
+    value: E,
+    score: f64,
+    collection_ttl: Option<CollectionTtl>,
+}
+
+impl<S: IntoBytes, E: IntoBytes> SortedSetPutElementRequest<S, E> {
+    pub fn new(cache_name: String, sorted_set_name: S, value: E, score: f64) -> Self {
+        let collection_ttl = CollectionTtl::default();
+        Self {
+            cache_name,
+            sorted_set_name,
+            value,
+            score,
+            collection_ttl: Some(collection_ttl),
+        }
+    }
+
+    pub fn with_ttl(mut self, collection_ttl: CollectionTtl) -> Self {
+        self.collection_ttl = Some(collection_ttl);
+        self
+    }
+}
+
+impl<S: IntoBytes, E: IntoBytes> MomentoRequest for SortedSetPutElementRequest<S, E> {
+    type Response = SortedSetPutElement;
+
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetPutElement> {
+        let collection_ttl = self.collection_ttl.unwrap_or_default();
+        let element = SortedSetElement {
+            value: self.value.into_bytes(),
+            score: self.score,
+        };
+        let set_name = self.sorted_set_name.into_bytes();
+        let cache_name = &self.cache_name;
+        let request = prep_request_with_timeout(
+            cache_name,
+            cache_client.configuration.deadline_millis(),
+            SortedSetPutRequest {
+                set_name,
+                elements: vec![element],
+                ttl_milliseconds: cache_client.expand_ttl_ms(collection_ttl.ttl())?,
+                refresh_ttl: collection_ttl.refresh(),
+            },
+        )?;
+
+        let _ = cache_client
+            .data_client
+            .clone()
+            .sorted_set_put(request)
+            .await?;
+        Ok(SortedSetPutElement {})
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct SortedSetPutElement {}

--- a/src/requests/cache/sorted_set_put_element.rs
+++ b/src/requests/cache/sorted_set_put_element.rs
@@ -4,6 +4,45 @@ use crate::requests::cache::MomentoRequest;
 use crate::simple_cache_client::prep_request_with_timeout;
 use crate::{CacheClient, CollectionTtl, IntoBytes, MomentoResult};
 
+/// Request to add an element to a sorted set. If the element already exists, its score is updated.
+/// Creates the sorted set if it does not exist.
+///
+/// # Arguments
+///
+/// * `cache_name` - The name of the cache containing the sorted set.
+/// * `sorted_set_name` - The name of the sorted set ot add an element to.
+/// * `value` - The value of the element to add. Must be able to be converted to a Vec<u8>.
+/// * `score` - The score of the element to add.
+///
+/// # Optional Arguments
+///
+/// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
+///
+/// # Examples
+/// Assumes that a CacheClient named `cache_client` has been created and is available.
+/// ```
+/// # fn main() -> anyhow::Result<()> {
+/// # use momento_test_util::create_doctest_client;
+/// # tokio_test::block_on(async {
+/// use momento::CollectionTtl;
+/// use momento::requests::cache::sorted_set_put_element::SortedSetPutElement;
+/// use momento::requests::cache::sorted_set_put_element::SortedSetPutElementRequest;
+/// # let (cache_client, cache_name) = create_doctest_client();
+/// let sorted_set_name = "sorted_set";
+///
+/// let put_element_request = SortedSetPutElementRequest::new(
+///     cache_name.to_string(),
+///     sorted_set_name.to_string(),
+///     "value",
+///     1.0
+/// ).with_ttl(CollectionTtl::default());
+///
+/// let create_cache_response = cache_client.send_request(put_element_request).await?;
+///
+/// assert_eq!(create_cache_response, SortedSetPutElement {});
+/// # Ok(())
+/// # })
+/// # }
 pub struct SortedSetPutElementRequest<S: IntoBytes, E: IntoBytes> {
     cache_name: String,
     sorted_set_name: S,
@@ -24,6 +63,7 @@ impl<S: IntoBytes, E: IntoBytes> SortedSetPutElementRequest<S, E> {
         }
     }
 
+    /// Set the time-to-live for the collection.
     pub fn with_ttl(mut self, collection_ttl: CollectionTtl) -> Self {
         self.collection_ttl = Some(collection_ttl);
         self

--- a/src/requests/cache/sorted_set_put_element.rs
+++ b/src/requests/cache/sorted_set_put_element.rs
@@ -43,16 +43,16 @@ use crate::{CacheClient, CollectionTtl, IntoBytes, MomentoResult};
 /// # Ok(())
 /// # })
 /// # }
-pub struct SortedSetPutElementRequest<S: IntoBytes, E: IntoBytes> {
+pub struct SortedSetPutElementRequest<S: IntoBytes, V: IntoBytes> {
     cache_name: String,
     sorted_set_name: S,
-    value: E,
+    value: V,
     score: f64,
     collection_ttl: Option<CollectionTtl>,
 }
 
-impl<S: IntoBytes, E: IntoBytes> SortedSetPutElementRequest<S, E> {
-    pub fn new(cache_name: String, sorted_set_name: S, value: E, score: f64) -> Self {
+impl<S: IntoBytes, V: IntoBytes> SortedSetPutElementRequest<S, V> {
+    pub fn new(cache_name: String, sorted_set_name: S, value: V, score: f64) -> Self {
         let collection_ttl = CollectionTtl::default();
         Self {
             cache_name,
@@ -70,7 +70,7 @@ impl<S: IntoBytes, E: IntoBytes> SortedSetPutElementRequest<S, E> {
     }
 }
 
-impl<S: IntoBytes, E: IntoBytes> MomentoRequest for SortedSetPutElementRequest<S, E> {
+impl<S: IntoBytes, V: IntoBytes> MomentoRequest for SortedSetPutElementRequest<S, V> {
     type Response = SortedSetPutElement;
 
     async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetPutElement> {

--- a/src/requests/cache/sorted_set_put_elements.rs
+++ b/src/requests/cache/sorted_set_put_elements.rs
@@ -1,0 +1,67 @@
+use momento_protos::cache_client::{SortedSetElement, SortedSetPutRequest};
+
+use crate::requests::cache::MomentoRequest;
+use crate::simple_cache_client::prep_request_with_timeout;
+use crate::{CacheClient, CollectionTtl, IntoBytes, MomentoResult};
+
+pub struct SortedSetPutElementsRequest<S: IntoBytes, E: IntoBytes> {
+    cache_name: String,
+    sorted_set_name: S,
+    elements: Vec<(E, f64)>,
+    collection_ttl: Option<CollectionTtl>,
+}
+
+impl<S: IntoBytes, E: IntoBytes> SortedSetPutElementsRequest<S, E> {
+    pub fn new(cache_name: String, sorted_set_name: S, elements: Vec<(E, f64)>) -> Self {
+        let collection_ttl = CollectionTtl::default();
+        Self {
+            cache_name,
+            sorted_set_name,
+            elements,
+            collection_ttl: Some(collection_ttl),
+        }
+    }
+
+    pub fn with_ttl(mut self, collection_ttl: CollectionTtl) -> Self {
+        self.collection_ttl = Some(collection_ttl);
+        self
+    }
+}
+
+impl<S: IntoBytes, E: IntoBytes> MomentoRequest for SortedSetPutElementsRequest<S, E> {
+    type Response = SortedSetPutElements;
+
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetPutElements> {
+        let collection_ttl = self.collection_ttl.unwrap_or_default();
+        let elements = self
+            .elements
+            .into_iter()
+            .map(|e| SortedSetElement {
+                value: e.0.into_bytes(),
+                score: e.1,
+            })
+            .collect();
+        let set_name = self.sorted_set_name.into_bytes();
+        let cache_name = &self.cache_name;
+        let request = prep_request_with_timeout(
+            cache_name,
+            cache_client.configuration.deadline_millis(),
+            SortedSetPutRequest {
+                set_name,
+                elements,
+                ttl_milliseconds: cache_client.expand_ttl_ms(collection_ttl.ttl())?,
+                refresh_ttl: collection_ttl.refresh(),
+            },
+        )?;
+
+        let _ = cache_client
+            .data_client
+            .clone()
+            .sorted_set_put(request)
+            .await?;
+        Ok(SortedSetPutElements {})
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct SortedSetPutElements {}

--- a/src/requests/cache/sorted_set_put_elements.rs
+++ b/src/requests/cache/sorted_set_put_elements.rs
@@ -4,6 +4,43 @@ use crate::requests::cache::MomentoRequest;
 use crate::simple_cache_client::prep_request_with_timeout;
 use crate::{CacheClient, CollectionTtl, IntoBytes, MomentoResult};
 
+/// Request to add elements to a sorted set. If an element already exists, its score is updated.
+/// Creates the sorted set if it does not exist.
+///
+/// # Arguments
+///
+/// * `cache_name` - The name of the cache containing the sorted set.
+/// * `sorted_set_name` - The name of the sorted set ot add an element to.
+/// * `elements` - The values and scores to add. The values must be able to be converted to a Vec<u8>.
+///
+/// # Optional Arguments
+///
+/// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
+///
+/// # Examples
+/// Assumes that a CacheClient named `cache_client` has been created and is available.
+/// ```
+/// # fn main() -> anyhow::Result<()> {
+/// # use momento_test_util::create_doctest_client;
+/// # tokio_test::block_on(async {
+/// use momento::CollectionTtl;
+/// use momento::requests::cache::sorted_set_put_elements::SortedSetPutElements;
+/// use momento::requests::cache::sorted_set_put_elements::SortedSetPutElementsRequest;
+/// # let (cache_client, cache_name) = create_doctest_client();
+/// let sorted_set_name = "sorted_set";
+///
+/// let put_elements_request = SortedSetPutElementsRequest::new(
+///     cache_name.to_string(),
+///     sorted_set_name.to_string(),
+///     vec![("value1", 1.0), ("value2", 2.0)]
+/// ).with_ttl(CollectionTtl::default());
+///
+/// let put_elements_response = cache_client.send_request(put_elements_request).await?;
+///
+/// assert_eq!(put_elements_response, SortedSetPutElements {});
+/// # Ok(())
+/// # })
+/// # }
 pub struct SortedSetPutElementsRequest<S: IntoBytes, E: IntoBytes> {
     cache_name: String,
     sorted_set_name: S,
@@ -22,6 +59,7 @@ impl<S: IntoBytes, E: IntoBytes> SortedSetPutElementsRequest<S, E> {
         }
     }
 
+    /// Set the time-to-live for the collection.
     pub fn with_ttl(mut self, collection_ttl: CollectionTtl) -> Self {
         self.collection_ttl = Some(collection_ttl);
         self

--- a/src/response/cache/mod.rs
+++ b/src/response/cache/mod.rs
@@ -1,0 +1,1 @@
+pub mod sorted_set_fetch;

--- a/src/response/cache/sorted_set_fetch.rs
+++ b/src/response/cache/sorted_set_fetch.rs
@@ -1,0 +1,128 @@
+use std::convert::{TryFrom, TryInto};
+
+use momento_protos::cache_client::sorted_set_fetch_response::found::Elements;
+use momento_protos::cache_client::sorted_set_fetch_response::SortedSet;
+use momento_protos::cache_client::SortedSetFetchResponse;
+
+use crate::{MomentoError, MomentoResult};
+
+#[derive(Debug, PartialEq)]
+pub enum SortedSetFetch {
+    Hit { elements: SortedSetElements },
+    Miss,
+}
+
+impl SortedSetFetch {
+    pub(crate) fn from_fetch_response(response: SortedSetFetchResponse) -> MomentoResult<Self> {
+        match response.sorted_set {
+            None => Ok(SortedSetFetch::Miss),
+            Some(SortedSet::Missing(_)) => Ok(SortedSetFetch::Miss),
+            Some(SortedSet::Found(elements)) => match elements.elements {
+                None => Ok(SortedSetFetch::Hit {
+                    elements: SortedSetElements::new(Vec::new()),
+                }),
+                Some(elements) => match elements {
+                    Elements::ValuesWithScores(values_with_scores) => {
+                        let elements = values_with_scores
+                            .elements
+                            .into_iter()
+                            .map(|element| (element.value, element.score))
+                            .collect();
+                        Ok(SortedSetFetch::Hit {
+                            elements: SortedSetElements::new(elements),
+                        })
+                    }
+                    Elements::Values(_) => {
+                        return Err(MomentoError::ClientSdkError {
+                            description: std::borrow::Cow::Borrowed(
+                                "sorted_set_fetch_by_index response included elements without values"
+                            ),
+                            source: crate::response::ErrorSource::Unknown(
+                                std::io::Error::new(
+                                    std::io::ErrorKind::InvalidData,
+                                    "unexpected response",
+                                ).into()),
+                        });
+                    }
+                },
+            },
+        }
+    }
+}
+
+impl TryFrom<SortedSetFetch> for Vec<(Vec<u8>, f64)> {
+    type Error = MomentoError;
+
+    fn try_from(value: SortedSetFetch) -> Result<Self, Self::Error> {
+        match value {
+            SortedSetFetch::Hit { elements } => Ok(elements.elements),
+            SortedSetFetch::Miss => Err(MomentoError::Miss {
+                description: std::borrow::Cow::Borrowed("sorted set was not found"),
+            }),
+        }
+    }
+}
+
+impl TryFrom<SortedSetFetch> for Vec<(String, f64)> {
+    type Error = MomentoError;
+
+    fn try_from(value: SortedSetFetch) -> Result<Self, Self::Error> {
+        match value {
+            SortedSetFetch::Hit { elements } => elements.into_strings(),
+            SortedSetFetch::Miss => Err(MomentoError::Miss {
+                description: std::borrow::Cow::Borrowed("sorted set was not found"),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct SortedSetElements {
+    pub elements: Vec<(Vec<u8>, f64)>,
+}
+
+impl SortedSetElements {
+    pub fn new(elements: Vec<(Vec<u8>, f64)>) -> Self {
+        SortedSetElements { elements }
+    }
+
+    pub fn into_strings(self) -> MomentoResult<Vec<(String, f64)>> {
+        self.try_into()
+    }
+
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+}
+
+impl TryFrom<SortedSetElements> for Vec<(Vec<u8>, f64)> {
+    type Error = MomentoError;
+
+    fn try_from(value: SortedSetElements) -> Result<Self, Self::Error> {
+        Ok(value.elements)
+    }
+}
+
+impl TryFrom<SortedSetElements> for Vec<(String, f64)> {
+    type Error = MomentoError;
+
+    fn try_from(value: SortedSetElements) -> Result<Self, Self::Error> {
+        let mut result = Vec::with_capacity(value.elements.len());
+        for element in value.elements {
+            match String::from_utf8(element.0) {
+                Ok(value) => {
+                    result.push((value, element.1));
+                }
+                Err(e) => {
+                    return Err::<Self, Self::Error>(MomentoError::TypeError {
+                        description: std::borrow::Cow::Borrowed(
+                            "element value was not a valid utf-8 string",
+                        ),
+                        source: Box::new(e),
+                    });
+                }
+            }
+        }
+        Ok(result)
+    }
+}

--- a/src/response/cache/sorted_set_fetch.rs
+++ b/src/response/cache/sorted_set_fetch.rs
@@ -93,6 +93,10 @@ impl SortedSetElements {
     pub fn len(&self) -> usize {
         self.elements.len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.elements.is_empty()
+    }
 }
 
 impl TryFrom<SortedSetElements> for Vec<(Vec<u8>, f64)> {

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 mod cache_dictionary_fetch_response;
 mod cache_dictionary_get_response;
 mod cache_dictionary_increment_response;

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -52,15 +52,8 @@ where
 }
 
 pub fn create_doctest_client() -> (CacheClient, String) {
-    let cache_name =
-        env::var("TEST_CACHE_NAME").expect("environment variable TEST_CACHE_NAME should be set");
-
-    let credential_provider =
-        CredentialProviderBuilder::from_environment_variable("TEST_API_KEY".to_string())
-            .build()
-            .expect(
-                "credential provider should be created using the TEST_API_KEY environment variable",
-            );
+    let cache_name = get_test_cache_name();
+    let credential_provider = get_test_credential_provider();
 
     let cache_client = momento::CacheClient::new(
         credential_provider,
@@ -70,4 +63,14 @@ pub fn create_doctest_client() -> (CacheClient, String) {
     .expect("cache client should be created");
 
     (cache_client, cache_name)
+}
+
+pub fn get_test_cache_name() -> String {
+    env::var("TEST_CACHE_NAME").unwrap_or("rust-sdk-test-cache".to_string())
+}
+
+pub fn get_test_credential_provider() -> CredentialProvider {
+    CredentialProviderBuilder::from_environment_variable("MOMENTO_API_KEY".to_string())
+        .build()
+        .expect("auth token should be valid")
 }

--- a/tests/cache_sorted_set_tests.rs
+++ b/tests/cache_sorted_set_tests.rs
@@ -1,0 +1,311 @@
+use uuid::Uuid;
+
+use momento::requests::cache::sorted_set_fetch_by_rank::SortOrder::{Ascending, Descending};
+use momento::requests::cache::sorted_set_fetch_by_rank::SortedSetFetchByRankRequest;
+use momento::requests::cache::sorted_set_fetch_by_score::SortedSetFetchByScoreRequest;
+use momento::response::cache::sorted_set_fetch::SortedSetFetch;
+
+use crate::cache_test_state::TEST_STATE;
+
+mod cache_test_state;
+
+#[tokio::test]
+async fn sorted_set_put_element_happy_path() {
+    let client = TEST_STATE.client.clone();
+    let cache_name = TEST_STATE.cache_name.clone();
+    let sorted_set_name = "sorted-set-".to_string() + &Uuid::new_v4().to_string();
+    let value = "value";
+    let score = 1.0;
+
+    let result = client
+        .sorted_set_fetch_by_rank(cache_name.clone(), sorted_set_name.clone(), Ascending)
+        .await
+        .unwrap();
+    assert_eq!(result, SortedSetFetch::Miss);
+
+    client
+        .sorted_set_put_element(cache_name.clone(), sorted_set_name.clone(), "value", 1.0)
+        .await
+        .unwrap();
+
+    let result = client
+        .sorted_set_fetch_by_rank(cache_name.clone(), sorted_set_name.clone(), Ascending)
+        .await
+        .unwrap();
+
+    match result {
+        SortedSetFetch::Hit { elements } => {
+            assert_eq!(elements.len(), 1);
+            let string_elements = elements.into_strings().unwrap();
+            assert_eq!(string_elements[0].0, value);
+            assert_eq!(string_elements[0].1, score)
+        }
+        _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
+    }
+}
+
+#[tokio::test]
+async fn sorted_set_put_element_nonexistent_cache() {
+    let client = TEST_STATE.client.clone();
+    let cache_name = "fake-cache-".to_string() + &Uuid::new_v4().to_string();
+    let sorted_set_name = "sorted-set";
+
+    let result = client
+        .sorted_set_put_element(cache_name, sorted_set_name, "value", 1.0)
+        .await
+        .unwrap_err();
+
+    let _err_msg = "Cache name cannot be empty".to_string();
+    assert!(matches!(result.to_string(), _err_message))
+}
+
+#[tokio::test]
+async fn sorted_set_put_elements_happy_path() {
+    let client = TEST_STATE.client.clone();
+    let cache_name = TEST_STATE.cache_name.clone();
+    let sorted_set_name = "sorted-set-".to_string() + &Uuid::new_v4().to_string();
+    let to_put = vec![("element1".to_string(), 1.0), ("element2".to_string(), 2.0)];
+
+    let result = client
+        .sorted_set_fetch_by_score(cache_name.clone(), sorted_set_name.clone(), Ascending)
+        .await
+        .unwrap();
+    assert_eq!(result, SortedSetFetch::Miss);
+
+    client
+        .sorted_set_put_elements(cache_name.clone(), sorted_set_name.clone(), to_put.clone())
+        .await
+        .unwrap();
+
+    let result = client
+        .sorted_set_fetch_by_score(cache_name.clone(), sorted_set_name.clone(), Ascending)
+        .await
+        .unwrap();
+
+    match result {
+        SortedSetFetch::Hit { elements } => {
+            assert_eq!(elements.len(), 2);
+            let string_elements = elements.into_strings().unwrap();
+            assert_eq!(to_put, string_elements)
+        }
+        _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
+    }
+}
+
+#[tokio::test]
+async fn sorted_set_put_elements_nonexistent_cache() {
+    let client = TEST_STATE.client.clone();
+    let cache_name = "fake-cache-".to_string() + &Uuid::new_v4().to_string();
+    let sorted_set_name = "sorted-set";
+
+    let result = client
+        .sorted_set_put_elements(
+            cache_name.clone(),
+            sorted_set_name,
+            vec![("element1".to_string(), 1.0), ("element2".to_string(), 2.0)],
+        )
+        .await
+        .unwrap_err();
+
+    let _err_msg = "Cache name cannot be empty".to_string();
+    assert!(matches!(result.to_string(), _err_message))
+}
+
+#[tokio::test]
+async fn sorted_set_fetch_by_rank_happy_path() {
+    let client = TEST_STATE.client.clone();
+    let cache_name = TEST_STATE.cache_name.clone();
+    let sorted_set_name = "sorted-set-".to_string() + &Uuid::new_v4().to_string();
+    let to_put = vec![
+        ("1".to_string(), 0.0),
+        ("2".to_string(), 1.0),
+        ("3".to_string(), 0.5),
+        ("4".to_string(), 2.0),
+        ("5".to_string(), 1.5),
+    ];
+
+    let result = client
+        .sorted_set_fetch_by_rank(cache_name.clone(), sorted_set_name.clone(), Ascending)
+        .await
+        .unwrap();
+    assert_eq!(result, SortedSetFetch::Miss);
+
+    client
+        .sorted_set_put_elements(cache_name.clone(), sorted_set_name.clone(), to_put.clone())
+        .await
+        .unwrap();
+
+    // Full set ascending, end index larger than set
+    let fetch_request =
+        SortedSetFetchByRankRequest::new(cache_name.clone(), sorted_set_name.clone())
+            .with_order(Ascending)
+            .with_start_rank(0)
+            .with_end_rank(6);
+
+    let result = client.send_request(fetch_request).await.unwrap();
+
+    match result {
+        SortedSetFetch::Hit { elements } => {
+            assert_eq!(elements.len(), 5);
+            let string_elements: Vec<String> = elements
+                .into_strings()
+                .unwrap()
+                .into_iter()
+                .map(|e| e.0)
+                .collect();
+
+            assert_eq!(string_elements, vec!["1", "3", "2", "5", "4"])
+        }
+        _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
+    }
+
+    // Partial set descending
+    let fetch_request =
+        SortedSetFetchByRankRequest::new(cache_name.clone(), sorted_set_name.clone())
+            .with_order(Descending)
+            .with_start_rank(1)
+            .with_end_rank(4);
+
+    let result = client.send_request(fetch_request).await.unwrap();
+
+    match result {
+        SortedSetFetch::Hit { elements } => {
+            assert_eq!(elements.len(), 3);
+            let string_elements: Vec<String> = elements
+                .into_strings()
+                .unwrap()
+                .into_iter()
+                .map(|e| e.0)
+                .collect();
+
+            assert_eq!(string_elements, vec!["5", "2", "3"])
+        }
+        _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
+    }
+}
+
+#[tokio::test]
+async fn sorted_set_fetch_by_rank_nonexistent_cache() {
+    let client = TEST_STATE.client.clone();
+    let cache_name = "fake-cache-".to_string() + &Uuid::new_v4().to_string();
+    let sorted_set_name = "sorted-set";
+
+    let result = client
+        .sorted_set_fetch_by_rank(cache_name.clone(), sorted_set_name, Ascending)
+        .await
+        .unwrap_err();
+
+    let _err_msg = "Cache name cannot be empty".to_string();
+    assert!(matches!(result.to_string(), _err_message))
+}
+
+#[tokio::test]
+async fn sorted_set_fetch_by_score_happy_path() {
+    let client = TEST_STATE.client.clone();
+    let cache_name = TEST_STATE.cache_name.clone();
+    let sorted_set_name = "sorted-set-".to_string() + &Uuid::new_v4().to_string();
+    let to_put = vec![
+        ("1".to_string(), 0.0),
+        ("2".to_string(), 1.0),
+        ("3".to_string(), 0.5),
+        ("4".to_string(), 2.0),
+        ("5".to_string(), 1.5),
+    ];
+
+    let result = client
+        .sorted_set_fetch_by_score(cache_name.clone(), sorted_set_name.clone(), Ascending)
+        .await
+        .unwrap();
+    assert_eq!(result, SortedSetFetch::Miss);
+
+    client
+        .sorted_set_put_elements(cache_name.clone(), sorted_set_name.clone(), to_put.clone())
+        .await
+        .unwrap();
+
+    // Full set ascending, end score larger than set
+    let fetch_request =
+        SortedSetFetchByScoreRequest::new(cache_name.clone(), sorted_set_name.clone())
+            .with_order(Ascending)
+            .with_min_score(0.0)
+            .with_max_score(9.9);
+
+    let result = client.send_request(fetch_request).await.unwrap();
+
+    match result {
+        SortedSetFetch::Hit { elements } => {
+            assert_eq!(elements.len(), 5);
+            let string_elements: Vec<String> = elements
+                .into_strings()
+                .unwrap()
+                .into_iter()
+                .map(|e| e.0)
+                .collect();
+
+            assert_eq!(string_elements, vec!["1", "3", "2", "5", "4"])
+        }
+        _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
+    }
+
+    // Partial set descending
+    let fetch_request =
+        SortedSetFetchByScoreRequest::new(cache_name.clone(), sorted_set_name.clone())
+            .with_order(Descending)
+            .with_min_score(0.1)
+            .with_max_score(1.9);
+
+    let result = client.send_request(fetch_request).await.unwrap();
+
+    match result {
+        SortedSetFetch::Hit { elements } => {
+            assert_eq!(elements.len(), 3);
+            let string_elements: Vec<String> = elements
+                .into_strings()
+                .unwrap()
+                .into_iter()
+                .map(|e| e.0)
+                .collect();
+
+            assert_eq!(string_elements, vec!["5", "2", "3"])
+        }
+        _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
+    }
+
+    // Partial set limited by offset and count
+    let fetch_request =
+        SortedSetFetchByScoreRequest::new(cache_name.clone(), sorted_set_name.clone())
+            .with_offset(1)
+            .with_count(3);
+
+    let result = client.send_request(fetch_request).await.unwrap();
+
+    match result {
+        SortedSetFetch::Hit { elements } => {
+            assert_eq!(elements.len(), 3);
+            let string_elements: Vec<String> = elements
+                .into_strings()
+                .unwrap()
+                .into_iter()
+                .map(|e| e.0)
+                .collect();
+
+            assert_eq!(string_elements, vec!["3", "2", "5"])
+        }
+        _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
+    }
+}
+
+#[tokio::test]
+async fn sorted_set_fetch_by_score_nonexistent_cache() {
+    let client = TEST_STATE.client.clone();
+    let cache_name = "fake-cache-".to_string() + &Uuid::new_v4().to_string();
+    let sorted_set_name = "sorted-set";
+
+    let result = client
+        .sorted_set_fetch_by_score(cache_name.clone(), sorted_set_name, Ascending)
+        .await
+        .unwrap_err();
+
+    let _err_msg = "Cache name cannot be empty".to_string();
+    assert!(matches!(result.to_string(), _err_message))
+}

--- a/tests/cache_test_state.rs
+++ b/tests/cache_test_state.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -6,7 +5,7 @@ use once_cell::sync::Lazy;
 use tokio::sync::watch::channel;
 
 use momento::config::configurations;
-use momento::{CacheClient, CredentialProviderBuilder, MomentoError};
+use momento::{CacheClient, MomentoError};
 use momento_test_util::{get_test_cache_name, get_test_credential_provider};
 
 pub static TEST_STATE: Lazy<Arc<TestState>> = Lazy::new(|| Arc::new(TestState::new()));

--- a/tests/cache_test_state.rs
+++ b/tests/cache_test_state.rs
@@ -1,0 +1,77 @@
+use momento::config::configurations;
+use momento::{CacheClient, CredentialProviderBuilder, MomentoError};
+use once_cell::sync::Lazy;
+use std::env;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::watch::channel;
+
+pub static TEST_STATE: Lazy<Arc<TestState>> = Lazy::new(|| Arc::new(TestState::new()));
+
+pub struct TestState {
+    pub client: Arc<CacheClient>,
+    pub cache_name: String,
+    #[allow(dead_code)]
+    runtime: tokio::runtime::Runtime,
+}
+
+impl TestState {
+    fn new() -> Self {
+        let cache_name =
+            env::var("TEST_CACHE_NAME").unwrap_or_else(|_| "rust-test-cache".to_string());
+        println!("Using cache name: {}", cache_name);
+        let thread_cache_name = cache_name.clone();
+
+        let credential_provider =
+            CredentialProviderBuilder::from_environment_variable("TEST_API_KEY".to_string())
+                .build()
+                .expect("auth token should be valid");
+
+        // The cache client must be created using a separate tokio runtime because each test
+        // creates it own runtime, and the client will stop running if its runtime is destroyed.
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let (sender, client_receiver) = channel(None);
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+        let thread_barrier = barrier.clone();
+        runtime.spawn(async move {
+            let cache_client = CacheClient::new(
+                credential_provider,
+                configurations::laptop::latest(),
+                Duration::from_secs(5),
+            )
+            .expect("Failed to create cache client");
+
+            match cache_client.clone().create_cache(thread_cache_name).await {
+                Ok(_) => {}
+                Err(e) => match e {
+                    MomentoError::AlreadyExists { .. } => {
+                        println!("Cache already exists.");
+                    }
+                    _ => {
+                        panic!("Failed to create cache: {:?}", e);
+                    }
+                },
+            }
+
+            sender.send(Some(cache_client)).unwrap();
+            thread_barrier.wait();
+        });
+        barrier.wait();
+
+        // Retrieve the client from the runtime that created it.
+        let client = client_receiver
+            .borrow()
+            .as_ref()
+            .expect("Client should already exist")
+            .clone();
+
+        TestState {
+            client: Arc::new(client),
+            cache_name,
+            runtime,
+        }
+    }
+}

--- a/tests/cache_test_state.rs
+++ b/tests/cache_test_state.rs
@@ -7,6 +7,7 @@ use tokio::sync::watch::channel;
 
 use momento::config::configurations;
 use momento::{CacheClient, CredentialProviderBuilder, MomentoError};
+use momento_test_util::{get_test_cache_name, get_test_credential_provider};
 
 pub static TEST_STATE: Lazy<Arc<TestState>> = Lazy::new(|| Arc::new(TestState::new()));
 
@@ -19,15 +20,11 @@ pub struct TestState {
 
 impl TestState {
     fn new() -> Self {
-        let cache_name =
-            env::var("TEST_CACHE_NAME").unwrap_or_else(|_| "rust-test-cache".to_string());
+        let cache_name = get_test_cache_name();
         println!("Using cache name: {}", cache_name);
         let thread_cache_name = cache_name.clone();
 
-        let credential_provider =
-            CredentialProviderBuilder::from_environment_variable("TEST_API_KEY".to_string())
-                .build()
-                .expect("auth token should be valid");
+        let credential_provider = get_test_credential_provider();
 
         // The cache client must be created using a separate tokio runtime because each test
         // creates it own runtime, and the client will stop running if its runtime is destroyed.

--- a/tests/cache_test_state.rs
+++ b/tests/cache_test_state.rs
@@ -1,10 +1,12 @@
-use momento::config::configurations;
-use momento::{CacheClient, CredentialProviderBuilder, MomentoError};
-use once_cell::sync::Lazy;
 use std::env;
 use std::sync::Arc;
 use std::time::Duration;
+
+use once_cell::sync::Lazy;
 use tokio::sync::watch::channel;
+
+use momento::config::configurations;
+use momento::{CacheClient, CredentialProviderBuilder, MomentoError};
 
 pub static TEST_STATE: Lazy<Arc<TestState>> = Lazy::new(|| Arc::new(TestState::new()));
 
@@ -32,7 +34,7 @@ impl TestState {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
-            .unwrap();
+            .expect("test state tokio runtime failure");
         let (sender, client_receiver) = channel(None);
         let barrier = Arc::new(std::sync::Barrier::new(2));
         let thread_barrier = barrier.clone();
@@ -56,7 +58,9 @@ impl TestState {
                 },
             }
 
-            sender.send(Some(cache_client)).unwrap();
+            sender
+                .send(Some(cache_client))
+                .expect("client should be sent to test state thread");
             thread_barrier.wait();
         });
         barrier.wait();


### PR DESCRIPTION
Add sorted set put element(s), fetch by rank, and fetch by score.

Add create and delete cache methods for testing.

Add test setup and teardown scripts so that we can guarantee the cache exists for doc and integration tests, and ensure it is deleted after they run.

Call the setup and teardown scripts in github ci.