### PR TITLE
test: organize integration tests following js integration tests

### DIFF
--- a/tests/cache_control.rs
+++ b/tests/cache_control.rs
@@ -4,88 +4,96 @@ use momento::MomentoResult;
 use momento_test_util::unique_string;
 use momento_test_util::CACHE_TEST_STATE;
 
-#[tokio::test]
-async fn delete_nonexistent_cache_returns_not_found() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = unique_string("fake-cache");
-    let result = client.delete_cache(cache_name).await.unwrap_err();
-    assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
-    Ok(())
+mod create_delete_list_cache {
+    use super::*;
+
+    #[tokio::test]
+    async fn delete_nonexistent_cache_returns_not_found() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_string("fake-cache");
+        let result = client.delete_cache(cache_name).await.unwrap_err();
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_existing_cache_returns_already_exists() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let result = client.create_cache(cache_name).await?;
+        assert_eq!(result, CreateCache::AlreadyExists {});
+        Ok(())
+    }
 }
 
-#[tokio::test]
-async fn create_existing_cache_returns_already_exists() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = &CACHE_TEST_STATE.cache_name;
-    let result = client.create_cache(cache_name).await?;
-    assert_eq!(result, CreateCache::AlreadyExists {});
-    Ok(())
-}
+mod flush_cache {
+    use super::*;
 
-#[tokio::test]
-async fn lists_existing_test_cache() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = &CACHE_TEST_STATE.cache_name;
-    let result = client.list_caches().await?;
-    let cache_names: Vec<String> = result
-        .caches
-        .iter()
-        .map(|cache_info| cache_info.name.clone())
-        .collect();
-    assert!(
-        cache_names.contains(cache_name),
-        "Expected {} to be in list of caches: {:#?}",
-        cache_name,
-        cache_names
-    );
-    Ok(())
-}
+    #[tokio::test]
+    async fn lists_existing_test_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let result = client.list_caches().await?;
+        let cache_names: Vec<String> = result
+            .caches
+            .iter()
+            .map(|cache_info| cache_info.name.clone())
+            .collect();
+        assert!(
+            cache_names.contains(cache_name),
+            "Expected {} to be in list of caches: {:#?}",
+            cache_name,
+            cache_names
+        );
+        Ok(())
+    }
 
-#[tokio::test]
-async fn flush_nonexistent_cache_returns_not_found() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = unique_string("fake-cache");
-    let result = client.flush_cache(cache_name).await.unwrap_err();
-    assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
-    Ok(())
-}
+    #[tokio::test]
+    async fn flush_nonexistent_cache_returns_not_found() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_string("fake-cache");
+        let result = client.flush_cache(cache_name).await.unwrap_err();
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+        Ok(())
+    }
 
-#[tokio::test]
-async fn flush_existing_cache_returns_success() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = &CACHE_TEST_STATE.cache_name;
+    #[tokio::test]
+    async fn flush_existing_cache_returns_success() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
 
-    // Insert some elements
-    let set_result1 = client.set(cache_name, "key1", "value1").await?;
-    assert_eq!(set_result1, Set {});
-    let set_result2 = client.set(cache_name, "key2", "value2").await?;
-    assert_eq!(set_result2, Set {});
+        // Insert some elements
+        let set_result1 = client.set(cache_name, "key1", "value1").await?;
+        assert_eq!(set_result1, Set {});
+        let set_result2 = client.set(cache_name, "key2", "value2").await?;
+        assert_eq!(set_result2, Set {});
 
-    // Verify that the elements are in the cache
-    let get_result1 = client.get(cache_name, "key1").await?;
-    assert_eq!(
-        get_result1,
-        Get::Hit {
-            value: GetValue::new("value1".into())
-        }
-    );
-    let get_result2 = client.get(cache_name, "key2").await?;
-    assert_eq!(
-        get_result2,
-        Get::Hit {
-            value: GetValue::new("value2".into())
-        }
-    );
+        // Verify that the elements are in the cache
+        let get_result1 = client.get(cache_name, "key1").await?;
+        assert_eq!(
+            get_result1,
+            Get::Hit {
+                value: GetValue::new("value1".into())
+            }
+        );
+        let get_result2 = client.get(cache_name, "key2").await?;
+        assert_eq!(
+            get_result2,
+            Get::Hit {
+                value: GetValue::new("value2".into())
+            }
+        );
 
-    // Flush the cache
-    let result = client.flush_cache(cache_name).await?;
-    assert_eq!(result, FlushCache {});
+        // Flush the cache
+        let result = client.flush_cache(cache_name).await?;
+        assert_eq!(result, FlushCache {});
 
-    // Verify that the elements were flushed from the cache
-    let get_result3 = client.get(cache_name, "key1").await?;
-    assert_eq!(get_result3, Get::Miss {});
-    let get_result4 = client.get(cache_name, "key2").await?;
-    assert_eq!(get_result4, Get::Miss {});
+        // Verify that the elements were flushed from the cache
+        let get_result3 = client.get(cache_name, "key1").await?;
+        assert_eq!(get_result3, Get::Miss {});
+        let get_result4 = client.get(cache_name, "key2").await?;
+        assert_eq!(get_result4, Get::Miss {});
 
-    Ok(())
+        Ok(())
+    }
 }

