### PR TITLE
chore: refactor tests for better consistency, more accurate asserts

### DIFF
--- a/src/requests/errors.rs
+++ b/src/requests/errors.rs
@@ -4,7 +4,7 @@ use tonic::codegen::http;
 
 use crate::auth::AuthError;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum MomentoErrorCode {
     /// Invalid argument passed to Momento client
     InvalidArgumentError,

--- a/tests/cache_control.rs
+++ b/tests/cache_control.rs
@@ -40,7 +40,12 @@ async fn lists_existing_test_cache() -> MomentoResult<()> {
         .iter()
         .map(|cache_info| cache_info.name.clone())
         .collect();
-    assert!(cache_names.contains(cache_name), "Expected {} to be in list of caches: {:#?}", cache_name, cache_names);
+    assert!(
+        cache_names.contains(cache_name),
+        "Expected {} to be in list of caches: {:#?}",
+        cache_name,
+        cache_names
+    );
     Ok(())
 }
 

--- a/tests/cache_control.rs
+++ b/tests/cache_control.rs
@@ -6,6 +6,7 @@ use momento::requests::cache::{
     },
     flush_cache::FlushCache,
 };
+use momento::requests::MomentoErrorCode;
 use momento::MomentoResult;
 use uuid::Uuid;
 
@@ -16,8 +17,7 @@ async fn delete_nonexistent_cache_returns_not_found() -> MomentoResult<()> {
     let client = &CACHE_TEST_STATE.client;
     let cache_name = "fake-cache-".to_string() + &Uuid::new_v4().to_string();
     let result = client.delete_cache(cache_name).await.unwrap_err();
-    let _err_msg = "not found".to_string();
-    assert!(matches!(result.to_string(), _err_message));
+    assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
     Ok(())
 }
 
@@ -40,7 +40,7 @@ async fn lists_existing_test_cache() -> MomentoResult<()> {
         .iter()
         .map(|cache_info| cache_info.name.clone())
         .collect();
-    assert!(cache_names.contains(cache_name));
+    assert!(cache_names.contains(cache_name), "Expected {} to be in list of caches: {:#?}", cache_name, cache_names);
     Ok(())
 }
 
@@ -49,8 +49,7 @@ async fn flush_nonexistent_cache_returns_not_found() -> MomentoResult<()> {
     let client = &CACHE_TEST_STATE.client;
     let cache_name = "fake-cache-".to_string() + &Uuid::new_v4().to_string();
     let result = client.flush_cache(cache_name).await.unwrap_err();
-    let _err_msg = "not found".to_string();
-    assert!(matches!(result.to_string(), _err_message));
+    assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
     Ok(())
 }
 

