### PR TITLE
test: add test data types to ease test data creation

### DIFF
--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -1,8 +1,12 @@
 mod cache_test_state;
+mod test_data;
 mod test_utils;
 
 pub use crate::cache_test_state::CACHE_TEST_STATE;
+pub use crate::test_data::{
+    unique_cache_name, unique_key, unique_string, unique_value, TestScalar, TestSet, TestSortedSet,
+};
 pub use crate::test_utils::{
     create_doctest_cache_client, doctest, get_test_cache_name, get_test_credential_provider,
-    unique_string, DoctestResult,
+    DoctestResult,
 };

--- a/test-util/src/test_data.rs
+++ b/test-util/src/test_data.rs
@@ -1,0 +1,101 @@
+use uuid::Uuid;
+
+pub fn unique_string(prefix: impl Into<String>) -> String {
+    format!("{}-{}", prefix.into(), Uuid::new_v4())
+}
+
+pub fn unique_cache_name() -> String {
+    unique_string("rust-sdk")
+}
+
+pub fn unique_key() -> String {
+    unique_string("key")
+}
+
+pub fn unique_value() -> String {
+    unique_string("value")
+}
+
+pub struct TestScalar {
+    pub key: String,
+    pub value: String,
+}
+
+impl TestScalar {
+    pub fn new() -> Self {
+        Self {
+            key: unique_key(),
+            value: unique_value(),
+        }
+    }
+
+    pub fn key(&self) -> String {
+        self.key.clone()
+    }
+
+    pub fn value(&self) -> String {
+        self.value.clone()
+    }
+}
+
+impl Default for TestScalar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct TestSet {
+    pub name: String,
+    pub elements: Vec<String>,
+}
+
+impl TestSet {
+    pub fn new() -> Self {
+        Self {
+            name: unique_key(),
+            elements: vec![unique_value(), unique_value()],
+        }
+    }
+
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    pub fn elements(&self) -> Vec<String> {
+        self.elements.clone()
+    }
+}
+
+impl Default for TestSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct TestSortedSet {
+    pub name: String,
+    pub elements: Vec<(String, f64)>,
+}
+
+impl TestSortedSet {
+    pub fn new() -> Self {
+        Self {
+            name: unique_key(),
+            elements: vec![(unique_value(), 1.0), (unique_value(), 2.0)],
+        }
+    }
+
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    pub fn elements(&self) -> Vec<(String, f64)> {
+        self.elements.clone()
+    }
+}
+
+impl Default for TestSortedSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/test-util/src/test_utils.rs
+++ b/test-util/src/test_utils.rs
@@ -2,11 +2,11 @@ use std::env;
 use std::future::Future;
 use std::time::Duration;
 
-use uuid::Uuid;
-
 use momento::cache::configurations;
 use momento::CredentialProvider;
 use momento::{CacheClient, SimpleCacheClientBuilder};
+
+use crate::unique_cache_name;
 
 pub type DoctestResult = anyhow::Result<()>;
 
@@ -28,7 +28,7 @@ where
     // The constructor for the cache client needs a tokio runtime to be active.
     let _guard = runtime.enter();
 
-    let cache_name = unique_string("rust-sdk");
+    let cache_name = unique_cache_name();
     let credential_provider = CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
         .expect("MOMENTO_API_KEY must be set");
 
