### PR TITLE
fix: move prep_request_with_timeout into utils

### DIFF
--- a/src/cache/requests/scalar/delete.rs
+++ b/src/cache/requests/scalar/delete.rs
@@ -1,6 +1,5 @@
 use crate::{
-    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes,
-    MomentoResult,
+    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoResult,
 };
 
 /// Deletes an item in a Momento Cache

--- a/src/cache/requests/scalar/delete.rs
+++ b/src/cache/requests/scalar/delete.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cache::MomentoRequest, simple_cache_client::prep_request_with_timeout, CacheClient, IntoBytes,
+    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes,
     MomentoResult,
 };
 

--- a/src/cache/requests/scalar/get.rs
+++ b/src/cache/requests/scalar/get.rs
@@ -1,7 +1,7 @@
 use crate::cache::requests::MomentoRequest;
 use crate::cache_client::CacheClient;
-use crate::simple_cache_client::prep_request_with_timeout;
 use crate::utils::parse_string;
+use crate::utils::prep_request_with_timeout;
 use crate::MomentoErrorCode;
 use crate::{IntoBytes, MomentoError, MomentoResult};
 use momento_protos::cache_client::ECacheResult;

--- a/src/cache/requests/scalar/increment.rs
+++ b/src/cache/requests/scalar/increment.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use crate::{
-    cache::MomentoRequest, simple_cache_client::prep_request_with_timeout, CacheClient, IntoBytes,
+    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes,
     MomentoResult,
 };
 

--- a/src/cache/requests/scalar/increment.rs
+++ b/src/cache/requests/scalar/increment.rs
@@ -1,8 +1,7 @@
 use std::time::Duration;
 
 use crate::{
-    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes,
-    MomentoResult,
+    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoResult,
 };
 
 /// Adds an integer quantity to a field value.

--- a/src/cache/requests/scalar/item_get_type.rs
+++ b/src/cache/requests/scalar/item_get_type.rs
@@ -3,8 +3,8 @@ use std::convert::TryFrom;
 use momento_protos::cache_client::item_get_type_response::{self};
 
 use crate::{
-    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes,
-    MomentoError, MomentoErrorCode, MomentoResult,
+    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoError,
+    MomentoErrorCode, MomentoResult,
 };
 
 /// Return the type of the key in the cache.

--- a/src/cache/requests/scalar/item_get_type.rs
+++ b/src/cache/requests/scalar/item_get_type.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use momento_protos::cache_client::item_get_type_response::{self};
 
 use crate::{
-    cache::MomentoRequest, simple_cache_client::prep_request_with_timeout, CacheClient, IntoBytes,
+    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes,
     MomentoError, MomentoErrorCode, MomentoResult,
 };
 

--- a/src/cache/requests/scalar/key_exists.rs
+++ b/src/cache/requests/scalar/key_exists.rs
@@ -1,5 +1,5 @@
 use crate::cache::MomentoRequest;
-use crate::simple_cache_client::prep_request_with_timeout;
+use crate::utils::prep_request_with_timeout;
 use crate::{CacheClient, IntoBytes, MomentoResult};
 
 /// Request to check if a key exists in a cache.

--- a/src/cache/requests/scalar/keys_exist.rs
+++ b/src/cache/requests/scalar/keys_exist.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use crate::cache::MomentoRequest;
-use crate::simple_cache_client::prep_request_with_timeout;
 use crate::utils::parse_string;
+use crate::utils::prep_request_with_timeout;
 use crate::{CacheClient, IntoBytes, MomentoResult};
 
 /// Request to check if the provided keys exist in the cache.

--- a/src/cache/requests/scalar/set.rs
+++ b/src/cache/requests/scalar/set.rs
@@ -1,6 +1,6 @@
 use crate::cache::requests::MomentoRequest;
 use crate::cache_client::CacheClient;