--- a/tests/cache_item.rs
+++ b/tests/cache_item.rs
@@ -1,0 +1,86 @@
+use momento::{
+    cache::{ItemGetType, ItemType},
+    MomentoErrorCode, MomentoResult,
+};
+use momento_test_util::{unique_string, CACHE_TEST_STATE};
+
+mod item_get_type {
+    use super::*;
+
+    #[tokio::test]
+    async fn invalid_cache_name() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let result = client.item_get_type("   ", "key").await.unwrap_err();
+        assert_eq!(result.error_code, MomentoErrorCode::InvalidArgumentError);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn nonexistent_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_string("fake-cache");
+        let result = client.item_get_type(cache_name, "key").await.unwrap_err();
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn happy_path() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = CACHE_TEST_STATE.cache_name.as_str();
+        let key_uuid = unique_string("key");
+        let key = key_uuid.as_str();
+
+        // Expect miss when key is not set
+        let result = client.item_get_type(cache_name, key).await?;
+        assert_eq!(result, ItemGetType::Miss {});
+        client.delete(cache_name, key).await?;
+
+        // Expect Scalar after using set
+        client.set(cache_name, key, "value").await?;
+        let result = client.item_get_type(cache_name, key).await?;
+        match result {
+            ItemGetType::Hit { key_type } => assert_eq!(
+                key_type,
+                ItemType::Scalar,
+                "Expected Scalar, got {:?}",
+                key_type
+            ),
+            _ => panic!("Expected Hit, got {:?}", result),
+        }
+        client.delete(cache_name, key).await?;
+
+        // Expect Set after using setAddElements
+        client
+            .set_add_elements(cache_name, key, vec!["value1", "value2"])
+            .await?;
+        let result = client.item_get_type(cache_name, key).await?;
+        match result {
+            ItemGetType::Hit { key_type } => {
+                assert_eq!(key_type, ItemType::Set, "Expected Set, got {:?}", key_type)
+            }
+            _ => panic!("Expected Hit, got {:?}", result),
+        }
+        client.delete(cache_name, key).await?;
+
+        // Expect SortedSet after using sortedSetPutElements
+        client
+            .sorted_set_put_elements(cache_name, key, vec![("value1", 1.0), ("value2", 2.0)])
+            .await?;
+        let result = client.item_get_type(cache_name, key).await?;
+        match result {
+            ItemGetType::Hit { key_type } => assert_eq!(
+                key_type,
+                ItemType::SortedSet,
+                "Expected SortedSet, got {:?}",
+                key_type
+            ),
+            _ => panic!("Expected Hit, got {:?}", result),
+        }
+        client.delete(cache_name, key).await?;
+
+        Ok(())
+    }
+}
+
+mod item_get_ttl {}

--- a/tests/cache_key_exists.rs
+++ b/tests/cache_key_exists.rs
@@ -1,0 +1,127 @@
+use std::collections::HashMap;
+
+use momento::{MomentoErrorCode, MomentoResult};
+use momento_test_util::{unique_string, CACHE_TEST_STATE};
+
+mod key_exists {
+    use super::*;
+
+    #[tokio::test]
+    async fn invalid_cache_name() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let result = client.key_exists("   ", "key").await.unwrap_err();
+        assert_eq!(result.error_code, MomentoErrorCode::InvalidArgumentError);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn nonexistent_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_string("fake-cache");
+        let result = client.key_exists(cache_name, "key").await.unwrap_err();
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn happy_path() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = CACHE_TEST_STATE.cache_name.as_str();
+        let key_uuid = unique_string("key");
+        let key = key_uuid.as_str();
+
+        // Key should not exist yet
+        let result = client.key_exists(cache_name, key).await?;
+        assert!(
+            !result.exists,
+            "Expected key {} to not exist in cache {}, but it does",
+            key, cache_name
+        );
+
+        // Key should exist after setting a key
+        client.set(cache_name, key, "value").await?;
+        let result = client.key_exists(cache_name, key).await?;
+        assert!(
+            result.exists,
+            "Expected key {} to exist in cache {}, but it does not",
+            key, cache_name
+        );
+
+        Ok(())
+    }
+}
+
+mod keys_exists {
+    use super::*;
+
+    #[tokio::test]
+    async fn invalid_cache_name() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let result = client.keys_exist("   ", vec!["key"]).await.unwrap_err();
+        assert_eq!(result.error_code, MomentoErrorCode::InvalidArgumentError);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn nonexistent_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_string("fake-cache");
+        let result = client
+            .keys_exist(cache_name, vec!["key"])
+            .await
+            .unwrap_err();
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn happy_path() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = CACHE_TEST_STATE.cache_name.as_str();
+
+        // Should return empty list if given empty key list
+        let empty_vector: Vec<String> = vec![];
+        let keys_received: Vec<bool> = client.keys_exist(cache_name, empty_vector).await?.into();
+        assert!(
+            keys_received.is_empty(),
+            "Expected empty list of bools given no keys, but received {:#?}",
+            keys_received
+        );
+
+        // Key should return true only for keys that exist in the cache
+        let unique_key1 = unique_string("keys-exist");
+        let key1 = unique_key1.as_str();
+
+        let unique_key2 = unique_string("keys-exist");
+        let key2 = unique_key2.as_str();
+
+        let unique_key3 = unique_string("keys-exist");
+        let key3 = unique_key3.as_str();
+
+        let unique_key4 = unique_string("keys-exist");
+        let key4 = unique_key4.as_str();
+
+        client.set(cache_name, key1, key1).await?;
+        client.set(cache_name, key3, key3).await?;
+
+        let result = client
+            .keys_exist(cache_name, vec![key1, key2, key3, key4])
+            .await?;
+
+        let keys_list: Vec<bool> = result.clone().into();
+        assert_eq!(keys_list.len(), 4);
+        assert_eq!(keys_list, [true, false, true, false]);
+
+        let keys_dict: HashMap<String, bool> = result.into();
+
+        // these dictionary entries should be true
+        assert!(keys_dict[key1]);
+        assert!(keys_dict[key3]);
+
+        // these dictionary entries should be false
+        assert!(!keys_dict[key2]);
+        assert!(!keys_dict[key4]);
+
+        Ok(())
+    }
+}