--- a/tests/cache_sorted_set.rs
+++ b/tests/cache_sorted_set.rs
@@ -20,13 +20,7 @@ async fn sorted_set_put_element_happy_path() -> MomentoResult<()> {
     let score = 1.0;
 
     let result = client
-        .sorted_set_fetch_by_rank(
-            cache_name,
-            &*sorted_set_name,
-            Ascending,
-            None,
-            None,
-        )
+        .sorted_set_fetch_by_rank(cache_name, &*sorted_set_name, Ascending, None, None)
         .await?;
     assert_eq!(result, SortedSetFetch::Miss);
 
@@ -36,13 +30,7 @@ async fn sorted_set_put_element_happy_path() -> MomentoResult<()> {
         .unwrap();
 
     let result = client
-        .sorted_set_fetch_by_rank(
-            cache_name,
-            &*sorted_set_name,
-            Ascending,
-            None,
-            None,
-        )
+        .sorted_set_fetch_by_rank(cache_name, &*sorted_set_name, Ascending, None, None)
         .await?;
 
     match result {
@@ -136,13 +124,7 @@ async fn sorted_set_fetch_by_rank_happy_path() -> MomentoResult<()> {
     ];
 
     let result = client
-        .sorted_set_fetch_by_rank(
-            cache_name,
-            &*sorted_set_name,
-            Ascending,
-            None,
-            None,
-        )
+        .sorted_set_fetch_by_rank(cache_name, &*sorted_set_name, Ascending, None, None)
         .await?;
     assert_eq!(result, SortedSetFetch::Miss);
 
@@ -151,11 +133,10 @@ async fn sorted_set_fetch_by_rank_happy_path() -> MomentoResult<()> {
         .await?;
 
     // Full set ascending, end index larger than set
-    let fetch_request =
-        SortedSetFetchByRankRequest::new(cache_name, &*sorted_set_name)
-            .order(Ascending)
-            .start_rank(0)
-            .end_rank(6);
+    let fetch_request = SortedSetFetchByRankRequest::new(cache_name, &*sorted_set_name)
+        .order(Ascending)
+        .start_rank(0)
+        .end_rank(6);
 
     let result = client.send_request(fetch_request).await.unwrap();
 
@@ -175,11 +156,10 @@ async fn sorted_set_fetch_by_rank_happy_path() -> MomentoResult<()> {
     }
 
     // Partial set descending
-    let fetch_request =
-        SortedSetFetchByRankRequest::new(cache_name, &*sorted_set_name)
-            .order(Descending)
-            .start_rank(1)
-            .end_rank(4);
+    let fetch_request = SortedSetFetchByRankRequest::new(cache_name, &*sorted_set_name)
+        .order(Descending)
+        .start_rank(1)
+        .end_rank(4);
 
     let result = client.send_request(fetch_request).await.unwrap();
 
@@ -238,11 +218,10 @@ async fn sorted_set_fetch_by_score_happy_path() -> MomentoResult<()> {
         .await?;
 
     // Full set ascending, end score larger than set
-    let fetch_request =
-        SortedSetFetchByScoreRequest::new(cache_name, &*sorted_set_name)
-            .order(Ascending)
-            .min_score(0.0)
-            .max_score(9.9);
+    let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, &*sorted_set_name)
+        .order(Ascending)
+        .min_score(0.0)
+        .max_score(9.9);
 
     let result = client.send_request(fetch_request).await.unwrap();
 
@@ -262,11 +241,10 @@ async fn sorted_set_fetch_by_score_happy_path() -> MomentoResult<()> {
     }
 
     // Partial set descending
-    let fetch_request =
-        SortedSetFetchByScoreRequest::new(cache_name, &*sorted_set_name)
-            .order(Descending)
-            .min_score(0.1)
-            .max_score(1.9);
+    let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, &*sorted_set_name)
+        .order(Descending)
+        .min_score(0.1)
+        .max_score(1.9);
 
     let result = client.send_request(fetch_request).await.unwrap();
 
@@ -286,10 +264,9 @@ async fn sorted_set_fetch_by_score_happy_path() -> MomentoResult<()> {
     }
 
     // Partial set limited by offset and count
-    let fetch_request =
-        SortedSetFetchByScoreRequest::new(cache_name, &*sorted_set_name)
-            .offset(1)
-            .count(3);
+    let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, &*sorted_set_name)
+        .offset(1)
+        .count(3);
 
     let result = client.send_request(fetch_request).await.unwrap();
 


### PR DESCRIPTION
Trying to revise existing tests to better align what we want for best practices:
* avoid using `unwrap`, use `?` instead as per the [contributing docs](https://github.com/momentohq/client-sdk-rust/blob/main/CONTRIBUTING.md)
* tests should return a `MomentoResult` (see [this comment](https://github.com/momentohq/client-sdk-rust/pull/209#discussion_r1542177360))
* avoid `clone()`-ing things unnecessarily
* ran into an issue with `assert!(matches!(...))` not actually working as expected with strings (see [this comment](https://github.com/momentohq/client-sdk-rust/pull/217#issuecomment-2043730017)). Preferring to compare `MomentoErrorCode`s instead when expecting errors