-use crate::simple_cache_client::prep_request_with_timeout;
+use crate::utils::prep_request_with_timeout;
 use crate::{IntoBytes, MomentoResult};
 use std::time::Duration;
 

--- a/src/cache/requests/set/set_add_elements.rs
+++ b/src/cache/requests/set/set_add_elements.rs
@@ -2,7 +2,7 @@ use momento_protos::cache_client::SetUnionRequest;
 
 use crate::cache::requests::MomentoRequest;
 use crate::cache_client::CacheClient;
-use crate::simple_cache_client::prep_request_with_timeout;
+use crate::utils::prep_request_with_timeout;
 use crate::{CollectionTtl, IntoBytes, MomentoResult};
 
 /// Request to add elements to the given set. Creates the set if it does not exist.

--- a/src/cache/requests/sorted_set/sorted_set_fetch_by_rank.rs
+++ b/src/cache/requests/sorted_set/sorted_set_fetch_by_rank.rs
@@ -3,7 +3,7 @@ use momento_protos::cache_client::{SortedSetFetchRequest, Unbounded};
 
 use crate::cache::requests::sorted_set::sorted_set_fetch_response::SortedSetFetch;
 use crate::cache::requests::MomentoRequest;
-use crate::simple_cache_client::prep_request_with_timeout;
+use crate::utils::prep_request_with_timeout;
 use crate::{CacheClient, IntoBytes, MomentoResult};
 
 #[repr(i32)]

--- a/src/cache/requests/sorted_set/sorted_set_fetch_by_score.rs
+++ b/src/cache/requests/sorted_set/sorted_set_fetch_by_score.rs
@@ -6,7 +6,7 @@ use crate::cache::requests::sorted_set::sorted_set_fetch_by_rank::SortedSetOrder
 use crate::cache::requests::sorted_set::sorted_set_fetch_by_rank::SortedSetOrder::Ascending;
 use crate::cache::requests::sorted_set::sorted_set_fetch_response::SortedSetFetch;
 use crate::cache::requests::MomentoRequest;
-use crate::simple_cache_client::prep_request_with_timeout;
+use crate::utils::prep_request_with_timeout;
 use crate::{CacheClient, IntoBytes, MomentoResult};
 
 /// Fetch the elements in the given sorted set by their score.

--- a/src/cache/requests/sorted_set/sorted_set_put_element.rs
+++ b/src/cache/requests/sorted_set/sorted_set_put_element.rs
@@ -1,7 +1,7 @@
 use momento_protos::cache_client::{SortedSetElement, SortedSetPutRequest};
 
 use crate::cache::requests::MomentoRequest;
-use crate::simple_cache_client::prep_request_with_timeout;
+use crate::utils::prep_request_with_timeout;
 use crate::{CacheClient, CollectionTtl, IntoBytes, MomentoResult};
 
 /// Request to add an element to a sorted set. If the element already exists, its score is updated.

--- a/src/cache/requests/sorted_set/sorted_set_put_elements.rs
+++ b/src/cache/requests/sorted_set/sorted_set_put_elements.rs
@@ -5,7 +5,7 @@ use momento_protos::cache_client::SortedSetElement as ProtoSortedSetElement;
 use momento_protos::cache_client::SortedSetPutRequest;
 
 use crate::cache::requests::MomentoRequest;
-use crate::simple_cache_client::prep_request_with_timeout;
+use crate::utils::prep_request_with_timeout;
 use crate::{CacheClient, CollectionTtl, IntoBytes, MomentoResult};
 
 /// This trait defines an interface for converting a type into a vector of `SortedSetElement`s.


### PR DESCRIPTION
Addresses https://github.com/momentohq/client-sdk-rust/issues/220 

Pulls `prep_request_with_timeout` and `request_meta_data` into `utils`, but leaves `prep_request` in `simple_cache_client` so that can be removed along with `simple_cache_client`.

We'll be using only `prep_request_with_timeout` when implementing new APIs.