--- a/tests/cache_scalar.rs
+++ b/tests/cache_scalar.rs
@@ -1,290 +1,119 @@
-use std::collections::HashMap;
-
-use momento::{
-    cache::{Delete, ItemGetType, ItemType},
-    MomentoErrorCode, MomentoResult,
-};
+use momento::{cache::Delete, MomentoErrorCode, MomentoResult};
 use momento_test_util::{unique_string, CACHE_TEST_STATE};
 
-#[tokio::test]
-async fn key_exists_invalid_cache_name() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let result = client.key_exists("   ", "key").await.unwrap_err();
-    assert_eq!(result.error_code, MomentoErrorCode::InvalidArgumentError);
-    Ok(())
-}
+mod get_set_delete {
+    use super::*;
 
-#[tokio::test]
-async fn key_exists_nonexistent_cache() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = unique_string("fake-cache");
-    let result = client.key_exists(cache_name, "key").await.unwrap_err();
-    assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
-    Ok(())
-}
-
-#[tokio::test]
-async fn key_exists_happy_path() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = CACHE_TEST_STATE.cache_name.as_str();
-    let key_uuid = unique_string("key");
-    let key = key_uuid.as_str();
-
-    // Key should not exist yet
-    let result = client.key_exists(cache_name, key).await?;
-    assert!(
-        !result.exists,
-        "Expected key {} to not exist in cache {}, but it does",
-        key, cache_name
-    );
-
-    // Key should exist after setting a key
-    client.set(cache_name, key, "value").await?;
-    let result = client.key_exists(cache_name, key).await?;
-    assert!(
-        result.exists,
-        "Expected key {} to exist in cache {}, but it does not",
-        key, cache_name
-    );
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn keys_exist_invalid_cache_name() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let result = client.keys_exist("   ", vec!["key"]).await.unwrap_err();
-    assert_eq!(result.error_code, MomentoErrorCode::InvalidArgumentError);
-    Ok(())
-}
-
-#[tokio::test]
-async fn keys_exist_nonexistent_cache() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = unique_string("fake-cache");
-    let result = client
-        .keys_exist(cache_name, vec!["key"])
-        .await
-        .unwrap_err();
-    assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
-    Ok(())
-}
-
-#[tokio::test]
-async fn keys_exist_happy_path() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = CACHE_TEST_STATE.cache_name.as_str();
-
-    // Should return empty list if given empty key list
-    let empty_vector: Vec<String> = vec![];
-    let keys_received: Vec<bool> = client.keys_exist(cache_name, empty_vector).await?.into();
-    assert!(
-        keys_received.is_empty(),
-        "Expected empty list of bools given no keys, but received {:#?}",
-        keys_received
-    );
-
-    // Key should return true only for keys that exist in the cache
-    let unique_key1 = unique_string("keys-exist");
-    let key1 = unique_key1.as_str();
-
-    let unique_key2 = unique_string("keys-exist");
-    let key2 = unique_key2.as_str();
-
-    let unique_key3 = unique_string("keys-exist");
-    let key3 = unique_key3.as_str();
-
-    let unique_key4 = unique_string("keys-exist");
-    let key4 = unique_key4.as_str();
-
-    client.set(cache_name, key1, key1).await?;
-    client.set(cache_name, key3, key3).await?;
-
-    let result = client
-        .keys_exist(cache_name, vec![key1, key2, key3, key4])
-        .await?;
-
-    let keys_list: Vec<bool> = result.clone().into();
-    assert_eq!(keys_list.len(), 4);
-    assert_eq!(keys_list, [true, false, true, false]);
-
-    let keys_dict: HashMap<String, bool> = result.into();
-
-    // these dictionary entries should be true
-    assert!(keys_dict[key1]);
-    assert!(keys_dict[key3]);
-
-    // these dictionary entries should be false
-    assert!(!keys_dict[key2]);
-    assert!(!keys_dict[key4]);
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn increment_invalid_cache_name() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let result = client.increment("   ", "key", 1).await.unwrap_err();
-    assert_eq!(result.error_code, MomentoErrorCode::InvalidArgumentError);
-    Ok(())
-}
-
-#[tokio::test]
-async fn increment_nonexistent_cache() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = unique_string("fake-cache");
-    let result = client.increment(cache_name, "key", 1).await.unwrap_err();
-    assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
-    Ok(())
-}
-
-#[tokio::test]
-async fn increment_happy_path() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = CACHE_TEST_STATE.cache_name.as_str();
-    let key_uuid = unique_string("key");
-    let key = key_uuid.as_str();
-
-    // Incrementing a key that doesn't exist should create it
-    let result = client.increment(cache_name, key, 1).await?;
-    assert_eq!(result.value, 1);
-
-    // Incrementing an existing key should increment it
-    let result = client.increment(cache_name, key, 1).await?;
-    assert_eq!(result.value, 2);
-
-    // Incrementing by a negative number should decrement the value
-    let result = client.increment(cache_name, key, -2).await?;
-    assert_eq!(result.value, 0);
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn item_get_type_invalid_cache_name() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let result = client.item_get_type("   ", "key").await.unwrap_err();
-    assert_eq!(result.error_code, MomentoErrorCode::InvalidArgumentError);
-    Ok(())
-}
-
-#[tokio::test]
-async fn item_get_type_nonexistent_cache() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = unique_string("fake-cache");
-    let result = client.item_get_type(cache_name, "key").await.unwrap_err();
-    assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
-    Ok(())
-}
-
-#[tokio::test]
-async fn item_get_type_happy_path() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = CACHE_TEST_STATE.cache_name.as_str();
-    let key_uuid = unique_string("key");
-    let key = key_uuid.as_str();
-
-    // Expect miss when key is not set
-    let result = client.item_get_type(cache_name, key).await?;
-    assert_eq!(result, ItemGetType::Miss {});
-    client.delete(cache_name, key).await?;
-
-    // Expect Scalar after using set
-    client.set(cache_name, key, "value").await?;
-    let result = client.item_get_type(cache_name, key).await?;
-    match result {
-        ItemGetType::Hit { key_type } => assert_eq!(
-            key_type,
-            ItemType::Scalar,
-            "Expected Scalar, got {:?}",
-            key_type
-        ),
-        _ => panic!("Expected Hit, got {:?}", result),
+    #[tokio::test]
+    async fn delete_invalid_cache_name() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let result = client.delete("   ", "key").await.unwrap_err();
+        assert_eq!(result.error_code, MomentoErrorCode::InvalidArgumentError);
+        Ok(())
     }
