### PR TITLE
feat: add get/set to CacheClient to support readme.ts example

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-momento = "0.15.0"
+#momento = "0.15.0"
+momento = { path = "../" }
 tokio = { version = "1.18.2", features = ["full"] }

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -5,6 +5,9 @@ use momento::simple_cache_client::SimpleCacheClientBuilder;
 use std::env;
 use std::num::NonZeroU64;
 use std::process;
+use std::time::Duration;
+use momento::{CacheClient, CredentialProvider};
+use momento::config::configurations::laptop;
 
 #[tokio::main]
 async fn main() {

--- a/example/src/readme.rs
+++ b/example/src/readme.rs
@@ -1,3 +1,26 @@
-pub fn main() {
-    // TODO: add example code here
+use std::time::Duration;
+use momento::{CacheClient, CredentialProvider};
+use momento::config::configurations::laptop;
+
+const CACHE_NAME: String = "cache";
+
+pub async fn main() {
+    let cache_client = CacheClient::new(
+        CredentialProvider::from_env_var("MOMENTO_API_KEY")?,
+        laptop::latest(),
+        Duration::from_secs(60)
+    )?;
+
+    cache_client.create_cache(CACHE_NAME).await?;
+    
+    match(cache_client.set(CACHE_NAME, "mykey", "myvalue").await) {
+        Ok(_) => println!("Successfully stored key 'mykey' with value 'myvalue'"),
+        Err(e) => println!("Error: {}", e)
+    }
+    
+    let value = match(cache_client.get(CACHE_NAME, "mykey").await?) {
+        
+    };
+
+
 }

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -172,7 +172,6 @@ impl CacheClient {
     /// * `cache_name` - name of cache
     /// * `key` - key of the item whose value we are setting
     /// * `value` - data to stored in the cache item
-    /// * `ttl` - The TTL to use for the
     ///
     /// # Examples
     ///

--- a/src/credential_provider.rs
+++ b/src/credential_provider.rs
@@ -52,7 +52,7 @@ impl CredentialProvider {
         CredentialProviderBuilder::from_environment_variable(env_var_name).build()
     }
 
-    /// Returns a builder to produce a Credential Provider from the provided API key
+    /// Returns a Credential Provider from the provided API key
     ///
     /// # Arguments
     ///

--- a/src/credential_provider.rs
+++ b/src/credential_provider.rs
@@ -32,7 +32,7 @@ pub struct CredentialProvider {
 }
 
 impl CredentialProvider {
-    /// Returns a builder to produce a Credential Provider using an API key stored in the specified
+    /// Returns a Credential Provider using an API key stored in the specified
     /// environment variable
     ///
     /// # Arguments

--- a/src/credential_provider.rs
+++ b/src/credential_provider.rs
@@ -42,9 +42,9 @@ impl CredentialProvider {
     ///
     /// ```
     /// # tokio_test::block_on(async {
-    ///     use momento::CredentialProvider;
-    ///     let credential_provider = CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
-    ///         .expect("MOMENTO_API_KEY must be set");
+    /// use momento::CredentialProvider;
+    /// let credential_provider = CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
+    ///     .expect("MOMENTO_API_KEY must be set");
     /// # })
     /// ```
     ///
@@ -63,16 +63,16 @@ impl CredentialProvider {
     /// # use momento::MomentoResult;
     /// # fn main() -> () {
     /// # tokio_test::block_on(async {
-    ///     use momento::CredentialProvider;
+    /// use momento::CredentialProvider;
     ///
-    ///     let api_key = "YOUR API KEY GOES HERE";
-    ///     let credential_provider = match(CredentialProvider::from_string(api_key.to_string())) {
-    ///        Ok(credential_provider) => credential_provider,
-    ///        Err(e) => {
-    ///             println!("Error while creating credential provider: {}", e);
-    ///             return // probably you will do something else here
-    ///        }
-    ///     };
+    /// let api_key = "YOUR API KEY GOES HERE";
+    /// let credential_provider = match(CredentialProvider::from_string(api_key.to_string())) {
+    ///    Ok(credential_provider) => credential_provider,
+    ///    Err(e) => {
+    ///         println!("Error while creating credential provider: {}", e);
+    ///         return // probably you will do something else here
+    ///    }
+    /// };
     ///
     /// # ()
     /// # })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod grpc;
 mod simple_cache_client;
 mod utils;
 
-pub use crate::credential_provider::{CredentialProvider, CredentialProviderBuilder};
+pub use crate::credential_provider::CredentialProvider;
 pub use crate::response::ErrorSource;
 pub use crate::response::MomentoError;
 pub use crate::simple_cache_client::{

--- a/src/preview/topics.rs
+++ b/src/preview/topics.rs
@@ -21,12 +21,11 @@ pub struct TopicClient {
 /// Work with topics, publishing and subscribing.
 /// ```rust
 /// use momento::preview::topics::TopicClient;
-/// use momento::{CredentialProvider, CredentialProviderBuilder};
+/// use momento::{CredentialProvider};
 /// use futures::StreamExt;
 ///
 /// async {
-///     let credential_provider = CredentialProviderBuilder::from_string("token".to_string())
-///        .build()
+///     let credential_provider = CredentialProvider::from_string("token".to_string())
 ///        .expect("could not get credentials");
 ///     // Get a topic client
 ///     let client = TopicClient::connect(

--- a/src/requests/cache/basic/get.rs
+++ b/src/requests/cache/basic/get.rs
@@ -1,0 +1,169 @@
+use crate::cache_client::CacheClient;
+use crate::requests::cache::MomentoRequest;
+use crate::simple_cache_client::prep_request;
+use crate::utils::parse_string;
+use crate::{IntoBytes, MomentoError, MomentoResult};
+use momento_protos::cache_client::ECacheResult;
+use std::convert::{TryFrom, TryInto};
+
+/// ```
+/// # fn main() -> anyhow::Result<()> {
+/// # use momento_test_util::create_doctest_client;
+/// # tokio_test::block_on(async {
+/// # let (cache_client, cache_name) = create_doctest_client();
+/// use std::convert::TryInto;
+/// use momento::requests::cache::basic::get::Get;
+///
+/// let get_response = cache_client.get(&cache_name, "key").await?;
+///
+/// let item: String = match get_response {
+///     Get::Hit { value } => value.try_into().expect("I stored a string!"),
+///     Get::Miss => return Err(anyhow::Error::msg("cache miss")) // probably you'll do something else here
+/// };
+///
+/// # Ok(())
+/// # })
+/// #
+/// }
+/// ```
+pub struct GetRequest<K: IntoBytes> {
+    cache_name: String,
+    key: K,
+}
+
+impl<K: IntoBytes> GetRequest<K> {
+    pub fn new(cache_name: String, key: K) -> Self {
+        Self { cache_name, key }
+    }
+}
+
+impl<K: IntoBytes> MomentoRequest for GetRequest<K> {
+    type Response = Get;
+
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<Get> {
+        let request = prep_request(
+            &self.cache_name,
+            momento_protos::cache_client::GetRequest {
+                cache_key: self.key.into_bytes(),
+            },
+        )?;
+
+        let response = cache_client
+            .data_client
+            .clone()
+            .get(request)
+            .await?
+            .into_inner();
+        match response.result() {
+            ECacheResult::Hit => Ok(Get::Hit {
+                value: GetValue {
+                    raw_item: response.cache_body,
+                },
+            }),
+            ECacheResult::Miss => Ok(Get::Miss),
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// Response for a cache get operation.
+///
+/// If you'd like to handle misses you can simply match and handle your response:
+/// ```
+/// # use momento::response::Get;
+/// # use momento::MomentoResult;
+/// # let get_response = Get::Hit { value: momento::response::GetValue::new(vec![]) };
+/// use std::convert::TryInto;
+/// let item: String = match get_response {
+///     Get::Hit { value } => value.try_into().expect("I stored a string!"),
+///     Get::Miss => return // probably you'll do something else here
+/// };
+/// ```
+///
+/// Or, if you're storing raw bytes you can get at them simply:
+/// ```
+/// # use momento::response::Get;
+/// # use momento::MomentoResult;
+/// # let get_response = Get::Hit { value: momento::response::GetValue::new(vec![]) };
+/// let item: Vec<u8> = match get_response {
+///     Get::Hit { value } => value.into(),
+///     Get::Miss => return // probably you'll do something else here
+/// };
+/// ```
+///
+/// You can cast your result directly into a Result<String, MomentoError> suitable for
+/// ?-propagation if you know you are expecting a String item.
+///
+/// Of course, a Miss in this case will be turned into an Error. If that's what you want, then
+/// this is what you're after:
+/// ```
+/// # use momento::response::Get;
+/// # use momento::MomentoResult;
+/// # let get_response = Get::Hit { value: momento::response::GetValue::new(vec![]) };
+/// use std::convert::TryInto;
+/// let item: MomentoResult<String> = get_response.try_into();
+/// ```
+///
+/// You can also go straight into a Vec<u8> if you prefer:
+/// ```
+/// # use momento::response::Get;
+/// # use momento::MomentoResult;
+/// # let get_response = Get::Hit { value: momento::response::GetValue::new(vec![]) };
+/// use std::convert::TryInto;
+/// let item: MomentoResult<Vec<u8>> = get_response.try_into();
+/// ```
+#[derive(Debug, PartialEq, Eq)]
+pub enum Get {
+    Hit { value: GetValue },
+    Miss,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct GetValue {
+    pub(crate) raw_item: Vec<u8>,
+}
+impl GetValue {
+    pub fn new(raw_item: Vec<u8>) -> Self {
+        Self { raw_item }
+    }
+}
+
+impl TryFrom<GetValue> for String {
+    type Error = MomentoError;
+
+    fn try_from(value: GetValue) -> Result<Self, Self::Error> {
+        parse_string(value.raw_item)
+    }
+}
+
+impl From<GetValue> for Vec<u8> {
+    fn from(value: GetValue) -> Self {
+        value.raw_item
+    }
+}
+
+impl TryFrom<Get> for String {
+    type Error = MomentoError;
+
+    fn try_from(value: Get) -> Result<Self, Self::Error> {
+        match value {
+            Get::Hit { value } => value.try_into(),
+            Get::Miss => Err(MomentoError::Miss {
+                description: std::borrow::Cow::Borrowed("get response was a miss"),
+            }),
+        }
+    }
+}
+
+impl TryFrom<Get> for Vec<u8> {
+    type Error = MomentoError;
+
+    fn try_from(value: Get) -> Result<Self, Self::Error> {
+        match value {
+            Get::Hit { value } => Ok(value.into()),
+            Get::Miss => Err(MomentoError::Miss {
+                description: std::borrow::Cow::Borrowed("get response was a miss"),
+            }),
+        }
+    }
+}

--- a/src/requests/cache/basic/mod.rs
+++ b/src/requests/cache/basic/mod.rs
@@ -1,0 +1,2 @@
+pub mod get;
+pub mod set;

--- a/src/requests/cache/basic/set.rs
+++ b/src/requests/cache/basic/set.rs
@@ -1,0 +1,68 @@
+use crate::cache_client::CacheClient;
+use crate::requests::cache::MomentoRequest;
+use crate::simple_cache_client::prep_request_with_timeout;
+use crate::{IntoBytes, MomentoResult};
+use std::time::Duration;
+
+/// ```
+/// # fn main() -> anyhow::Result<()> {
+/// # use momento_test_util::create_doctest_client;
+/// # tokio_test::block_on(async {
+/// # let (cache_client, cache_name) = create_doctest_client();
+/// use momento::requests::cache::basic::set::Set;
+///
+/// let set_response = cache_client.set(&cache_name, "key", "value").await?;
+/// assert_eq!(set_response, Set {});
+/// # Ok(())
+/// # })
+/// #
+/// }
+/// ```
+pub struct SetRequest<K: IntoBytes, V: IntoBytes> {
+    cache_name: String,
+    key: K,
+    value: V,
+    ttl: Option<Duration>,
+}
+
+impl<K: IntoBytes, V: IntoBytes> SetRequest<K, V> {
+    pub fn new(cache_name: String, key: K, value: V) -> Self {
+        let ttl = None;
+        Self {
+            cache_name,
+            key,
+            value,
+            ttl,
+        }
+    }
+
+    pub fn with_ttl(mut self, ttl: Duration) -> Self {
+        self.ttl = Some(ttl);
+        self
+    }
+}
+
+impl<K: IntoBytes, V: IntoBytes> MomentoRequest for SetRequest<K, V> {
+    type Response = Set;
+
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<Set> {
+        // let ttl = self.ttl.unwrap_or_default();
+        // let elements = self.elements.into_iter().map(|e| e.into_bytes()).collect();
+        // let set_name = self.set_name.into_bytes();
+        let request = prep_request_with_timeout(
+            &self.cache_name,
+            cache_client.configuration.deadline_millis(),
+            momento_protos::cache_client::SetRequest {
+                cache_key: self.key.into_bytes(),
+                cache_body: self.value.into_bytes(),
+                ttl_milliseconds: cache_client.expand_ttl_ms(self.ttl)?,
+            },
+        )?;
+
+        let _ = cache_client.data_client.clone().set(request).await?;
+        Ok(Set {})
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Set {}

--- a/src/requests/cache/basic/set.rs
+++ b/src/requests/cache/basic/set.rs
@@ -46,9 +46,6 @@ impl<K: IntoBytes, V: IntoBytes> MomentoRequest for SetRequest<K, V> {
     type Response = Set;
 
     async fn send(self, cache_client: &CacheClient) -> MomentoResult<Set> {
-        // let ttl = self.ttl.unwrap_or_default();
-        // let elements = self.elements.into_iter().map(|e| e.into_bytes()).collect();
-        // let set_name = self.set_name.into_bytes();
         let request = prep_request_with_timeout(
             &self.cache_name,
             cache_client.configuration.deadline_millis(),

--- a/src/requests/cache/mod.rs
+++ b/src/requests/cache/mod.rs
@@ -4,11 +4,9 @@ use crate::MomentoResult;
 pub mod create_cache;
 pub mod delete_cache;
 
-pub mod set_add_elements;
-pub mod sorted_set_fetch_by_rank;
-pub mod sorted_set_fetch_by_score;
-pub mod sorted_set_put_element;
-pub mod sorted_set_put_elements;
+pub mod basic;
+pub mod set;
+pub mod sorted_set;
 
 pub trait MomentoRequest {
     type Response;

--- a/src/requests/cache/set/mod.rs
+++ b/src/requests/cache/set/mod.rs
@@ -1,0 +1,1 @@
+pub mod set_add_elements;

--- a/src/requests/cache/set/set_add_elements.rs
+++ b/src/requests/cache/set/set_add_elements.rs
@@ -9,12 +9,11 @@ use crate::{CollectionTtl, IntoBytes, MomentoResult};
 /// # fn main() -> anyhow::Result<()> {
 /// # tokio_test::block_on(async {
 /// use std::time::Duration;
-/// use momento::{CredentialProviderBuilder};
-/// use momento::requests::cache::set_add_elements::SetAddElements;
+/// use momento::{CredentialProvider};
+/// use momento::requests::cache::set::set_add_elements::SetAddElements;
 /// use momento::config::configurations;
 ///
-/// let credential_provider = CredentialProviderBuilder::from_environment_variable("MOMENTO_API_KEY".to_string())
-///     .build()?;
+/// let credential_provider = CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())?;
 /// let cache_name = "cache";
 ///
 /// let cache_client = momento::CacheClient::new(credential_provider, configurations::laptop::latest(), Duration::from_secs(5))?;

--- a/src/requests/cache/sorted_set/mod.rs
+++ b/src/requests/cache/sorted_set/mod.rs
@@ -1,0 +1,4 @@
+pub mod sorted_set_fetch_by_rank;
+pub mod sorted_set_fetch_by_score;
+pub mod sorted_set_put_element;
+pub mod sorted_set_put_elements;

--- a/src/requests/cache/sorted_set/sorted_set_fetch_by_rank.rs
+++ b/src/requests/cache/sorted_set/sorted_set_fetch_by_rank.rs
@@ -1,7 +1,6 @@
 use momento_protos::cache_client::sorted_set_fetch_request::{by_index, ByIndex, Range};
 use momento_protos::cache_client::{SortedSetFetchRequest, Unbounded};
 
-use crate::requests::cache::sorted_set_fetch_by_rank::SortOrder::Ascending;
 use crate::requests::cache::MomentoRequest;
 use crate::response::cache::sorted_set_fetch::SortedSetFetch;
 use crate::simple_cache_client::prep_request_with_timeout;
@@ -37,8 +36,8 @@ pub enum SortOrder {
 /// # use std::convert::TryInto;
 /// # use momento_test_util::create_doctest_client;
 /// # tokio_test::block_on(async {
-/// use momento::requests::cache::sorted_set_fetch_by_rank::SortOrder;
-/// use momento::requests::cache::sorted_set_fetch_by_rank::SortedSetFetchByRankRequest;
+/// use momento::requests::cache::sorted_set::sorted_set_fetch_by_rank::SortOrder;
+/// use momento::requests::cache::sorted_set::sorted_set_fetch_by_rank::SortedSetFetchByRankRequest;
 /// use momento::response::cache::sorted_set_fetch::SortedSetFetch;
 /// # let (cache_client, cache_name) = create_doctest_client();
 /// let sorted_set_name = "sorted_set";
@@ -77,7 +76,7 @@ impl<S: IntoBytes> SortedSetFetchByRankRequest<S> {
             sorted_set_name,
             start_rank: None,
             end_rank: None,
-            order: Ascending,
+            order: SortOrder::Ascending,
         }
     }
 

--- a/src/requests/cache/sorted_set/sorted_set_fetch_by_score.rs
+++ b/src/requests/cache/sorted_set/sorted_set_fetch_by_score.rs
@@ -2,8 +2,8 @@ use momento_protos::cache_client::sorted_set_fetch_request::by_score::Score;
 use momento_protos::cache_client::sorted_set_fetch_request::{by_score, ByScore, Range};
 use momento_protos::cache_client::{SortedSetFetchRequest, Unbounded};
 
-use crate::requests::cache::sorted_set_fetch_by_rank::SortOrder;
-use crate::requests::cache::sorted_set_fetch_by_rank::SortOrder::Ascending;
+use crate::requests::cache::sorted_set::sorted_set_fetch_by_rank::SortOrder;
+use crate::requests::cache::sorted_set::sorted_set_fetch_by_rank::SortOrder::Ascending;
 use crate::requests::cache::MomentoRequest;
 use crate::response::cache::sorted_set_fetch::SortedSetFetch;
 use crate::simple_cache_client::prep_request_with_timeout;
@@ -36,8 +36,8 @@ use crate::{CacheClient, IntoBytes, MomentoResult};
 /// # use std::convert::TryInto;
 /// # use momento_test_util::create_doctest_client;
 /// # tokio_test::block_on(async {
-/// use momento::requests::cache::sorted_set_fetch_by_rank::SortOrder;
-/// use momento::requests::cache::sorted_set_fetch_by_score::SortedSetFetchByScoreRequest;
+/// use momento::requests::cache::sorted_set::sorted_set_fetch_by_rank::SortOrder;
+/// use momento::requests::cache::sorted_set::sorted_set_fetch_by_score::SortedSetFetchByScoreRequest;
 /// use momento::response::cache::sorted_set_fetch::SortedSetFetch;
 /// # let (cache_client, cache_name) = create_doctest_client();
 /// let sorted_set_name = "sorted_set";

--- a/src/requests/cache/sorted_set/sorted_set_put_element.rs
+++ b/src/requests/cache/sorted_set/sorted_set_put_element.rs
@@ -4,14 +4,15 @@ use crate::requests::cache::MomentoRequest;
 use crate::simple_cache_client::prep_request_with_timeout;
 use crate::{CacheClient, CollectionTtl, IntoBytes, MomentoResult};
 
-/// Request to add elements to a sorted set. If an element already exists, its score is updated.
+/// Request to add an element to a sorted set. If the element already exists, its score is updated.
 /// Creates the sorted set if it does not exist.
 ///
 /// # Arguments
 ///
 /// * `cache_name` - The name of the cache containing the sorted set.
 /// * `sorted_set_name` - The name of the sorted set ot add an element to.
-/// * `elements` - The values and scores to add. The values must be able to be converted to a Vec<u8>.
+/// * `value` - The value of the element to add. Must be able to be converted to a Vec<u8>.
+/// * `score` - The score of the element to add.
 ///
 /// # Optional Arguments
 ///
@@ -24,37 +25,40 @@ use crate::{CacheClient, CollectionTtl, IntoBytes, MomentoResult};
 /// # use momento_test_util::create_doctest_client;
 /// # tokio_test::block_on(async {
 /// use momento::CollectionTtl;
-/// use momento::requests::cache::sorted_set_put_elements::SortedSetPutElements;
-/// use momento::requests::cache::sorted_set_put_elements::SortedSetPutElementsRequest;
+/// use momento::requests::cache::sorted_set::sorted_set_put_element::SortedSetPutElement;
+/// use momento::requests::cache::sorted_set::sorted_set_put_element::SortedSetPutElementRequest;
 /// # let (cache_client, cache_name) = create_doctest_client();
 /// let sorted_set_name = "sorted_set";
 ///
-/// let put_elements_request = SortedSetPutElementsRequest::new(
+/// let put_element_request = SortedSetPutElementRequest::new(
 ///     cache_name.to_string(),
 ///     sorted_set_name.to_string(),
-///     vec![("value1", 1.0), ("value2", 2.0)]
+///     "value",
+///     1.0
 /// ).with_ttl(CollectionTtl::default());
 ///
-/// let put_elements_response = cache_client.send_request(put_elements_request).await?;
+/// let create_cache_response = cache_client.send_request(put_element_request).await?;
 ///
-/// assert_eq!(put_elements_response, SortedSetPutElements {});
+/// assert_eq!(create_cache_response, SortedSetPutElement {});
 /// # Ok(())
 /// # })
 /// # }
-pub struct SortedSetPutElementsRequest<S: IntoBytes, E: IntoBytes> {
+pub struct SortedSetPutElementRequest<S: IntoBytes, V: IntoBytes> {
     cache_name: String,
     sorted_set_name: S,
-    elements: Vec<(E, f64)>,
+    value: V,
+    score: f64,
     collection_ttl: Option<CollectionTtl>,
 }
 
-impl<S: IntoBytes, E: IntoBytes> SortedSetPutElementsRequest<S, E> {
-    pub fn new(cache_name: String, sorted_set_name: S, elements: Vec<(E, f64)>) -> Self {
+impl<S: IntoBytes, V: IntoBytes> SortedSetPutElementRequest<S, V> {
+    pub fn new(cache_name: String, sorted_set_name: S, value: V, score: f64) -> Self {
         let collection_ttl = CollectionTtl::default();
         Self {
             cache_name,
             sorted_set_name,
-            elements,
+            value,
+            score,
             collection_ttl: Some(collection_ttl),
         }
     }
@@ -66,19 +70,15 @@ impl<S: IntoBytes, E: IntoBytes> SortedSetPutElementsRequest<S, E> {
     }
 }
 
-impl<S: IntoBytes, E: IntoBytes> MomentoRequest for SortedSetPutElementsRequest<S, E> {
-    type Response = SortedSetPutElements;
+impl<S: IntoBytes, V: IntoBytes> MomentoRequest for SortedSetPutElementRequest<S, V> {
+    type Response = SortedSetPutElement;
 
-    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetPutElements> {
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetPutElement> {
         let collection_ttl = self.collection_ttl.unwrap_or_default();
-        let elements = self
-            .elements
-            .into_iter()
-            .map(|e| SortedSetElement {
-                value: e.0.into_bytes(),
-                score: e.1,
-            })
-            .collect();
+        let element = SortedSetElement {
+            value: self.value.into_bytes(),
+            score: self.score,
+        };
         let set_name = self.sorted_set_name.into_bytes();
         let cache_name = &self.cache_name;
         let request = prep_request_with_timeout(
@@ -86,7 +86,7 @@ impl<S: IntoBytes, E: IntoBytes> MomentoRequest for SortedSetPutElementsRequest<
             cache_client.configuration.deadline_millis(),
             SortedSetPutRequest {
                 set_name,
-                elements,
+                elements: vec![element],
                 ttl_milliseconds: cache_client.expand_ttl_ms(collection_ttl.ttl())?,
                 refresh_ttl: collection_ttl.refresh(),
             },
@@ -97,9 +97,9 @@ impl<S: IntoBytes, E: IntoBytes> MomentoRequest for SortedSetPutElementsRequest<
             .clone()
             .sorted_set_put(request)
             .await?;
-        Ok(SortedSetPutElements {})
+        Ok(SortedSetPutElement {})
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct SortedSetPutElements {}
+pub struct SortedSetPutElement {}

--- a/src/requests/cache/sorted_set/sorted_set_put_elements.rs
+++ b/src/requests/cache/sorted_set/sorted_set_put_elements.rs
@@ -4,15 +4,14 @@ use crate::requests::cache::MomentoRequest;
 use crate::simple_cache_client::prep_request_with_timeout;
 use crate::{CacheClient, CollectionTtl, IntoBytes, MomentoResult};
 
-/// Request to add an element to a sorted set. If the element already exists, its score is updated.
+/// Request to add elements to a sorted set. If an element already exists, its score is updated.
 /// Creates the sorted set if it does not exist.
 ///
 /// # Arguments
 ///
 /// * `cache_name` - The name of the cache containing the sorted set.
 /// * `sorted_set_name` - The name of the sorted set ot add an element to.
-/// * `value` - The value of the element to add. Must be able to be converted to a Vec<u8>.
-/// * `score` - The score of the element to add.
+/// * `elements` - The values and scores to add. The values must be able to be converted to a Vec<u8>.
 ///
 /// # Optional Arguments
 ///
@@ -25,40 +24,37 @@ use crate::{CacheClient, CollectionTtl, IntoBytes, MomentoResult};
 /// # use momento_test_util::create_doctest_client;
 /// # tokio_test::block_on(async {
 /// use momento::CollectionTtl;
-/// use momento::requests::cache::sorted_set_put_element::SortedSetPutElement;
-/// use momento::requests::cache::sorted_set_put_element::SortedSetPutElementRequest;
+/// use momento::requests::cache::sorted_set::sorted_set_put_elements::SortedSetPutElements;
+/// use momento::requests::cache::sorted_set::sorted_set_put_elements::SortedSetPutElementsRequest;
 /// # let (cache_client, cache_name) = create_doctest_client();
 /// let sorted_set_name = "sorted_set";
 ///
-/// let put_element_request = SortedSetPutElementRequest::new(
+/// let put_elements_request = SortedSetPutElementsRequest::new(
 ///     cache_name.to_string(),
 ///     sorted_set_name.to_string(),
-///     "value",
-///     1.0
+///     vec![("value1", 1.0), ("value2", 2.0)]
 /// ).with_ttl(CollectionTtl::default());
 ///
-/// let create_cache_response = cache_client.send_request(put_element_request).await?;
+/// let put_elements_response = cache_client.send_request(put_elements_request).await?;
 ///
-/// assert_eq!(create_cache_response, SortedSetPutElement {});
+/// assert_eq!(put_elements_response, SortedSetPutElements {});
 /// # Ok(())
 /// # })
 /// # }
-pub struct SortedSetPutElementRequest<S: IntoBytes, V: IntoBytes> {
+pub struct SortedSetPutElementsRequest<S: IntoBytes, E: IntoBytes> {
     cache_name: String,
     sorted_set_name: S,
-    value: V,
-    score: f64,
+    elements: Vec<(E, f64)>,
     collection_ttl: Option<CollectionTtl>,
 }
 
-impl<S: IntoBytes, V: IntoBytes> SortedSetPutElementRequest<S, V> {
-    pub fn new(cache_name: String, sorted_set_name: S, value: V, score: f64) -> Self {
+impl<S: IntoBytes, E: IntoBytes> SortedSetPutElementsRequest<S, E> {
+    pub fn new(cache_name: String, sorted_set_name: S, elements: Vec<(E, f64)>) -> Self {
         let collection_ttl = CollectionTtl::default();
         Self {
             cache_name,
             sorted_set_name,
-            value,
-            score,
+            elements,
             collection_ttl: Some(collection_ttl),
         }
     }
@@ -70,15 +66,19 @@ impl<S: IntoBytes, V: IntoBytes> SortedSetPutElementRequest<S, V> {
     }
 }
 
-impl<S: IntoBytes, V: IntoBytes> MomentoRequest for SortedSetPutElementRequest<S, V> {
-    type Response = SortedSetPutElement;
+impl<S: IntoBytes, E: IntoBytes> MomentoRequest for SortedSetPutElementsRequest<S, E> {
+    type Response = SortedSetPutElements;
 
-    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetPutElement> {
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetPutElements> {
         let collection_ttl = self.collection_ttl.unwrap_or_default();
-        let element = SortedSetElement {
-            value: self.value.into_bytes(),
-            score: self.score,
-        };
+        let elements = self
+            .elements
+            .into_iter()
+            .map(|e| SortedSetElement {
+                value: e.0.into_bytes(),
+                score: e.1,
+            })
+            .collect();
         let set_name = self.sorted_set_name.into_bytes();
         let cache_name = &self.cache_name;
         let request = prep_request_with_timeout(
@@ -86,7 +86,7 @@ impl<S: IntoBytes, V: IntoBytes> MomentoRequest for SortedSetPutElementRequest<S
             cache_client.configuration.deadline_millis(),
             SortedSetPutRequest {
                 set_name,
-                elements: vec![element],
+                elements,
                 ttl_milliseconds: cache_client.expand_ttl_ms(collection_ttl.ttl())?,
                 refresh_ttl: collection_ttl.refresh(),
             },
@@ -97,9 +97,9 @@ impl<S: IntoBytes, V: IntoBytes> MomentoRequest for SortedSetPutElementRequest<S
             .clone()
             .sorted_set_put(request)
             .await?;
-        Ok(SortedSetPutElement {})
+        Ok(SortedSetPutElements {})
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct SortedSetPutElement {}
+pub struct SortedSetPutElements {}

--- a/src/response/cache/sorted_set_fetch.rs
+++ b/src/response/cache/sorted_set_fetch.rs
@@ -6,6 +6,8 @@ use momento_protos::cache_client::SortedSetFetchResponse;
 
 use crate::{MomentoError, MomentoResult};
 
+// TODO this needs to be moved to the requests directory
+
 #[derive(Debug, PartialEq)]
 pub enum SortedSetFetch {
     Hit { elements: SortedSetElements },

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -167,10 +167,9 @@ impl SimpleCacheClientBuilder {
     ///
     /// ```
     /// # tokio_test::block_on(async {
-    ///     use momento::{CredentialProviderBuilder, SimpleCacheClientBuilder};
+    ///     use momento::{CredentialProvider, SimpleCacheClientBuilder};
     ///     use std::time::Duration;
-    ///     let credential_provider = CredentialProviderBuilder::from_environment_variable("MOMENTO_API_KEY".to_string())
-    ///         .build()
+    ///     let credential_provider = CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
     ///         .expect("MOMENTO_API_KEY must be set");
     ///     let momento = SimpleCacheClientBuilder::new(credential_provider, Duration::from_secs(30))
     ///         .expect("could not create a client")
@@ -282,10 +281,9 @@ impl SimpleCacheClient {
     /// # tokio_test::block_on(async {
     /// use uuid::Uuid;
     /// use std::time::Duration;
-    /// use momento::{CredentialProviderBuilder, SimpleCacheClientBuilder};
+    /// use momento::{CredentialProvider, SimpleCacheClientBuilder};
     ///
-    /// let credential_provider = CredentialProviderBuilder::from_environment_variable("MOMENTO_API_KEY".to_string())
-    ///     .build()
+    /// let credential_provider = CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
     ///     .expect("MOMENTO_API_KEY must be set");
     /// let cache_name = "rust-sdk-".to_string() + &Uuid::new_v4().to_string();
     /// let mut momento = SimpleCacheClientBuilder::new(credential_provider, Duration::from_secs(5))?
@@ -316,10 +314,9 @@ impl SimpleCacheClient {
     /// # use futures::FutureExt;
     /// use uuid::Uuid;
     /// use std::time::Duration;
-    /// use momento::{CredentialProviderBuilder, SimpleCacheClientBuilder};
+    /// use momento::{CredentialProvider, SimpleCacheClientBuilder};
     ///
-    /// let credential_provider = CredentialProviderBuilder::from_environment_variable("MOMENTO_API_KEY".to_string())
-    ///     .build()
+    /// let credential_provider = CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
     ///     .expect("MOMENTO_API_KEY must be set");
     /// let cache_name = "rust-sdk-".to_string() + &Uuid::new_v4().to_string();
     /// let mut momento = SimpleCacheClientBuilder::new(credential_provider, Duration::from_secs(5))?
@@ -421,11 +418,10 @@ impl SimpleCacheClient {
     /// # use futures::FutureExt;
     /// use uuid::Uuid;
     /// use std::time::Duration;
-    /// use momento::{CredentialProviderBuilder, SimpleCacheClientBuilder};
+    /// use momento::{CredentialProvider, SimpleCacheClientBuilder};
     ///
     /// let ttl_minutes = 10;
-    /// let credential_provider = CredentialProviderBuilder::from_environment_variable("MOMENTO_API_KEY".to_string())
-    ///     .build()
+    /// let credential_provider = CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
     ///     .expect("MOMENTO_API_KEY must be set");
     /// let mut momento = SimpleCacheClientBuilder::new(credential_provider, Duration::from_secs(5))?
     ///     .build();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,7 +12,7 @@ use std::time::{self, Duration};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub fn is_ttl_valid(ttl: Duration) -> MomentoResult<()> {
+pub(crate) fn is_ttl_valid(ttl: Duration) -> MomentoResult<()> {
     let max_ttl = Duration::from_millis(u64::MAX);
     if ttl > max_ttl {
         return Err(MomentoError::InvalidArgument {
@@ -28,7 +28,7 @@ pub fn is_ttl_valid(ttl: Duration) -> MomentoResult<()> {
     Ok(())
 }
 
-pub fn is_cache_name_valid(cache_name: &str) -> Result<(), MomentoError> {
+pub(crate) fn is_cache_name_valid(cache_name: &str) -> Result<(), MomentoError> {
     if cache_name.trim().is_empty() {
         return Err(MomentoError::InvalidArgument {
             description: "Cache name cannot be empty".into(),
@@ -38,7 +38,7 @@ pub fn is_cache_name_valid(cache_name: &str) -> Result<(), MomentoError> {
     Ok(())
 }
 
-pub fn is_key_id_valid(key_id: &str) -> Result<(), MomentoError> {
+pub(crate) fn is_key_id_valid(key_id: &str) -> Result<(), MomentoError> {
     if key_id.trim().is_empty() {
         return Err(MomentoError::InvalidArgument {
             description: "Key ID cannot be empty".into(),
@@ -100,6 +100,13 @@ pub(crate) fn connect_channel_lazily_configurable(
     Ok(endpoint.connect_lazy())
 }
 
-pub fn user_agent(user_agent_name: &str) -> String {
+pub(crate) fn user_agent(user_agent_name: &str) -> String {
     format!("rust-{user_agent_name}:{VERSION}")
+}
+
+pub(crate) fn parse_string(raw: Vec<u8>) -> MomentoResult<String> {
+    String::from_utf8(raw).map_err(|e| MomentoError::TypeError {
+        description: std::borrow::Cow::Borrowed("item is not a utf-8 string"),
+        source: Box::new(e),
+    })
 }

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use uuid::Uuid;
 
 use momento::config::configurations;
+use momento::CredentialProvider;
 use momento::{CacheClient, SimpleCacheClientBuilder};
-use momento::{CredentialProvider, CredentialProviderBuilder};
 
 pub type DoctestResult = anyhow::Result<()>;
 
@@ -29,10 +29,8 @@ where
     let _guard = runtime.enter();
 
     let cache_name = "rust-sdk-".to_string() + &Uuid::new_v4().to_string();
-    let credential_provider =
-        CredentialProviderBuilder::from_environment_variable("MOMENTO_API_KEY".to_string())
-            .build()
-            .expect("MOMENTO_API_KEY must be set");
+    let credential_provider = CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
+        .expect("MOMENTO_API_KEY must be set");
 
     let mut client =
         SimpleCacheClientBuilder::new(credential_provider.clone(), Duration::from_secs(5))?.build();
@@ -70,7 +68,6 @@ pub fn get_test_cache_name() -> String {
 }
 
 pub fn get_test_credential_provider() -> CredentialProvider {
-    CredentialProviderBuilder::from_environment_variable("MOMENTO_API_KEY".to_string())
-        .build()
+    CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
         .expect("auth token should be valid")
 }

--- a/tests/cache_sorted_set_tests.rs
+++ b/tests/cache_sorted_set_tests.rs
@@ -1,8 +1,10 @@
 use uuid::Uuid;
 
-use momento::requests::cache::sorted_set_fetch_by_rank::SortOrder::{Ascending, Descending};
-use momento::requests::cache::sorted_set_fetch_by_rank::SortedSetFetchByRankRequest;
-use momento::requests::cache::sorted_set_fetch_by_score::SortedSetFetchByScoreRequest;
+use momento::requests::cache::sorted_set::sorted_set_fetch_by_rank::SortOrder::{
+    Ascending, Descending,
+};
+use momento::requests::cache::sorted_set::sorted_set_fetch_by_rank::SortedSetFetchByRankRequest;
+use momento::requests::cache::sorted_set::sorted_set_fetch_by_score::SortedSetFetchByScoreRequest;
 use momento::response::cache::sorted_set_fetch::SortedSetFetch;
 
 use crate::cache_test_state::TEST_STATE;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,7 +3,7 @@ mod tests {
     use std::{env, time::Duration};
 
     use momento::response::{Get, GetValue};
-    use momento::{CredentialProviderBuilder, SimpleCacheClient};
+    use momento::{CredentialProvider, SimpleCacheClient};
     use momento::{MomentoError, SimpleCacheClientBuilder};
     use serde_json::Value;
     use tokio::time::sleep;
@@ -19,9 +19,7 @@ mod tests {
         auth_token: String,
     ) -> Result<SimpleCacheClientBuilder, MomentoError> {
         SimpleCacheClientBuilder::new_with_explicit_agent_name(
-            CredentialProviderBuilder::from_string(auth_token)
-                .build()
-                .expect("auth token should be valid"),
+            CredentialProvider::from_string(auth_token)?,
             Duration::from_secs(5),
             "integration_test",
         )


### PR DESCRIPTION
The main goal of this PR is to get us closer to having a good example code snippet in the readme.ts file. There were a few things I discovered that we need along the way toward that, so this PR tries to bite off a few of them:

* We need `get` and `set`, so those are added in this PR.

* The credential provider builder pattern didn't seem quite as ergonomic as some of our newer ones (CacheClient/requests), and wasn't consistent with the direction of them, so I tweaked a few things to try to move it in that direction. This is not the final state of this, I intend to do at least one more pass to try to make sure that the builders/constructors for client, requests, cred providers, and configs are as consistent as possible, but this is an interim step.

* I also removed/commented out the support for overriding endpoints in the credential providers for now; these had gotten a little stale relative to the current endpoints support, and I'd rather keep the API surface area as small as possible for now. We will probably have to add these back in in some fashion in order to update the CLI to the new release of the SDK but we can do that when we get there.

I will also add a copy paste of what the example code will look like after this PR, but it can't be merged until we do a release because it exists in the examples dir and must be pinned to a released version of the SDK.