### PR TITLE
feat: use impl Into<String> on most public APIs

### DIFF
--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -61,7 +61,7 @@ impl CacheClient {
     /// use momento::requests::cache::create_cache::CreateCache;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     ///
-    /// let create_cache_response = cache_client.create_cache(cache_name.to_string()).await?;
+    /// let create_cache_response = cache_client.create_cache(cache_name).await?;
     ///
     /// assert_eq!(create_cache_response, CreateCache {});
     /// # Ok(())
@@ -77,7 +77,7 @@ impl CacheClient {
     /// use momento::requests::cache::create_cache::CreateCacheRequest;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     ///
-    /// let create_cache_request = CreateCacheRequest::new(cache_name.to_string());
+    /// let create_cache_request = CreateCacheRequest::new(cache_name);
     ///
     /// let create_cache_response = cache_client.send_request(create_cache_request).await?;
     ///
@@ -85,7 +85,7 @@ impl CacheClient {
     /// # Ok(())
     /// # })
     /// # }
-    pub async fn create_cache(&self, cache_name: String) -> MomentoResult<CreateCache> {
+    pub async fn create_cache(&self, cache_name: impl Into<String>) -> MomentoResult<CreateCache> {
         let request = CreateCacheRequest::new(cache_name);
         request.send(self).await
     }
@@ -105,7 +105,7 @@ impl CacheClient {
     /// use momento::requests::cache::delete_cache::DeleteCache;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     ///
-    /// let delete_cache_response = cache_client.delete_cache(cache_name.to_string()).await?;
+    /// let delete_cache_response = cache_client.delete_cache(cache_name).await?;
     ///
     /// assert_eq!(delete_cache_response, DeleteCache {});
     /// # Ok(())
@@ -121,7 +121,7 @@ impl CacheClient {
     /// use momento::requests::cache::delete_cache::DeleteCacheRequest;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     ///
-    /// let delete_cache_request = DeleteCacheRequest::new(cache_name.to_string());
+    /// let delete_cache_request = DeleteCacheRequest::new(cache_name);
     ///
     /// let delete_cache_response = cache_client.send_request(delete_cache_request).await?;
     ///
@@ -129,7 +129,7 @@ impl CacheClient {
     /// # Ok(())
     /// # })
     /// # }
-    pub async fn delete_cache(&self, cache_name: String) -> MomentoResult<DeleteCache> {
+    pub async fn delete_cache(&self, cache_name: impl Into<String>) -> MomentoResult<DeleteCache> {
         let request = DeleteCacheRequest::new(cache_name);
         request.send(self).await
     }
@@ -166,7 +166,7 @@ impl CacheClient {
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     ///
     /// let set_request = SetRequest::new(
-    ///     cache_name.to_string(),
+    ///     cache_name,
     ///     "key",
     ///     "value1"
     /// ).with_ttl(Duration::from_secs(60));
@@ -179,11 +179,11 @@ impl CacheClient {
     /// # }
     pub async fn set(
         &self,
-        cache_name: &str,
+        cache_name: impl Into<String>,
         key: impl IntoBytes,
         value: impl IntoBytes,
     ) -> MomentoResult<Set> {
-        let request = SetRequest::new(cache_name.to_string(), key, value);
+        let request = SetRequest::new(cache_name, key, value);
         request.send(self).await
     }
 
@@ -242,8 +242,12 @@ impl CacheClient {
     /// # Ok(())
     /// # })
     /// # }
-    pub async fn get(&self, cache_name: &str, key: impl IntoBytes) -> MomentoResult<Get> {
-        let request = GetRequest::new(cache_name.to_string(), key);
+    pub async fn get(
+        &self,
+        cache_name: impl Into<String>,
+        key: impl IntoBytes,
+    ) -> MomentoResult<Get> {
+        let request = GetRequest::new(cache_name, key);
         request.send(self).await
     }
 
@@ -272,8 +276,8 @@ impl CacheClient {
     /// let set_name = "set";
     ///
     /// let add_elements_response = cache_client.set_add_elements(
-    ///     cache_name.to_string(),
-    ///     set_name.to_string(),
+    ///     cache_name,
+    ///     set_name,
     ///     vec!["value1", "value2"]
     /// ).await?;
     ///
@@ -294,8 +298,8 @@ impl CacheClient {
     /// let set_name = "set";
     ///
     /// let add_elements_request = SetAddElementsRequest::new(
-    ///     cache_name.to_string(),
-    ///     set_name.to_string(),
+    ///     cache_name,
+    ///     set_name,
     ///     vec!["value1", "value2"]
     /// ).with_ttl(CollectionTtl::default());
     ///
@@ -307,7 +311,7 @@ impl CacheClient {
     /// # }
     pub async fn set_add_elements<E: IntoBytes>(
         &self,
-        cache_name: String,
+        cache_name: impl Into<String>,
         set_name: impl IntoBytes,
         elements: Vec<E>,
     ) -> MomentoResult<SetAddElements> {
@@ -342,8 +346,8 @@ impl CacheClient {
     /// let sorted_set_name = "sorted_set";
     ///
     /// let put_element_response = cache_client.sorted_set_put_element(
-    ///     cache_name.to_string(),
-    ///     sorted_set_name.to_string(),
+    ///     cache_name,
+    ///     sorted_set_name,
     ///     "value",
     ///     1.0
     /// ).await?;
@@ -365,8 +369,8 @@ impl CacheClient {
     /// let sorted_set_name = "sorted_set";
     ///
     /// let put_element_request = SortedSetPutElementRequest::new(
-    ///     cache_name.to_string(),
-    ///     sorted_set_name.to_string(),
+    ///     cache_name,
+    ///     sorted_set_name,
     ///     "value",
     ///     1.0
     /// ).with_ttl(CollectionTtl::default());
@@ -379,7 +383,7 @@ impl CacheClient {
     /// # }
     pub async fn sorted_set_put_element(
         &self,
-        cache_name: String,
+        cache_name: impl Into<String>,
         sorted_set_name: impl IntoBytes,
         value: impl IntoBytes,
         score: f64,
@@ -414,8 +418,8 @@ impl CacheClient {
     /// let sorted_set_name = "sorted_set";
     ///
     /// let put_element_response = cache_client.sorted_set_put_elements(
-    ///     cache_name.to_string(),
-    ///     sorted_set_name.to_string(),
+    ///     cache_name,
+    ///     sorted_set_name,
     ///     vec![("value1", 1.0), ("value2", 2.0)]
     /// ).await?;
     ///
@@ -436,8 +440,8 @@ impl CacheClient {
     /// let sorted_set_name = "sorted_set";
     ///
     /// let put_elements_request = SortedSetPutElementsRequest::new(
-    ///     cache_name.to_string(),
-    ///     sorted_set_name.to_string(),
+    ///     cache_name,
+    ///     sorted_set_name,
     ///     vec![("value1", 1.0), ("value2", 2.0)]
     /// ).with_ttl(CollectionTtl::default());
     ///
@@ -449,7 +453,7 @@ impl CacheClient {
     /// # }
     pub async fn sorted_set_put_elements<E: IntoBytes>(
         &self,
-        cache_name: String,
+        cache_name: impl Into<String>,
         sorted_set_name: impl IntoBytes,
         elements: Vec<(E, f64)>,
     ) -> MomentoResult<SortedSetPutElements> {
@@ -488,8 +492,8 @@ impl CacheClient {
     /// let sorted_set_name = "sorted_set";
     ///
     /// let fetch_response = cache_client.sorted_set_fetch_by_rank(
-    ///     cache_name.to_string(),
-    ///     sorted_set_name.to_string(),
+    ///     cache_name,
+    ///     sorted_set_name,
     ///     SortOrder::Ascending
     /// ).await?;
     ///
@@ -523,8 +527,8 @@ impl CacheClient {
     /// let sorted_set_name = "sorted_set";
     ///
     /// let put_element_response = cache_client.sorted_set_put_elements(
-    ///     cache_name.to_string(),
-    ///     sorted_set_name.to_string(),
+    ///     &cache_name,
+    ///     sorted_set_name,
     ///     vec![("value1", 1.0), ("value2", 2.0), ("value3", 3.0), ("value4", 4.0)]
     /// ).await?;
     ///
@@ -543,7 +547,7 @@ impl CacheClient {
     /// # }
     pub async fn sorted_set_fetch_by_rank(
         &self,
-        cache_name: String,
+        cache_name: impl Into<String>,
         sorted_set_name: impl IntoBytes,
         order: SortOrder,
     ) -> MomentoResult<SortedSetFetch> {
@@ -586,8 +590,8 @@ impl CacheClient {
     /// let sorted_set_name = "sorted_set";
     ///
     /// let fetch_response = cache_client.sorted_set_fetch_by_score(
-    ///     cache_name.to_string(),
-    ///     sorted_set_name.to_string(),
+    ///     cache_name,
+    ///     sorted_set_name,
     ///     SortOrder::Ascending
     /// ).await?;
     ///
@@ -621,8 +625,8 @@ impl CacheClient {
     /// let sorted_set_name = "sorted_set";
     ///
     /// let put_element_response = cache_client.sorted_set_put_elements(
-    ///     cache_name.to_string(),
-    ///     sorted_set_name.to_string(),
+    ///     &cache_name,
+    ///     sorted_set_name,
     ///     vec![("value1", 1.0), ("value2", 2.0), ("value3", 3.0), ("value4", 4.0)]
     /// ).await?;
     ///
@@ -641,7 +645,7 @@ impl CacheClient {
     /// # }
     pub async fn sorted_set_fetch_by_score(
         &self,
-        cache_name: String,
+        cache_name: impl Into<String>,
         sorted_set_name: impl IntoBytes,
         order: SortOrder,
     ) -> MomentoResult<SortedSetFetch> {
@@ -666,7 +670,7 @@ impl CacheClient {
     ///
     /// let sorted_set_name = "a_sorted_set";
     ///
-    /// let fetch_request = SortedSetFetchByRankRequest::new(cache_name.to_string(), sorted_set_name)
+    /// let fetch_request = SortedSetFetchByRankRequest::new(cache_name, sorted_set_name)
     ///     .with_order(SortOrder::Ascending)
     ///     .with_start_rank(1)
     ///     .with_end_rank(3);

--- a/src/credential_provider.rs
+++ b/src/credential_provider.rs
@@ -43,12 +43,13 @@ impl CredentialProvider {
     /// ```
     /// # tokio_test::block_on(async {
     /// use momento::CredentialProvider;
-    /// let credential_provider = CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
+    /// let credential_provider = CredentialProvider::from_env_var("MOMENTO_API_KEY")
     ///     .expect("MOMENTO_API_KEY must be set");
     /// # })
     /// ```
     ///
-    pub fn from_env_var(env_var_name: String) -> MomentoResult<CredentialProvider> {
+    pub fn from_env_var(env_var_name: impl Into<String>) -> MomentoResult<CredentialProvider> {
+        let env_var_name = env_var_name.into();
         let token_to_process = match env::var(&env_var_name) {
             Ok(auth_token) => auth_token,
             Err(e) => {
@@ -76,7 +77,7 @@ impl CredentialProvider {
     /// use momento::CredentialProvider;
     ///
     /// let api_key = "YOUR API KEY GOES HERE";
-    /// let credential_provider = match(CredentialProvider::from_string(api_key.to_string())) {
+    /// let credential_provider = match(CredentialProvider::from_string(api_key)) {
     ///    Ok(credential_provider) => credential_provider,
     ///    Err(e) => {
     ///         println!("Error while creating credential provider: {}", e);
@@ -88,7 +89,8 @@ impl CredentialProvider {
     /// #
     /// # }
     /// ```
-    pub fn from_string(auth_token: String) -> MomentoResult<CredentialProvider> {
+    pub fn from_string(auth_token: impl Into<String>) -> MomentoResult<CredentialProvider> {
+        let auth_token = auth_token.into();
         let token_to_process = {
             if auth_token.is_empty() {
                 return Err(MomentoError::InvalidArgument {
@@ -206,7 +208,7 @@ mod tests {
         let env_var_name = "TEST_ENV_VAR_CREDENTIAL_PROVIDER";
         let v1_token = "eyJlbmRwb2ludCI6Im1vbWVudG9fZW5kcG9pbnQiLCJhcGlfa2V5IjoiZXlKaGJHY2lPaUpJVXpJMU5pSjkuZXlKemRXSWlPaUowWlhOMElITjFZbXBsWTNRaUxDSjJaWElpT2pFc0luQWlPaUlpZlEuaGcyd01iV2Utd2VzUVZ0QTd3dUpjUlVMalJwaFhMUXdRVFZZZlFMM0w3YyJ9Cg==".to_string();
         env::set_var(env_var_name, v1_token);
-        let credential_provider = CredentialProvider::from_env_var(env_var_name.to_string())
+        let credential_provider = CredentialProvider::from_env_var(env_var_name)
             .expect("should be able to build credential provider");
         env::remove_var(env_var_name);
 
@@ -225,7 +227,7 @@ mod tests {
     fn env_var_not_set() {
         let env_var_name = "TEST_ENV_VAR_CREDENTIAL_PROVIDER_NOT_SET";
         let _err_msg = format!("invalid argument: Env var {env_var_name} must be set");
-        let e = CredentialProvider::from_env_var(env_var_name.to_string()).unwrap_err();
+        let e = CredentialProvider::from_env_var(env_var_name).unwrap_err();
 
         assert_eq!(e.to_string(), _err_msg);
     }
@@ -235,7 +237,7 @@ mod tests {
         let env_var_name = "TEST_ENV_VAR_CREDENTIAL_PROVIDER_EMPTY_STRING";
         env::set_var(env_var_name, "");
         let _err_msg = "client error: Could not parse token. Please ensure a valid token was entered correctly.";
-        let e = CredentialProvider::from_env_var(env_var_name.to_string()).unwrap_err();
+        let e = CredentialProvider::from_env_var(env_var_name).unwrap_err();
 
         assert_eq!(e.to_string(), _err_msg);
     }
@@ -271,14 +273,14 @@ mod tests {
 
     #[test]
     fn empty_token() {
-        let e = CredentialProvider::from_string("".to_string()).unwrap_err();
+        let e = CredentialProvider::from_string("").unwrap_err();
         let _err_msg = "invalid argument: Auth token string cannot be empty".to_owned();
         assert_eq!(e.to_string(), _err_msg);
     }
 
     #[test]
     fn invalid_token() {
-        let e = CredentialProvider::from_string("wfheofhriugheifweif".to_string()).unwrap_err();
+        let e = CredentialProvider::from_string("wfheofhriugheifweif").unwrap_err();
         let _err_msg =
             "client error: Could not parse token. Please ensure a valid token was entered correctly.".to_owned();
         assert_eq!(e.to_string(), _err_msg);
@@ -301,7 +303,7 @@ mod tests {
         //   "sub": "abcd"
         // }
         let auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhYmNkIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.PTgxba";
-        let e = CredentialProvider::from_string(auth_token.to_string()).unwrap_err();
+        let e = CredentialProvider::from_string(auth_token).unwrap_err();
         let _err_msg =
             "invalid argument: auth token is missing cache endpoint and endpoint override is missing. One or the other must be provided".to_string();
         assert_eq!(e.to_string(), _err_msg);
@@ -344,7 +346,7 @@ mod tests {
     #[test]
     fn invalid_v1_token_json() {
         let auth_token = "eyJmb28iOiJiYXIifQo=";
-        let e = CredentialProvider::from_string(auth_token.to_string()).unwrap_err();
+        let e = CredentialProvider::from_string(auth_token).unwrap_err();
         let _err_msg =
             "client error: Could not parse token. Please ensure a valid token was entered correctly.".to_string();
         assert_eq!(e.to_string(), _err_msg);

--- a/src/requests/cache/basic/get.rs
+++ b/src/requests/cache/basic/get.rs
@@ -30,8 +30,11 @@ pub struct GetRequest<K: IntoBytes> {
 }
 
 impl<K: IntoBytes> GetRequest<K> {
-    pub fn new(cache_name: String, key: K) -> Self {
-        Self { cache_name, key }
+    pub fn new(cache_name: impl Into<String>, key: K) -> Self {
+        Self {
+            cache_name: cache_name.into(),
+            key,
+        }
     }
 }
 

--- a/src/requests/cache/basic/set.rs
+++ b/src/requests/cache/basic/set.rs
@@ -25,10 +25,10 @@ pub struct SetRequest<K: IntoBytes, V: IntoBytes> {
 }
 
 impl<K: IntoBytes, V: IntoBytes> SetRequest<K, V> {
-    pub fn new(cache_name: String, key: K, value: V) -> Self {
+    pub fn new(cache_name: impl Into<String>, key: K, value: V) -> Self {
         let ttl = None;
         Self {
-            cache_name,
+            cache_name: cache_name.into(),
             key,
             value,
             ttl,

--- a/src/requests/cache/create_cache.rs
+++ b/src/requests/cache/create_cache.rs
@@ -33,8 +33,10 @@ pub struct CreateCacheRequest {
 }
 
 impl CreateCacheRequest {
-    pub fn new(cache_name: String) -> Self {
-        CreateCacheRequest { cache_name }
+    pub fn new(cache_name: impl Into<String>) -> Self {
+        CreateCacheRequest {
+            cache_name: cache_name.into(),
+        }
     }
 }
 
@@ -42,11 +44,9 @@ impl MomentoRequest for CreateCacheRequest {
     type Response = CreateCache;
 
     async fn send(self, cache_client: &CacheClient) -> MomentoResult<CreateCache> {
-        let cache_name = &self.cache_name;
-
-        utils::is_cache_name_valid(cache_name)?;
+        utils::is_cache_name_valid(&self.cache_name)?;
         let request = Request::new(control_client::CreateCacheRequest {
-            cache_name: cache_name.to_string(),
+            cache_name: self.cache_name,
         });
 
         let _ = cache_client

--- a/src/requests/cache/delete_cache.rs
+++ b/src/requests/cache/delete_cache.rs
@@ -33,8 +33,10 @@ pub struct DeleteCacheRequest {
 }
 
 impl DeleteCacheRequest {
-    pub fn new(cache_name: String) -> Self {
-        DeleteCacheRequest { cache_name }
+    pub fn new(cache_name: impl Into<String>) -> Self {
+        DeleteCacheRequest {
+            cache_name: cache_name.into(),
+        }
     }
 }
 

--- a/src/requests/cache/set/set_add_elements.rs
+++ b/src/requests/cache/set/set_add_elements.rs
@@ -26,10 +26,10 @@ pub struct SetAddElementsRequest<S: IntoBytes, E: IntoBytes> {
 }
 
 impl<S: IntoBytes, E: IntoBytes> SetAddElementsRequest<S, E> {
-    pub fn new(cache_name: String, set_name: S, elements: Vec<E>) -> Self {
+    pub fn new(cache_name: impl Into<String>, set_name: S, elements: Vec<E>) -> Self {
         let collection_ttl = CollectionTtl::default();
         Self {
-            cache_name,
+            cache_name: cache_name.into(),
             set_name,
             elements,
             collection_ttl: Some(collection_ttl),

--- a/src/requests/cache/sorted_set/sorted_set_fetch_by_rank.rs
+++ b/src/requests/cache/sorted_set/sorted_set_fetch_by_rank.rs
@@ -70,9 +70,9 @@ pub struct SortedSetFetchByRankRequest<S: IntoBytes> {
 }
 
 impl<S: IntoBytes> SortedSetFetchByRankRequest<S> {
-    pub fn new(cache_name: String, sorted_set_name: S) -> Self {
+    pub fn new(cache_name: impl Into<String>, sorted_set_name: S) -> Self {
         Self {
-            cache_name,
+            cache_name: cache_name.into(),
             sorted_set_name,
             start_rank: None,
             end_rank: None,

--- a/src/requests/cache/sorted_set/sorted_set_fetch_by_score.rs
+++ b/src/requests/cache/sorted_set/sorted_set_fetch_by_score.rs
@@ -72,9 +72,9 @@ pub struct SortedSetFetchByScoreRequest<S: IntoBytes> {
 }
 
 impl<S: IntoBytes> SortedSetFetchByScoreRequest<S> {
-    pub fn new(cache_name: String, sorted_set_name: S) -> Self {
+    pub fn new(cache_name: impl Into<String>, sorted_set_name: S) -> Self {
         Self {
-            cache_name,
+            cache_name: cache_name.into(),
             sorted_set_name,
             min_score: None,
             max_score: None,

--- a/src/requests/cache/sorted_set/sorted_set_put_element.rs
+++ b/src/requests/cache/sorted_set/sorted_set_put_element.rs
@@ -52,10 +52,10 @@ pub struct SortedSetPutElementRequest<S: IntoBytes, V: IntoBytes> {
 }
 
 impl<S: IntoBytes, V: IntoBytes> SortedSetPutElementRequest<S, V> {
-    pub fn new(cache_name: String, sorted_set_name: S, value: V, score: f64) -> Self {
+    pub fn new(cache_name: impl Into<String>, sorted_set_name: S, value: V, score: f64) -> Self {
         let collection_ttl = CollectionTtl::default();
         Self {
-            cache_name,
+            cache_name: cache_name.into(),
             sorted_set_name,
             value,
             score,

--- a/src/requests/cache/sorted_set/sorted_set_put_elements.rs
+++ b/src/requests/cache/sorted_set/sorted_set_put_elements.rs
@@ -49,10 +49,10 @@ pub struct SortedSetPutElementsRequest<S: IntoBytes, E: IntoBytes> {
 }
 
 impl<S: IntoBytes, E: IntoBytes> SortedSetPutElementsRequest<S, E> {
-    pub fn new(cache_name: String, sorted_set_name: S, elements: Vec<(E, f64)>) -> Self {
+    pub fn new(cache_name: impl Into<String>, sorted_set_name: S, elements: Vec<(E, f64)>) -> Self {
         let collection_ttl = CollectionTtl::default();
         Self {
-            cache_name,
+            cache_name: cache_name.into(),
             sorted_set_name,
             elements,
             collection_ttl: Some(collection_ttl),

--- a/src/requests/generate_api_token_request.rs
+++ b/src/requests/generate_api_token_request.rs
@@ -1,4 +1,0 @@
-pub enum TokenExpiry {
-    Never,
-    Expires { valid_for_seconds: u32 },
-}

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -1,2 +1,1 @@
 pub mod cache;
-pub mod generate_api_token_request;


### PR DESCRIPTION
This commit attempts to take a pass through all of the public APIs and find places where we were unnecessarily being too rigid about what flavor of String we accept. We use `impl Into<String>` as the argument type in most places now, which means that callers can pass us either `&str` or `String`.