-    client.delete(cache_name, key).await?;
 
-    // Expect Set after using setAddElements
-    client
-        .set_add_elements(cache_name, key, vec!["value1", "value2"])
-        .await?;
-    let result = client.item_get_type(cache_name, key).await?;
-    match result {
-        ItemGetType::Hit { key_type } => {
-            assert_eq!(key_type, ItemType::Set, "Expected Set, got {:?}", key_type)
-        }
-        _ => panic!("Expected Hit, got {:?}", result),
+    #[tokio::test]
+    async fn delete_nonexistent_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_string("fake-cache");
+        let result = client.delete(cache_name, "key").await.unwrap_err();
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+        Ok(())
     }
-    client.delete(cache_name, key).await?;
 
-    // Expect SortedSet after using sortedSetPutElements
-    client
-        .sorted_set_put_elements(cache_name, key, vec![("value1", 1.0), ("value2", 2.0)])
-        .await?;
-    let result = client.item_get_type(cache_name, key).await?;
-    match result {
-        ItemGetType::Hit { key_type } => assert_eq!(
-            key_type,
-            ItemType::SortedSet,
-            "Expected SortedSet, got {:?}",
-            key_type
-        ),
-        _ => panic!("Expected Hit, got {:?}", result),
+    #[tokio::test]
+    async fn delete_happy_path() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = CACHE_TEST_STATE.cache_name.as_str();
+        let key_uuid = unique_string("key");
+        let key = key_uuid.as_str();
+
+        // Deleting a key that doesn't exist should not error
+        let result = client.delete(cache_name, key).await?;
+        assert_eq!(
+            result,
+            Delete {},
+            "Expected successful Delete of nonexistent key, got {:?}",
+            result
+        );
+
+        // Deleting a key that exists should delete it
+        client.set(cache_name, key, "value").await?;
+        let result = client.delete(cache_name, key).await?;
+        assert_eq!(
+            result,
+            Delete {},
+            "Expected successful Delete of existing key, got {:?}",
+            result
+        );
+
+        // Key should not exist after deletion
+        let result = client.key_exists(cache_name, key).await?;
+        assert!(
+            !result.exists,
+            "Expected key 'key' to not exist in cache {} after deletion, but it does",
+            cache_name
+        );
+
+        Ok(())
     }
-    client.delete(cache_name, key).await?;
-
-    Ok(())
 }
 
-#[tokio::test]
-async fn delete_invalid_cache_name() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let result = client.delete("   ", "key").await.unwrap_err();
-    assert_eq!(result.error_code, MomentoErrorCode::InvalidArgumentError);
-    Ok(())
+mod increment {
+    use super::*;
+
+    #[tokio::test]
+    async fn invalid_cache_name() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let result = client.increment("   ", "key", 1).await.unwrap_err();
+        assert_eq!(result.error_code, MomentoErrorCode::InvalidArgumentError);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn nonexistent_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_string("fake-cache");
+        let result = client.increment(cache_name, "key", 1).await.unwrap_err();
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn happy_path() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = CACHE_TEST_STATE.cache_name.as_str();
+        let key_uuid = unique_string("key");
+        let key = key_uuid.as_str();
+
+        // Incrementing a key that doesn't exist should create it
+        let result = client.increment(cache_name, key, 1).await?;
+        assert_eq!(result.value, 1);
+
+        // Incrementing an existing key should increment it
+        let result = client.increment(cache_name, key, 1).await?;
+        assert_eq!(result.value, 2);
+
+        // Incrementing by a negative number should decrement the value
+        let result = client.increment(cache_name, key, -2).await?;
+        assert_eq!(result.value, 0);
+
+        Ok(())
+    }
 }
 
-#[tokio::test]
-async fn delete_nonexistent_cache() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = unique_string("fake-cache");
-    let result = client.delete(cache_name, "key").await.unwrap_err();
-    assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
-    Ok(())
-}
+mod set_if_not_exists {}
 
-#[tokio::test]
-async fn delete_happy_path() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = CACHE_TEST_STATE.cache_name.as_str();
-    let key_uuid = unique_string("key");
-    let key = key_uuid.as_str();
+mod set_if_absent {}
 
-    // Deleting a key that doesn't exist should not error
-    let result = client.delete(cache_name, key).await?;
-    assert_eq!(
-        result,
-        Delete {},
-        "Expected successful Delete of nonexistent key, got {:?}",
-        result
-    );
+mod set_if_present {}
 
