### PR TITLE
feat: add start_rank and end_rank as optional arguments to SortedSetFetchByRank

### DIFF
--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -556,7 +556,9 @@ impl CacheClient {
     /// let fetch_response = cache_client.sorted_set_fetch_by_rank(
     ///     cache_name,
     ///     sorted_set_name,
-    ///     SortOrder::Ascending
+    ///     SortOrder::Ascending,
+    ///     None,
+    ///     None
     /// ).await?;
     ///
     /// match fetch_response {
@@ -612,8 +614,18 @@ impl CacheClient {
         cache_name: impl Into<String>,
         sorted_set_name: impl IntoBytes,
         order: SortOrder,
+        start_rank: Option<i32>,
+        end_rank: Option<i32>,
     ) -> MomentoResult<SortedSetFetch> {
-        let request = SortedSetFetchByRankRequest::new(cache_name, sorted_set_name).order(order);
+        let mut request =
+            SortedSetFetchByRankRequest::new(cache_name, sorted_set_name).with_order(order);
+
+        if start_rank.is_some() {
+            request = request.with_start_rank(start_rank.expect("start_rank not specified"));
+        }
+        if end_rank.is_some() {
+            request = request.with_end_rank(end_rank.expect("end_rank not specified"));
+        }
         request.send(self).await
     }
 

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -620,11 +620,11 @@ impl CacheClient {
         let mut request =
             SortedSetFetchByRankRequest::new(cache_name, sorted_set_name).order(order);
 
-        if start_rank.is_some() {
-            request = request.start_rank(start_rank.expect("start_rank not specified"));
+        if let Some(start) = start_rank {
+            request = request.start_rank(start);
         }
-        if end_rank.is_some() {
-            request = request.end_rank(end_rank.expect("end_rank not specified"));
+        if let Some(end) = end_rank {
+            request = request.end_rank(end);
         }
         request.send(self).await
     }

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -618,13 +618,13 @@ impl CacheClient {
         end_rank: Option<i32>,
     ) -> MomentoResult<SortedSetFetch> {
         let mut request =
-            SortedSetFetchByRankRequest::new(cache_name, sorted_set_name).with_order(order);
+            SortedSetFetchByRankRequest::new(cache_name, sorted_set_name).order(order);
 
         if start_rank.is_some() {
-            request = request.with_start_rank(start_rank.expect("start_rank not specified"));
+            request = request.start_rank(start_rank.expect("start_rank not specified"));
         }
         if end_rank.is_some() {
-            request = request.with_end_rank(end_rank.expect("end_rank not specified"));
+            request = request.end_rank(end_rank.expect("end_rank not specified"));
         }
         request.send(self).await
     }

--- a/tests/cache_sorted_set.rs
+++ b/tests/cache_sorted_set.rs
@@ -18,7 +18,13 @@ async fn sorted_set_put_element_happy_path() {
     let score = 1.0;
 
     let result = client
-        .sorted_set_fetch_by_rank(cache_name.clone(), sorted_set_name.clone(), Ascending)
+        .sorted_set_fetch_by_rank(
+            cache_name.clone(),
+            sorted_set_name.clone(),
+            Ascending,
+            None,
+            None,
+        )
         .await
         .unwrap();
     assert_eq!(result, SortedSetFetch::Miss);
@@ -29,7 +35,13 @@ async fn sorted_set_put_element_happy_path() {
         .unwrap();
 
     let result = client
-        .sorted_set_fetch_by_rank(cache_name.clone(), sorted_set_name.clone(), Ascending)
+        .sorted_set_fetch_by_rank(
+            cache_name.clone(),
+            sorted_set_name.clone(),
+            Ascending,
+            None,
+            None,
+        )
         .await
         .unwrap();
 
@@ -125,7 +137,13 @@ async fn sorted_set_fetch_by_rank_happy_path() {
     ];
 
     let result = client
-        .sorted_set_fetch_by_rank(cache_name.clone(), sorted_set_name.clone(), Ascending)
+        .sorted_set_fetch_by_rank(
+            cache_name.clone(),
+            sorted_set_name.clone(),
+            Ascending,
+            None,
+            None,
+        )
         .await
         .unwrap();
     assert_eq!(result, SortedSetFetch::Miss);
@@ -191,7 +209,7 @@ async fn sorted_set_fetch_by_rank_nonexistent_cache() {
     let sorted_set_name = "sorted-set";
 
     let result = client
-        .sorted_set_fetch_by_rank(cache_name.clone(), sorted_set_name, Ascending)
+        .sorted_set_fetch_by_rank(cache_name.clone(), sorted_set_name, Ascending, None, None)
         .await
         .unwrap_err();
 


### PR DESCRIPTION
Addresses https://github.com/momentohq/client-sdk-rust/issues/192 

As discussed with Chris and Michael, it's pretty likely users will call fetch by rank to paginate through their sorted set, whereas we can't easily predict what arguments they'll want to set for fetch by score. Hence we're adding the start_rank and end_rank optional arguments to the fetch by rank API as required arguments to differentiate it from fetch by score.