### PR TITLE
chore: make build fail when there are docs warnings

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Lint (rustfmt and clippy)
         run: make lint
 
+      - name: Compile docs
+        run: make docs
+
   build_rust:
     runs-on: macos-latest
     env:

--- a/Makefile
+++ b/Makefile
@@ -12,17 +12,19 @@ lint:
 build:
 	cargo build --verbose
 
-
 .PHONY: clean
 ## Remove build files
 clean:
 	cargo clean
 
-
 .PHONY: clean-build
 ## Build project
 clean-build: clean build
 
+.PHONY: docs
+## Build the docs, fail on warnings
+docs:
+	RUSTDOCFLAGS="-D warnings" cargo doc
 
 .PHONY: precommit
 ## Run clean-build and test as a step before committing.

--- a/src/requests/cache/list_caches.rs
+++ b/src/requests/cache/list_caches.rs
@@ -68,8 +68,8 @@ pub struct CacheInfo {
 
 /// Response for a list caches operation.
 ///
-/// You can cast your result directly into a Result<Vec<CacheInfo>, MomentoError> suitable for
-/// ?-propagation if you know you are expecting a Vec<CacheInfo> item.
+/// You can cast your result directly into a `Result<Vec<CacheInfo>`, MomentoError> suitable for
+/// ?-propagation if you know you are expecting a `Vec<CacheInfo>` item.
 /// ```
 /// # use momento::requests::cache::list_caches::{CacheInfo, ListCaches};
 /// # use momento::MomentoResult;


### PR DESCRIPTION
Addresses https://github.com/momentohq/client-sdk-rust/issues/199

Adds new Makefile target to build the docs with a flag set to fail when there are warnings. 
Adds new `on-pull-request` workflow step to build the docs with that Makefile target.

First commit should fail with docs warning, second commit should fix the issue and the build should pass.