-    // Deleting a key that exists should delete it
-    client.set(cache_name, key, "value").await?;
-    let result = client.delete(cache_name, key).await?;
-    assert_eq!(
-        result,
-        Delete {},
-        "Expected successful Delete of existing key, got {:?}",
-        result
-    );
+mod set_if_equal {}
 
-    // Key should not exist after deletion
-    let result = client.key_exists(cache_name, key).await?;
-    assert!(
-        !result.exists,
-        "Expected key 'key' to not exist in cache {} after deletion, but it does",
-        cache_name
-    );
+mod set_if_not_equal {}
 
-    Ok(())
-}
+mod set_if_present_and_not_equal {}
+
+mod set_if_absent_or_equal {}
+
+mod when_readconcern_is_specified {}

--- a/tests/cache_sorted_set.rs
+++ b/tests/cache_sorted_set.rs
@@ -6,321 +6,352 @@ use momento::cache::{
     SortedSetOrder::{Ascending, Descending},
 };
 use momento::{CacheClient, MomentoErrorCode, MomentoResult};
-use uuid::Uuid;
 
 use momento_test_util::{unique_string, CACHE_TEST_STATE};
 
-#[tokio::test]
-async fn sorted_set_put_element_happy_path() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = &CACHE_TEST_STATE.cache_name;
-    let unique_sorted_set_name = unique_string("sorted-set");
-    let sorted_set_name = unique_sorted_set_name.as_str();
-    let value = "value";
-    let score = 1.0;
+mod sorted_set_fetch_by_rank {
+    use super::*;
 
-    let result = client
-        .sorted_set_fetch_by_rank(cache_name, sorted_set_name, Ascending, None, None)
-        .await?;
-    assert_eq!(result, SortedSetFetch::Miss);
-
-    client
-        .sorted_set_put_element(cache_name, sorted_set_name, "value", 1.0)
-        .await?;
-
-    let result = client
-        .sorted_set_fetch_by_rank(cache_name, sorted_set_name, Ascending, None, None)
-        .await?;
-
-    match result {
-        SortedSetFetch::Hit { elements } => {
-            assert_eq!(elements.len(), 1);
-            let string_elements = elements.into_strings()?;
-            assert_eq!(string_elements[0].0, value);
-            assert_eq!(string_elements[0].1, score)
-        }
-        _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
-    }
-    Ok(())
-}
-
-#[tokio::test]
-async fn sorted_set_put_element_nonexistent_cache() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = unique_string("fake-cache");
-    let sorted_set_name = "sorted-set";
-
-    let result = client
-        .sorted_set_put_element(cache_name, sorted_set_name, "value", 1.0)
-        .await
-        .unwrap_err();
-
-    assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
-    Ok(())
-}
-
-fn compare_by_first_entry(a: &(String, f64), b: &(String, f64)) -> std::cmp::Ordering {
-    a.0.cmp(&b.0)
-}
-
-#[tokio::test]
-async fn sorted_set_put_elements_happy_path() -> MomentoResult<()> {
-    async fn test_put_elements_happy_path(
-        client: &Arc<CacheClient>,
-        cache_name: &String,
-        to_put: impl IntoSortedSetElements<String> + Clone,
-    ) -> MomentoResult<()> {
+    #[tokio::test]
+    async fn happy_path() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
         let unique_sorted_set_name = unique_string("sorted-set");
         let sorted_set_name = unique_sorted_set_name.as_str();
+        let to_put = vec![
+            ("1".to_string(), 0.0),
+            ("2".to_string(), 1.0),
+            ("3".to_string(), 0.5),
+            ("4".to_string(), 2.0),
+            ("5".to_string(), 1.5),
+        ];
+
         let result = client
-            .sorted_set_fetch_by_score(cache_name, sorted_set_name, Ascending)
+            .sorted_set_fetch_by_rank(cache_name, sorted_set_name, Ascending, None, None)
             .await?;
         assert_eq!(result, SortedSetFetch::Miss);
 
         client
-            .sorted_set_put_elements(cache_name, sorted_set_name, to_put.clone())
+            .sorted_set_put_elements(cache_name, sorted_set_name, to_put)
             .await?;
 
-        let result = client
-            .sorted_set_fetch_by_score(cache_name, sorted_set_name, Ascending)
-            .await?;
+        // Full set ascending, end index larger than set
+        let fetch_request = SortedSetFetchByRankRequest::new(cache_name, sorted_set_name)
+            .order(Ascending)
+            .start_rank(0)
+            .end_rank(6);
+
+        let result = client.send_request(fetch_request).await?;
 
         match result {
             SortedSetFetch::Hit { elements } => {
-                let mut expected = to_put
-                    .into_sorted_set_elements()
-                    .into_iter()
-                    .map(|e| (e.value, e.score))
-                    .collect::<Vec<_>>();
-                expected.sort_by(compare_by_first_entry);
+                assert_eq!(elements.len(), 5);
+                let string_elements: Vec<String> =
+                    elements.into_strings()?.into_iter().map(|e| e.0).collect();
 
-                let mut actual = elements.into_strings()?;
-                actual.sort_by(compare_by_first_entry);
-                assert_eq!(actual, expected);
+                assert_eq!(string_elements, vec!["1", "3", "2", "5", "4"])
+            }
+            _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
+        }
+
+        // Partial set descending
+        let fetch_request = SortedSetFetchByRankRequest::new(cache_name, sorted_set_name)
+            .order(Descending)
+            .start_rank(1)
+            .end_rank(4);
+
+        let result = client.send_request(fetch_request).await?;
+
+        match result {
+            SortedSetFetch::Hit { elements } => {
+                assert_eq!(elements.len(), 3);
+                let string_elements: Vec<String> =
+                    elements.into_strings()?.into_iter().map(|e| e.0).collect();
+
+                assert_eq!(string_elements, vec!["5", "2", "3"])
             }
             _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
         }
         Ok(())
     }
 
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = &CACHE_TEST_STATE.cache_name;
+    #[tokio::test]
+    async fn nonexistent_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_string("fake-cache");
+        let sorted_set_name = "sorted-set";
 
-    let to_put = vec![("element1".to_string(), 1.0), ("element2".to_string(), 2.0)];
-    test_put_elements_happy_path(client, cache_name, to_put).await?;
+        let result = client
+            .sorted_set_fetch_by_rank(cache_name, sorted_set_name, Ascending, None, None)
+            .await
+            .unwrap_err();
 
-    let to_put = std::collections::HashMap::from([
-        ("element1".to_string(), 1.0),
-        ("element2".to_string(), 2.0),
-    ]);
-    test_put_elements_happy_path(client, cache_name, to_put).await?;
-
-    let to_put = vec![("element1".to_string(), 1.0), ("element2".to_string(), 2.0)];
-    test_put_elements_happy_path(client, cache_name, to_put).await?;
-
-    let to_put = vec![
-        SortedSetElement {
-            value: "element1".to_string(),
-            score: 1.0,
-        },
-        SortedSetElement {
-            value: "element2".to_string(),
-            score: 2.0,
-        },
-    ];
-    test_put_elements_happy_path(client, cache_name, to_put).await?;
-    Ok(())
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+        Ok(())
+    }
 }
 