@@ -70,8 +70,4 @@ pub fn get_test_cache_name() -> String {
 pub fn get_test_credential_provider() -> CredentialProvider {
     CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
         .expect("auth token should be valid")
-}
-
-pub fn unique_string(prefix: impl Into<String>) -> String {
-    format!("{}-{}", prefix.into(), Uuid::new_v4())
 }

--- a/tests/cache/key_existence.rs
+++ b/tests/cache/key_existence.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 
 use momento::{MomentoErrorCode, MomentoResult};
-use momento_test_util::{unique_string, CACHE_TEST_STATE};
+use momento_test_util::{unique_cache_name, TestScalar, CACHE_TEST_STATE};
 
 mod key_exists {
+    use momento_test_util::{unique_cache_name, TestScalar};
+
     use super::*;
 
     #[tokio::test]
@@ -17,7 +19,7 @@ mod key_exists {
     #[tokio::test]
     async fn nonexistent_cache() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
-        let cache_name = unique_string("fake-cache");
+        let cache_name = unique_cache_name();
         let result = client.key_exists(cache_name, "key").await.unwrap_err();
         assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
         Ok(())
@@ -27,24 +29,25 @@ mod key_exists {
     async fn happy_path() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = CACHE_TEST_STATE.cache_name.as_str();
-        let key_uuid = unique_string("key");
-        let key = key_uuid.as_str();
+        let item = TestScalar::new();
 
         // Key should not exist yet
-        let result = client.key_exists(cache_name, key).await?;
+        let result = client.key_exists(cache_name, item.key()).await?;
         assert!(
             !result.exists,
             "Expected key {} to not exist in cache {}, but it does",
-            key, cache_name
+            item.key(),
+            cache_name
         );
 
         // Key should exist after setting a key
-        client.set(cache_name, key, "value").await?;
-        let result = client.key_exists(cache_name, key).await?;
+        client.set(cache_name, item.key(), item.value()).await?;
+        let result = client.key_exists(cache_name, item.key()).await?;
         assert!(
             result.exists,
             "Expected key {} to exist in cache {}, but it does not",
-            key, cache_name
+            item.key(),
+            cache_name
         );
 
         Ok(())
@@ -65,7 +68,7 @@ mod keys_exists {
     #[tokio::test]
     async fn nonexistent_cache() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
-        let cache_name = unique_string("fake-cache");
+        let cache_name = unique_cache_name();
         let result = client
             .keys_exist(cache_name, vec!["key"])
             .await
@@ -89,23 +92,19 @@ mod keys_exists {
         );
 
         // Key should return true only for keys that exist in the cache
-        let unique_key1 = unique_string("keys-exist");
-        let key1 = unique_key1.as_str();
+        let items = (0..4)
+            .map(|_| TestScalar::new())
+            .collect::<Vec<TestScalar>>();
 
-        let unique_key2 = unique_string("keys-exist");
-        let key2 = unique_key2.as_str();
-
-        let unique_key3 = unique_string("keys-exist");
-        let key3 = unique_key3.as_str();
-
-        let unique_key4 = unique_string("keys-exist");
-        let key4 = unique_key4.as_str();
-
-        client.set(cache_name, key1, key1).await?;
-        client.set(cache_name, key3, key3).await?;
+        client
+            .set(cache_name, items[0].key(), items[0].value())
+            .await?;
+        client
+            .set(cache_name, items[2].key(), items[2].value())
+            .await?;
 
         let result = client
-            .keys_exist(cache_name, vec![key1, key2, key3, key4])
+            .keys_exist(cache_name, items.iter().map(|item| item.key()).collect())
             .await?;
 
         let keys_list: Vec<bool> = result.clone().into();
@@ -115,12 +114,12 @@ mod keys_exists {
         let keys_dict: HashMap<String, bool> = result.into();
 
         // these dictionary entries should be true
-        assert!(keys_dict[key1]);
-        assert!(keys_dict[key3]);
+        assert!(keys_dict[&items[0].key()]);
+        assert!(keys_dict[&items[1].key()]);
 
         // these dictionary entries should be false
-        assert!(!keys_dict[key2]);
-        assert!(!keys_dict[key4]);
+        assert!(!keys_dict[&items[1].key()]);
+        assert!(!keys_dict[&items[3].key()]);
 
         Ok(())
     }

--- a/tests/cache/scalar.rs
+++ b/tests/cache/scalar.rs
@@ -1,5 +1,5 @@
 use momento::{cache::Delete, MomentoErrorCode, MomentoResult};
-use momento_test_util::{unique_string, CACHE_TEST_STATE};
+use momento_test_util::{unique_cache_name, unique_key, TestScalar, CACHE_TEST_STATE};
 
 mod get_set_delete {
     use super::*;
@@ -15,7 +15,7 @@ mod get_set_delete {
     #[tokio::test]
     async fn delete_nonexistent_cache() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
-        let cache_name = unique_string("fake-cache");
+        let cache_name = unique_cache_name();
         let result = client.delete(cache_name, "key").await.unwrap_err();
         assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
         Ok(())
@@ -25,11 +25,10 @@ mod get_set_delete {
     async fn delete_happy_path() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = CACHE_TEST_STATE.cache_name.as_str();
-        let key_uuid = unique_string("key");
-        let key = key_uuid.as_str();
+        let item = TestScalar::new();
 
         // Deleting a key that doesn't exist should not error
-        let result = client.delete(cache_name, key).await?;
+        let result = client.delete(cache_name, item.key()).await?;
         assert_eq!(
             result,
             Delete {},
@@ -38,8 +37,8 @@ mod get_set_delete {
         );
 
         // Deleting a key that exists should delete it
-        client.set(cache_name, key, "value").await?;
-        let result = client.delete(cache_name, key).await?;
+        client.set(cache_name, item.key(), item.value()).await?;
+        let result = client.delete(cache_name, item.key()).await?;
         assert_eq!(
             result,
             Delete {},
@@ -48,7 +47,7 @@ mod get_set_delete {
         );
 
         // Key should not exist after deletion
-        let result = client.key_exists(cache_name, key).await?;
+        let result = client.key_exists(cache_name, item.key()).await?;
         assert!(
             !result.exists,
             "Expected key 'key' to not exist in cache {} after deletion, but it does",
@@ -73,7 +72,7 @@ mod increment {
     #[tokio::test]
     async fn nonexistent_cache() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
-        let cache_name = unique_string("fake-cache");
+        let cache_name = unique_cache_name();
         let result = client.increment(cache_name, "key", 1).await.unwrap_err();
         assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
         Ok(())
@@ -83,8 +82,8 @@ mod increment {
     async fn happy_path() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = CACHE_TEST_STATE.cache_name.as_str();
-        let key_uuid = unique_string("key");
-        let key = key_uuid.as_str();
+        let key = unique_key();
+        let key = key.as_str();
 
         // Incrementing a key that doesn't exist should create it
         let result = client.increment(cache_name, key, 1).await?;

--- a/tests/cache/sorted_set.rs
+++ b/tests/cache/sorted_set.rs
@@ -7,17 +7,18 @@ use momento::cache::{
 };
 use momento::{CacheClient, MomentoErrorCode, MomentoResult};
 
-use momento_test_util::{unique_string, CACHE_TEST_STATE};
+use momento_test_util::{unique_key, CACHE_TEST_STATE};
 
 mod sorted_set_fetch_by_rank {
+    use momento_test_util::unique_cache_name;
+
     use super::*;
 
     #[tokio::test]
     async fn happy_path() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = &CACHE_TEST_STATE.cache_name;
-        let unique_sorted_set_name = unique_string("sorted-set");
-        let sorted_set_name = unique_sorted_set_name.as_str();
+        let sorted_set_name = unique_key();
         let to_put = vec![
             ("1".to_string(), 0.0),
             ("2".to_string(), 1.0),
@@ -27,16 +28,16 @@ mod sorted_set_fetch_by_rank {
         ];
 
         let result = client
-            .sorted_set_fetch_by_rank(cache_name, sorted_set_name, Ascending, None, None)
+            .sorted_set_fetch_by_rank(cache_name, sorted_set_name.clone(), Ascending, None, None)
             .await?;
         assert_eq!(result, SortedSetFetch::Miss);
 
         client
-            .sorted_set_put_elements(cache_name, sorted_set_name, to_put)
+            .sorted_set_put_elements(cache_name, sorted_set_name.clone(), to_put)
             .await?;
 
         // Full set ascending, end index larger than set
-        let fetch_request = SortedSetFetchByRankRequest::new(cache_name, sorted_set_name)
+        let fetch_request = SortedSetFetchByRankRequest::new(cache_name, sorted_set_name.clone())
             .order(Ascending)
             .start_rank(0)
             .end_rank(6);
@@ -78,11 +79,10 @@ mod sorted_set_fetch_by_rank {
     #[tokio::test]
     async fn nonexistent_cache() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
-        let cache_name = unique_string("fake-cache");
-        let sorted_set_name = "sorted-set";
+        let cache_name = unique_cache_name();
 
         let result = client
-            .sorted_set_fetch_by_rank(cache_name, sorted_set_name, Ascending, None, None)
+            .sorted_set_fetch_by_rank(cache_name, "sorted-set", Ascending, None, None)
             .await
             .unwrap_err();
 
@@ -92,14 +92,16 @@ mod sorted_set_fetch_by_rank {
 }
 
 mod sorted_set_fetch_by_score {
+    use momento_test_util::unique_cache_name;
+
     use super::*;
 
     #[tokio::test]
     async fn happy_path() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = &CACHE_TEST_STATE.cache_name;
-        let unique_sorted_set_name = unique_string("sorted-set");
-        let sorted_set_name = unique_sorted_set_name.as_str();
+        let sorted_set_name = unique_key();
+        let sorted_set_name = sorted_set_name.as_str();
         let to_put = vec![
             ("1".to_string(), 0.0),
             ("2".to_string(), 1.0),
@@ -178,7 +180,7 @@ mod sorted_set_fetch_by_score {
     #[tokio::test]
     async fn nonexistent_cache() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
-        let cache_name = unique_string("fake-cache");
+        let cache_name = unique_cache_name();
         let sorted_set_name = "sorted-set";
 
         let result = client
@@ -202,14 +204,16 @@ mod sorted_set_increment_score {}
 mod sorted_set_remove_element {}
 
 mod sorted_set_put_element {
+    use momento_test_util::unique_cache_name;
+
     use super::*;
 
     #[tokio::test]
     async fn happy_path() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = &CACHE_TEST_STATE.cache_name;
-        let unique_sorted_set_name = unique_string("sorted-set");
-        let sorted_set_name = unique_sorted_set_name.as_str();
+        let sorted_set_name = unique_key();
+        let sorted_set_name = sorted_set_name.as_str();
         let value = "value";
         let score = 1.0;
 
@@ -241,7 +245,7 @@ mod sorted_set_put_element {
     #[tokio::test]
     async fn nonexistent_cache() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
-        let cache_name = unique_string("fake-cache");
+        let cache_name = unique_cache_name();
         let sorted_set_name = "sorted-set";
 
         let result = client
@@ -268,8 +272,8 @@ mod sorted_set_put_elements {
             cache_name: &String,
             to_put: impl IntoSortedSetElements<String> + Clone,
         ) -> MomentoResult<()> {
-            let unique_sorted_set_name = unique_string("sorted-set");
-            let sorted_set_name = unique_sorted_set_name.as_str();
+            let sorted_set_name = unique_key();
+            let sorted_set_name = sorted_set_name.as_str();
             let result = client
                 .sorted_set_fetch_by_score(cache_name, sorted_set_name, Ascending)
                 .await?;
@@ -333,7 +337,7 @@ mod sorted_set_put_elements {
     #[tokio::test]
     async fn nonexistent_cache() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
-        let cache_name = unique_string("fake-cache");
+        let cache_name = unique_key();
         let sorted_set_name = "sorted-set";
 
         let result = client


### PR DESCRIPTION
A common concern in the integration tests is creating test data. In
Rust, creating test data is a bit more painful than in other
languages. Thus we introduce some helper structs to create test data.

These test data create random data for each data type we have. In the
future we can also add comparators (PartialEq implementations) which
will be a common concern and pain in the test code.
