### PR TITLE
chore: fix and build examples

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -8,7 +8,7 @@ The Momento Rust SDK package is available on `crates.io`: [momento](https://crat
 
 Here is a quickstart you can use in your own project:
 
-```csharp
+```rust
 {% include "./example/src/readme.rs" %}
 ```
 

--- a/README.template.md
+++ b/README.template.md
@@ -9,7 +9,7 @@ The Momento Rust SDK package is available on `crates.io`: [momento](https://crat
 Here is a quickstart you can use in your own project:
 
 ```rust
-{% include "./example/src/readme.rs" %}
+{% include "./example/src/bin/readme.rs" %}
 ```
 
 Note that the above code requires an environment variable named MOMENTO_API_KEY which must

--- a/example/Makefile
+++ b/example/Makefile
@@ -7,6 +7,7 @@ lint:
 	cargo fmt -- --check
 	cargo clippy --all-targets --all-features -- -D warnings -W clippy::unwrap_used
 
+
 .PHONY: build
 ## Build project
 build:
@@ -27,29 +28,13 @@ clean-build: clean build
 
 .PHONY: precommit
 ## Run clean-build and test as a step before committing.
-precommit: clean-build lint test build-examples
+precommit: clean-build lint test
 
-
-.PHONY: test-unit
-test-unit:
-	cargo test --lib
-
-.PHONY: test-doctests
-test-doctests:
-	cargo test --doc
-
-.PHONY: test-integration
-test-integration:
-	cargo test --tests
 
 .PHONY: test
-## Run unit and integration tests
-test: test-unit test-integration test-doctests
+test:
+	cargo test
 
-.PHONY: build-examples
-## Build example code
-build-examples:
-	cd example; make lint; make build
 
 # See <https://gist.github.com/klmr/575726c7e05d8780505a> for explanation.
 .PHONY: help

--- a/example/src/bin/readme.rs
+++ b/example/src/bin/readme.rs
@@ -1,32 +1,33 @@
-use std::time::Duration;
-use momento::{CacheClient, CredentialProvider, MomentoError};
-use momento::requests::cache::basic::get::Get;
 use momento::config::configurations::laptop;
+use momento::requests::cache::basic::get::Get;
+use momento::{CacheClient, CredentialProvider, MomentoError};
+use std::time::Duration;
 
 const CACHE_NAME: &str = "cache";
 
+#[tokio::main]
 pub async fn main() -> Result<(), MomentoError> {
     let cache_client = CacheClient::new(
         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())?,
         laptop::latest(),
-        Duration::from_secs(60)
+        Duration::from_secs(60),
     )?;
 
     cache_client.create_cache(CACHE_NAME.to_string()).await?;
-    
-    match(cache_client.set(CACHE_NAME, "mykey", "myvalue").await) {
+
+    match cache_client.set(CACHE_NAME, "mykey", "myvalue").await {
         Ok(_) => println!("Successfully stored key 'mykey' with value 'myvalue'"),
-        Err(e) => println!("Error: {}", e)
+        Err(e) => println!("Error: {}", e),
     }
-    
-    let value: String = match(cache_client.get(CACHE_NAME, "mykey").await?) {
+
+    let value: String = match cache_client.get(CACHE_NAME, "mykey").await? {
         Get::Hit { value } => value.try_into().expect("I stored a string!"),
         Get::Miss => {
             println!("Cache miss!");
-            return Ok(()) // probably you'll do something else here
+            return Ok(()); // probably you'll do something else here
         }
     };
-    
+
     println!("Successfully retrieved value: {}", value);
 
     Ok(())

--- a/example/src/readme.rs
+++ b/example/src/readme.rs
@@ -1,26 +1,33 @@
 use std::time::Duration;
-use momento::{CacheClient, CredentialProvider};
+use momento::{CacheClient, CredentialProvider, MomentoError};
+use momento::requests::cache::basic::get::Get;
 use momento::config::configurations::laptop;
 
-const CACHE_NAME: String = "cache";
+const CACHE_NAME: &str = "cache";
 
-pub async fn main() {
+pub async fn main() -> Result<(), MomentoError> {
     let cache_client = CacheClient::new(
-        CredentialProvider::from_env_var("MOMENTO_API_KEY")?,
+        CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())?,
         laptop::latest(),
         Duration::from_secs(60)
     )?;
 
-    cache_client.create_cache(CACHE_NAME).await?;
+    cache_client.create_cache(CACHE_NAME.to_string()).await?;
     
     match(cache_client.set(CACHE_NAME, "mykey", "myvalue").await) {
         Ok(_) => println!("Successfully stored key 'mykey' with value 'myvalue'"),
         Err(e) => println!("Error: {}", e)
     }
     
-    let value = match(cache_client.get(CACHE_NAME, "mykey").await?) {
-        
+    let value: String = match(cache_client.get(CACHE_NAME, "mykey").await?) {
+        Get::Hit { value } => value.try_into().expect("I stored a string!"),
+        Get::Miss => {
+            println!("Cache miss!");
+            return Ok(()) // probably you'll do something else here
+        }
     };
+    
+    println!("Successfully retrieved value: {}", value);
 
-
+    Ok(())
 }


### PR DESCRIPTION
Prior to this commit, there was a bug in the Makefile that was preventing the examples from actually getting built in CI.

Also there were several things in the examples that were out of date and no longer compile, so this commit fixes them.

NOTE: in an earlier PR, I accidentally committed a change that makes the examples point to `..` to access the SDK, instead of using a release. I will fix this in a future commit but will be easier to do that once we have the release process working again.