-#[tokio::test]
-async fn sorted_set_put_elements_nonexistent_cache() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = format!("fake-cache-{}", Uuid::new_v4());
-    let sorted_set_name = "sorted-set";
+pub mod sorted_set_fetch_by_score {
+    use super::*;
 
-    let result = client
-        .sorted_set_put_elements(
-            cache_name,
-            sorted_set_name,
-            vec![("element1".to_string(), 1.0), ("element2".to_string(), 2.0)],
-        )
-        .await
-        .unwrap_err();
+    #[tokio::test]
+    async fn happy_path() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let unique_sorted_set_name = unique_string("sorted-set");
+        let sorted_set_name = unique_sorted_set_name.as_str();
+        let to_put = vec![
+            ("1".to_string(), 0.0),
+            ("2".to_string(), 1.0),
+            ("3".to_string(), 0.5),
+            ("4".to_string(), 2.0),
+            ("5".to_string(), 1.5),
+        ];
 
-    assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
-    Ok(())
-}
+        let result = client
+            .sorted_set_fetch_by_score(cache_name, sorted_set_name, Ascending)
+            .await?;
+        assert_eq!(result, SortedSetFetch::Miss);
 
-#[tokio::test]
-async fn sorted_set_fetch_by_rank_happy_path() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = &CACHE_TEST_STATE.cache_name;
-    let unique_sorted_set_name = unique_string("sorted-set");
-    let sorted_set_name = unique_sorted_set_name.as_str();
-    let to_put = vec![
-        ("1".to_string(), 0.0),
-        ("2".to_string(), 1.0),
-        ("3".to_string(), 0.5),
-        ("4".to_string(), 2.0),
-        ("5".to_string(), 1.5),
-    ];
+        client
+            .sorted_set_put_elements(cache_name, sorted_set_name, to_put)
+            .await?;
 
-    let result = client
-        .sorted_set_fetch_by_rank(cache_name, sorted_set_name, Ascending, None, None)
-        .await?;
-    assert_eq!(result, SortedSetFetch::Miss);
+        // Full set ascending, end score larger than set
+        let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
+            .order(Ascending)
+            .min_score(0.0)
+            .max_score(9.9);
 
-    client
-        .sorted_set_put_elements(cache_name, sorted_set_name, to_put)
-        .await?;
+        let result = client.send_request(fetch_request).await?;
 
-    // Full set ascending, end index larger than set
-    let fetch_request = SortedSetFetchByRankRequest::new(cache_name, sorted_set_name)
-        .order(Ascending)
-        .start_rank(0)
-        .end_rank(6);
+        match result {
+            SortedSetFetch::Hit { elements } => {
+                assert_eq!(elements.len(), 5);
+                let string_elements: Vec<String> =
+                    elements.into_strings()?.into_iter().map(|e| e.0).collect();
 
-    let result = client.send_request(fetch_request).await?;
-
-    match result {
-        SortedSetFetch::Hit { elements } => {
-            assert_eq!(elements.len(), 5);
-            let string_elements: Vec<String> =
-                elements.into_strings()?.into_iter().map(|e| e.0).collect();
-
-            assert_eq!(string_elements, vec!["1", "3", "2", "5", "4"])
+                assert_eq!(string_elements, vec!["1", "3", "2", "5", "4"])
+            }
+            _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
         }
-        _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
+
+        // Partial set descending
+        let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
+            .order(Descending)
+            .min_score(0.1)
+            .max_score(1.9);
+
+        let result = client.send_request(fetch_request).await?;
+
+        match result {
+            SortedSetFetch::Hit { elements } => {
+                assert_eq!(elements.len(), 3);
+                let string_elements: Vec<String> =
+                    elements.into_strings()?.into_iter().map(|e| e.0).collect();
+
+                assert_eq!(string_elements, vec!["5", "2", "3"])
+            }
+            _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
+        }
+
+        // Partial set limited by offset and count
+        let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
+            .offset(1)
+            .count(3);
+
+        let result = client.send_request(fetch_request).await?;
+
+        match result {
+            SortedSetFetch::Hit { elements } => {
+                assert_eq!(elements.len(), 3);
+                let string_elements: Vec<String> =
+                    elements.into_strings()?.into_iter().map(|e| e.0).collect();
+
+                assert_eq!(string_elements, vec!["3", "2", "5"])
+            }
+            _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
+        }
+        Ok(())
     }
 
-    // Partial set descending
-    let fetch_request = SortedSetFetchByRankRequest::new(cache_name, sorted_set_name)
-        .order(Descending)
-        .start_rank(1)
-        .end_rank(4);
+    #[tokio::test]
+    async fn nonexistent_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_string("fake-cache");
+        let sorted_set_name = "sorted-set";
 
-    let result = client.send_request(fetch_request).await?;
+        let result = client
+            .sorted_set_fetch_by_score(cache_name, sorted_set_name, Ascending)
+            .await
+            .unwrap_err();
 
-    match result {
-        SortedSetFetch::Hit { elements } => {
-            assert_eq!(elements.len(), 3);
-            let string_elements: Vec<String> =
-                elements.into_strings()?.into_iter().map(|e| e.0).collect();
-
-            assert_eq!(string_elements, vec!["5", "2", "3"])
-        }
-        _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+        Ok(())
     }
-    Ok(())
 }
 
