### PR TITLE
test: put ttl tests in new structure

### DIFF
--- a/tests/cache/item.rs
+++ b/tests/cache/item.rs
@@ -82,5 +82,3 @@ mod item_get_type {
         Ok(())
     }
 }
-
-mod item_get_ttl {}

--- a/tests/cache/mod.rs
+++ b/tests/cache/mod.rs
@@ -3,3 +3,4 @@ mod item;
 mod key_existence;
 mod scalar;
 mod sorted_set;
+mod ttl;

--- a/tests/cache/ttl.rs
+++ b/tests/cache/ttl.rs
@@ -1,10 +1,12 @@
 use std::convert::TryInto;
 use std::time::Duration;
 
-use momento::cache::{
-    DecreaseTtl, IncreaseTtl, ItemGetTtl, SetRequest, SortedSetPutElementsRequest, UpdateTtl,
+use momento::{
+    cache::{
+        DecreaseTtl, IncreaseTtl, ItemGetTtl, SetRequest, SortedSetPutElementsRequest, UpdateTtl,
+    },
+    CollectionTtl, MomentoErrorCode, MomentoResult,
 };
-use momento::{CollectionTtl, MomentoErrorCode, MomentoResult};
 use momento_test_util::{unique_string, CACHE_TEST_STATE};
 
 mod item_get_ttl {


### PR DESCRIPTION
Two PRs went in at the same time: the test refactor and the cache ttl
tests. Because of this the ttl tests were not in the new place. This
PR corrects that.
