### PR TITLE
chore: add happy path test for set API

### DIFF
--- a/tests/scalar.rs
+++ b/tests/scalar.rs
@@ -1,0 +1,18 @@
+use momento::requests::cache::basic::set::Set;
+use momento_test_util::CACHE_TEST_STATE;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn set_happy_path() {
+    let client = CACHE_TEST_STATE.client.clone();
+    let cache_name = CACHE_TEST_STATE.cache_name.clone();
+    let key = &Uuid::new_v4().to_string();
+    let value = &Uuid::new_v4().to_string();
+
+    let result = client
+        .set(cache_name.clone(), key.clone(), value.clone())
+        .await
+        .expect("Failed to execute set operation");
+
+    assert_eq!(result, Set {});
+}


### PR DESCRIPTION
Just wanted to add a super simple test for `set` to see the behavior and get a feel of the package.