-#[tokio::test]
-async fn sorted_set_fetch_by_rank_nonexistent_cache() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = unique_string("fake-cache");
-    let sorted_set_name = "sorted-set";
+pub mod sorted_set_get_rank {}
 
-    let result = client
-        .sorted_set_fetch_by_rank(cache_name, sorted_set_name, Ascending, None, None)
-        .await
-        .unwrap_err();
+pub mod sorted_set_get_score {}
 
-    assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
-    Ok(())
-}
+pub mod sorted_set_get_scores {}
 
-#[tokio::test]
-async fn sorted_set_fetch_by_score_happy_path() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = &CACHE_TEST_STATE.cache_name;
-    let unique_sorted_set_name = unique_string("sorted-set");
-    let sorted_set_name = unique_sorted_set_name.as_str();
-    let to_put = vec![
-        ("1".to_string(), 0.0),
-        ("2".to_string(), 1.0),
-        ("3".to_string(), 0.5),
-        ("4".to_string(), 2.0),
-        ("5".to_string(), 1.5),
-    ];
+pub mod sorted_set_increment_score {}
 
-    let result = client
-        .sorted_set_fetch_by_score(cache_name, sorted_set_name, Ascending)
-        .await?;
-    assert_eq!(result, SortedSetFetch::Miss);
+pub mod sorted_set_remove_element {}
 
