### PR TITLE
chore: minor test cleanups

### DIFF
--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -4,5 +4,5 @@ mod test_utils;
 pub use crate::cache_test_state::CACHE_TEST_STATE;
 pub use crate::test_utils::{
     create_doctest_cache_client, doctest, get_test_cache_name, get_test_credential_provider,
-    DoctestResult,
+    unique_string, DoctestResult,
 };

--- a/test-util/src/test_utils.rs
+++ b/test-util/src/test_utils.rs
@@ -28,7 +28,7 @@ where
     // The constructor for the cache client needs a tokio runtime to be active.
     let _guard = runtime.enter();
 
-    let cache_name = "rust-sdk-".to_string() + &Uuid::new_v4().to_string();
+    let cache_name = unique_string("rust-sdk");
     let credential_provider = CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
         .expect("MOMENTO_API_KEY must be set");
 
@@ -70,4 +70,8 @@ pub fn get_test_cache_name() -> String {
 pub fn get_test_credential_provider() -> CredentialProvider {
     CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
         .expect("auth token should be valid")
+}
+
+pub fn unique_string(prefix: impl Into<String>) -> String {
+    format!("{}-{}", prefix.into(), Uuid::new_v4())
 }

--- a/tests/cache_control.rs
+++ b/tests/cache_control.rs
@@ -1,14 +1,13 @@
 use momento::cache::{CreateCache, FlushCache, Get, GetValue, Set};
 use momento::MomentoErrorCode;
 use momento::MomentoResult;
-use uuid::Uuid;
-
+use momento_test_util::unique_string;
 use momento_test_util::CACHE_TEST_STATE;
 
 #[tokio::test]
 async fn delete_nonexistent_cache_returns_not_found() -> MomentoResult<()> {
     let client = &CACHE_TEST_STATE.client;
-    let cache_name = "fake-cache-".to_string() + &Uuid::new_v4().to_string();
+    let cache_name = unique_string("fake-cache");
     let result = client.delete_cache(cache_name).await.unwrap_err();
     assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
     Ok(())
@@ -45,7 +44,7 @@ async fn lists_existing_test_cache() -> MomentoResult<()> {
 #[tokio::test]
 async fn flush_nonexistent_cache_returns_not_found() -> MomentoResult<()> {
     let client = &CACHE_TEST_STATE.client;
-    let cache_name = "fake-cache-".to_string() + &Uuid::new_v4().to_string();
+    let cache_name = unique_string("fake-cache");
     let result = client.flush_cache(cache_name).await.unwrap_err();
     assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
     Ok(())

--- a/tests/cache_sorted_set.rs
+++ b/tests/cache_sorted_set.rs
@@ -8,27 +8,28 @@ use momento::cache::{
 use momento::{CacheClient, MomentoErrorCode, MomentoResult};
 use uuid::Uuid;
 
-use momento_test_util::CACHE_TEST_STATE;
+use momento_test_util::{unique_string, CACHE_TEST_STATE};
 
 #[tokio::test]
 async fn sorted_set_put_element_happy_path() -> MomentoResult<()> {
     let client = &CACHE_TEST_STATE.client;
     let cache_name = &CACHE_TEST_STATE.cache_name;
-    let sorted_set_name = "sorted-set-".to_string() + &Uuid::new_v4().to_string();
+    let unique_sorted_set_name = unique_string("sorted-set");
+    let sorted_set_name = unique_sorted_set_name.as_str();
     let value = "value";
     let score = 1.0;
 
     let result = client
-        .sorted_set_fetch_by_rank(cache_name, &*sorted_set_name, Ascending, None, None)
+        .sorted_set_fetch_by_rank(cache_name, sorted_set_name, Ascending, None, None)
         .await?;
     assert_eq!(result, SortedSetFetch::Miss);
 
     client
-        .sorted_set_put_element(cache_name, &*sorted_set_name, "value", 1.0)
+        .sorted_set_put_element(cache_name, sorted_set_name, "value", 1.0)
         .await?;
 
     let result = client
-        .sorted_set_fetch_by_rank(cache_name, &*sorted_set_name, Ascending, None, None)
+        .sorted_set_fetch_by_rank(cache_name, sorted_set_name, Ascending, None, None)
         .await?;
 
     match result {
@@ -46,7 +47,7 @@ async fn sorted_set_put_element_happy_path() -> MomentoResult<()> {
 #[tokio::test]
 async fn sorted_set_put_element_nonexistent_cache() -> MomentoResult<()> {
     let client = &CACHE_TEST_STATE.client;
-    let cache_name = "fake-cache-".to_string() + &Uuid::new_v4().to_string();
+    let cache_name = unique_string("fake-cache");
     let sorted_set_name = "sorted-set";
 
     let result = client
@@ -69,18 +70,19 @@ async fn sorted_set_put_elements_happy_path() -> MomentoResult<()> {
         cache_name: &String,
         to_put: impl IntoSortedSetElements<String> + Clone,
     ) -> MomentoResult<()> {
-        let sorted_set_name = format!("sorted-set-{}", Uuid::new_v4());
+        let unique_sorted_set_name = unique_string("sorted-set");
+        let sorted_set_name = unique_sorted_set_name.as_str();
         let result = client
-            .sorted_set_fetch_by_score(cache_name, &*sorted_set_name, Ascending)
+            .sorted_set_fetch_by_score(cache_name, sorted_set_name, Ascending)
             .await?;
         assert_eq!(result, SortedSetFetch::Miss);
 
         client
-            .sorted_set_put_elements(cache_name, &*sorted_set_name, to_put.clone())
+            .sorted_set_put_elements(cache_name, sorted_set_name, to_put.clone())
             .await?;
 
         let result = client
-            .sorted_set_fetch_by_score(cache_name, &*sorted_set_name, Ascending)
+            .sorted_set_fetch_by_score(cache_name, sorted_set_name, Ascending)
             .await?;
 
         match result {
@@ -153,7 +155,8 @@ async fn sorted_set_put_elements_nonexistent_cache() -> MomentoResult<()> {
 async fn sorted_set_fetch_by_rank_happy_path() -> MomentoResult<()> {
     let client = &CACHE_TEST_STATE.client;
     let cache_name = &CACHE_TEST_STATE.cache_name;
-    let sorted_set_name = "sorted-set-".to_string() + &Uuid::new_v4().to_string();
+    let unique_sorted_set_name = unique_string("sorted-set");
+    let sorted_set_name = unique_sorted_set_name.as_str();
     let to_put = vec![
         ("1".to_string(), 0.0),
         ("2".to_string(), 1.0),
@@ -163,16 +166,16 @@ async fn sorted_set_fetch_by_rank_happy_path() -> MomentoResult<()> {
     ];
 
     let result = client
-        .sorted_set_fetch_by_rank(cache_name, &*sorted_set_name, Ascending, None, None)
+        .sorted_set_fetch_by_rank(cache_name, sorted_set_name, Ascending, None, None)
         .await?;
     assert_eq!(result, SortedSetFetch::Miss);
 
     client
-        .sorted_set_put_elements(cache_name, &*sorted_set_name, to_put)
+        .sorted_set_put_elements(cache_name, sorted_set_name, to_put)
         .await?;
 
     // Full set ascending, end index larger than set
-    let fetch_request = SortedSetFetchByRankRequest::new(cache_name, &*sorted_set_name)
+    let fetch_request = SortedSetFetchByRankRequest::new(cache_name, sorted_set_name)
         .order(Ascending)
         .start_rank(0)
         .end_rank(6);
@@ -191,7 +194,7 @@ async fn sorted_set_fetch_by_rank_happy_path() -> MomentoResult<()> {
     }
 
     // Partial set descending
-    let fetch_request = SortedSetFetchByRankRequest::new(cache_name, &*sorted_set_name)
+    let fetch_request = SortedSetFetchByRankRequest::new(cache_name, sorted_set_name)
         .order(Descending)
         .start_rank(1)
         .end_rank(4);
@@ -214,7 +217,7 @@ async fn sorted_set_fetch_by_rank_happy_path() -> MomentoResult<()> {
 #[tokio::test]
 async fn sorted_set_fetch_by_rank_nonexistent_cache() -> MomentoResult<()> {
     let client = &CACHE_TEST_STATE.client;
-    let cache_name = "fake-cache-".to_string() + &Uuid::new_v4().to_string();
+    let cache_name = unique_string("fake-cache");
     let sorted_set_name = "sorted-set";
 
     let result = client
@@ -230,7 +233,8 @@ async fn sorted_set_fetch_by_rank_nonexistent_cache() -> MomentoResult<()> {
 async fn sorted_set_fetch_by_score_happy_path() -> MomentoResult<()> {
     let client = &CACHE_TEST_STATE.client;
     let cache_name = &CACHE_TEST_STATE.cache_name;
-    let sorted_set_name = "sorted-set-".to_string() + &Uuid::new_v4().to_string();
+    let unique_sorted_set_name = unique_string("sorted-set");
+    let sorted_set_name = unique_sorted_set_name.as_str();
     let to_put = vec![
         ("1".to_string(), 0.0),
         ("2".to_string(), 1.0),
@@ -240,16 +244,16 @@ async fn sorted_set_fetch_by_score_happy_path() -> MomentoResult<()> {
     ];
 
     let result = client
-        .sorted_set_fetch_by_score(cache_name, &*sorted_set_name, Ascending)
+        .sorted_set_fetch_by_score(cache_name, sorted_set_name, Ascending)
         .await?;
     assert_eq!(result, SortedSetFetch::Miss);
 
     client
-        .sorted_set_put_elements(cache_name, &*sorted_set_name, to_put)
+        .sorted_set_put_elements(cache_name, sorted_set_name, to_put)
         .await?;
 
     // Full set ascending, end score larger than set
-    let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, &*sorted_set_name)
+    let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
         .order(Ascending)
         .min_score(0.0)
         .max_score(9.9);
@@ -268,7 +272,7 @@ async fn sorted_set_fetch_by_score_happy_path() -> MomentoResult<()> {
     }
 
     // Partial set descending
-    let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, &*sorted_set_name)
+    let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
         .order(Descending)
         .min_score(0.1)
         .max_score(1.9);
@@ -287,7 +291,7 @@ async fn sorted_set_fetch_by_score_happy_path() -> MomentoResult<()> {
     }
 
     // Partial set limited by offset and count
-    let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, &*sorted_set_name)
+    let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
         .offset(1)
         .count(3);
 
@@ -309,7 +313,7 @@ async fn sorted_set_fetch_by_score_happy_path() -> MomentoResult<()> {
 #[tokio::test]
 async fn sorted_set_fetch_by_score_nonexistent_cache() -> MomentoResult<()> {
     let client = &CACHE_TEST_STATE.client;
-    let cache_name = "fake-cache-".to_string() + &Uuid::new_v4().to_string();
+    let cache_name = unique_string("fake-cache");
     let sorted_set_name = "sorted-set";
 
     let result = client

--- a/tests/old/integration_test.rs
+++ b/tests/old/integration_test.rs
@@ -5,9 +5,9 @@ mod tests {
     use momento::response::{Get, GetValue};
     use momento::{CredentialProvider, SimpleCacheClient};
     use momento::{MomentoError, SimpleCacheClientBuilder};
+    use momento_test_util::unique_string;
     use serde_json::Value;
     use tokio::time::sleep;
-    use uuid::Uuid;
 
     fn hit(value: impl Into<Vec<u8>>) -> Get {
         Get::Hit {
@@ -33,13 +33,13 @@ mod tests {
     }
 
     fn create_random_cache_name() -> String {
-        "rust-sdk-".to_string() + &Uuid::new_v4().to_string()
+        unique_string("rust-sdk")
     }
 
     #[tokio::test]
     async fn cache_miss() {
         let cache_name = create_random_cache_name();
-        let cache_key = Uuid::new_v4().to_string();
+        let cache_key = unique_string("key");
         let mut mm = get_momento_instance();
         mm.create_cache(&cache_name)
             .await
@@ -75,8 +75,8 @@ mod tests {
     #[tokio::test]
     async fn ttl_validation() {
         let cache_name = create_random_cache_name();
-        let cache_key = Uuid::new_v4().to_string();
-        let cache_body = Uuid::new_v4().to_string();
+        let cache_key = unique_string("key");
+        let cache_body = unique_string("body");
         let mut mm = get_momento_instance();
         mm.create_cache(&cache_name)
             .await
@@ -98,8 +98,8 @@ mod tests {
     #[tokio::test]
     async fn cache_hit() {
         let cache_name = create_random_cache_name();
-        let cache_key = Uuid::new_v4().to_string();
-        let cache_body = Uuid::new_v4().to_string();
+        let cache_key = unique_string("key");
+        let cache_body = unique_string("body");
         let mut mm = get_momento_instance();
         mm.create_cache(&cache_name)
             .await
@@ -120,8 +120,8 @@ mod tests {
     #[tokio::test]
     async fn cache_respects_default_ttl() {
         let cache_name = create_random_cache_name();
-        let cache_key = Uuid::new_v4().to_string();
-        let cache_body = Uuid::new_v4().to_string();
+        let cache_key = unique_string("key");
+        let cache_body = unique_string("body");
         let mut mm = get_momento_instance();
         mm.create_cache(&cache_name)
             .await
@@ -143,8 +143,8 @@ mod tests {
     #[tokio::test]
     async fn create_cache_then_set() {
         let cache_name = create_random_cache_name();
-        let cache_key = Uuid::new_v4().to_string();
-        let cache_body = Uuid::new_v4().to_string();
+        let cache_key = unique_string("key");
+        let cache_body = unique_string("body");
         let mut mm = get_momento_instance();
         mm.create_cache(&cache_name)
             .await
@@ -345,8 +345,8 @@ mod tests {
     #[tokio::test]
     async fn delete_item() {
         let cache_name = create_random_cache_name();
-        let cache_key = Uuid::new_v4().to_string();
-        let cache_body = Uuid::new_v4().to_string();
+        let cache_key = unique_string("key");
+        let cache_body = unique_string("body");
         let mut mm = get_momento_instance();
         mm.create_cache(&cache_name)
             .await


### PR DESCRIPTION
This commit does two things:

1. Adds a test utility function to DRY up all the places where
   we were creating UUIDs to create unique strings, and
2. In all the places where the tests were doing `&*` or `&**` to
   get access to a `&str` to pass to the APIs under test, we now
   just create two variables. The first variable is a `String`,
   so that the lifetime / ownership of the `String` extends through
   the end of the function; the second variable is a `&str` acquired
   via `&str`. This can be passed to the APIs under test as many times
   as possible without a "move" causing a compile failure, and prevents
   the need to do `.clone()` or `.as_str()` at every call site.