-    client
-        .sorted_set_put_elements(cache_name, sorted_set_name, to_put)
-        .await?;
+mod sorted_set_put_element {
+    use super::*;
 
-    // Full set ascending, end score larger than set
-    let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
-        .order(Ascending)
-        .min_score(0.0)
-        .max_score(9.9);
+    #[tokio::test]
+    async fn happy_path() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let unique_sorted_set_name = unique_string("sorted-set");
+        let sorted_set_name = unique_sorted_set_name.as_str();
+        let value = "value";
+        let score = 1.0;
 
-    let result = client.send_request(fetch_request).await?;
+        let result = client
+            .sorted_set_fetch_by_rank(cache_name, sorted_set_name, Ascending, None, None)
+            .await?;
+        assert_eq!(result, SortedSetFetch::Miss);
 
-    match result {
-        SortedSetFetch::Hit { elements } => {
-            assert_eq!(elements.len(), 5);
-            let string_elements: Vec<String> =
-                elements.into_strings()?.into_iter().map(|e| e.0).collect();
+        client
+            .sorted_set_put_element(cache_name, sorted_set_name, "value", 1.0)
+            .await?;
 
-            assert_eq!(string_elements, vec!["1", "3", "2", "5", "4"])
+        let result = client
+            .sorted_set_fetch_by_rank(cache_name, sorted_set_name, Ascending, None, None)
+            .await?;
+
+        match result {
+            SortedSetFetch::Hit { elements } => {
+                assert_eq!(elements.len(), 1);
+                let string_elements = elements.into_strings()?;
+                assert_eq!(string_elements[0].0, value);
+                assert_eq!(string_elements[0].1, score)
+            }
+            _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
         }
-        _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
+        Ok(())
     }
 
-    // Partial set descending
-    let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
-        .order(Descending)
-        .min_score(0.1)
-        .max_score(1.9);
+    #[tokio::test]
+    async fn nonexistent_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_string("fake-cache");
+        let sorted_set_name = "sorted-set";
 
-    let result = client.send_request(fetch_request).await?;
+        let result = client
+            .sorted_set_put_element(cache_name, sorted_set_name, "value", 1.0)
+            .await
+            .unwrap_err();
 
-    match result {
-        SortedSetFetch::Hit { elements } => {
-            assert_eq!(elements.len(), 3);
-            let string_elements: Vec<String> =
-                elements.into_strings()?.into_iter().map(|e| e.0).collect();
-
-            assert_eq!(string_elements, vec!["5", "2", "3"])
-        }
-        _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+        Ok(())
     }
-
-    // Partial set limited by offset and count
-    let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
-        .offset(1)
-        .count(3);
-
-    let result = client.send_request(fetch_request).await?;
-
-    match result {
-        SortedSetFetch::Hit { elements } => {
-            assert_eq!(elements.len(), 3);
-            let string_elements: Vec<String> =
-                elements.into_strings()?.into_iter().map(|e| e.0).collect();
-
-            assert_eq!(string_elements, vec!["3", "2", "5"])
-        }
-        _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
-    }
-    Ok(())
 }
 
-#[tokio::test]
-async fn sorted_set_fetch_by_score_nonexistent_cache() -> MomentoResult<()> {
-    let client = &CACHE_TEST_STATE.client;
-    let cache_name = unique_string("fake-cache");
-    let sorted_set_name = "sorted-set";
+mod sorted_set_put_elements {
+    use super::*;
 
-    let result = client
-        .sorted_set_fetch_by_score(cache_name, sorted_set_name, Ascending)
-        .await
-        .unwrap_err();
+    fn compare_by_first_entry(a: &(String, f64), b: &(String, f64)) -> std::cmp::Ordering {
+        a.0.cmp(&b.0)
+    }
 
-    assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
-    Ok(())
+    #[tokio::test]
+    async fn happy_path() -> MomentoResult<()> {
+        async fn test_put_elements_happy_path(
+            client: &Arc<CacheClient>,
+            cache_name: &String,
+            to_put: impl IntoSortedSetElements<String> + Clone,
+        ) -> MomentoResult<()> {
+            let unique_sorted_set_name = unique_string("sorted-set");
+            let sorted_set_name = unique_sorted_set_name.as_str();
+            let result = client
+                .sorted_set_fetch_by_score(cache_name, sorted_set_name, Ascending)
+                .await?;
+            assert_eq!(result, SortedSetFetch::Miss);
+
+            client
+                .sorted_set_put_elements(cache_name, sorted_set_name, to_put.clone())
+                .await?;
+
+            let result = client
+                .sorted_set_fetch_by_score(cache_name, sorted_set_name, Ascending)
+                .await?;
+
+            match result {
+                SortedSetFetch::Hit { elements } => {
+                    let mut expected = to_put
+                        .into_sorted_set_elements()
+                        .into_iter()
+                        .map(|e| (e.value, e.score))
+                        .collect::<Vec<_>>();
+                    expected.sort_by(compare_by_first_entry);
+
+                    let mut actual = elements.into_strings()?;
+                    actual.sort_by(compare_by_first_entry);
+                    assert_eq!(actual, expected);
+                }
+                _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
+            }
+            Ok(())
+        }
+
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+
+        let to_put = vec![("element1".to_string(), 1.0), ("element2".to_string(), 2.0)];
+        test_put_elements_happy_path(client, cache_name, to_put).await?;
+
+        let to_put = std::collections::HashMap::from([
+            ("element1".to_string(), 1.0),
+            ("element2".to_string(), 2.0),
+        ]);
+        test_put_elements_happy_path(client, cache_name, to_put).await?;
+
+        let to_put = vec![("element1".to_string(), 1.0), ("element2".to_string(), 2.0)];
+        test_put_elements_happy_path(client, cache_name, to_put).await?;
+
+        let to_put = vec![
+            SortedSetElement {
+                value: "element1".to_string(),
+                score: 1.0,
+            },
+            SortedSetElement {
+                value: "element2".to_string(),
+                score: 2.0,
+            },
+        ];
+        test_put_elements_happy_path(client, cache_name, to_put).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn nonexistent_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_string("fake-cache");
+        let sorted_set_name = "sorted-set";
+
+        let result = client
+            .sorted_set_put_elements(
+                cache_name,
+                sorted_set_name,
+                vec![("element1".to_string(), 1.0), ("element2".to_string(), 2.0)],
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+        Ok(())
+    }
 }
+
+mod sorted_set_length {}
+
+mod sorted_set_length_by_score {}
+
+mod delete_sorted_set {}


### PR DESCRIPTION
# tldr
In order for developers to easily compare integration test coverage vs
the JS suite, a package with known well coverage, we organize the
integration tests to mirror those.

# Changes
Specifically we chose filenames that are similar to those used in the
JS integration test repos. Then, in order to parallel the `describe`
blocks, we introduce a `mod` for each describe. The individual tests
therein should be parallel to the `it` calls in the JS repo.

We've organized the data plane commands into the following
files:
- cache_scalar.rs: commands where the value type is scalar
- cache_sorted_set.rs: commands where the value type is sorted set
- cache_key_exists.rs: commands to test existence of a cache key
- cache_item.rs: commands that apply to a cache item irrespective of
type.

Previously the tests under `cache_item.rs` had been grouped under
`cache_scalar.rs`. This wasn't as cohesive as the scalar tests group
by commands that operate on scalar-valued items whereas the item tests
apply to all cache keys.

In the future we ought to group the cache tests under a folder `cache`
and rename the integration tests as appropriate.

Note this PR did not add or delete tests; nor did it modify test behavior.

# Benefits
This also allows developers to easily run a subset of the
tests. A developer can run `cargo t <modname>` to just run the tests
therein. There is also IDE support for running all tests in a mod (see
below). Additionally, this allows us to shorten test function names
and use the same test function name for common
concerns ("nonexistent_cache").

# Demonstrations
Can now group by functionality and collapse as in the JS tests. This 
makes it easy to see at a glance which groups of tests/functionality we 
have not implemented:
![image](https://github.com/momentohq/client-sdk-rust/assets/3690240/a656bbd9-70c6-4d9e-a63f-0671dfeddc35)
We can proactively stub out mods based on the JS repo coverage.

Can now run a subset of tests by functionality in IDE:
![image](https://github.com/momentohq/client-sdk-rust/assets/3690240/a867f32a-6576-4a63-9a62-56c005acafb8)

Or on the command line:
![image](https://github.com/momentohq/client-sdk-rust/assets/3690240/e128b48d-85c9-4e24-b795-eeff964e879f)

And we get shorter test names:
![image](https://github.com/momentohq/client-sdk-rust/assets/3690240/db483abc-56cd-48eb-b30e-4b227bae5f80)
