### PR TITLE
test: more scalar coverage and test conveniences

### DIFF
--- a/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
+++ b/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
@@ -87,6 +87,18 @@ impl TryFrom<SortedSetFetch> for Vec<(String, f64)> {
     }
 }
 
+impl Into<SortedSetFetch> for Vec<(String, f64)> {
+    fn into(self) -> SortedSetFetch {
+        SortedSetFetch::Hit {
+            elements: SortedSetElements::new(
+                self.into_iter()
+                    .map(|(element, score)| (element.into_bytes(), score))
+                    .collect(),
+            ),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub struct SortedSetElements {
     pub elements: Vec<(Vec<u8>, f64)>,

--- a/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
+++ b/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
@@ -87,11 +87,12 @@ impl TryFrom<SortedSetFetch> for Vec<(String, f64)> {
     }
 }
 
-impl Into<SortedSetFetch> for Vec<(String, f64)> {
-    fn into(self) -> SortedSetFetch {
+impl From<Vec<(String, f64)>> for SortedSetFetch {
+    fn from(elements: Vec<(String, f64)>) -> Self {
         SortedSetFetch::Hit {
             elements: SortedSetElements::new(
-                self.into_iter()
+                elements
+                    .into_iter()
                     .map(|(element, score)| (element.into_bytes(), score))
                     .collect(),
             ),

--- a/test-util/src/test_data.rs
+++ b/test-util/src/test_data.rs
@@ -1,3 +1,7 @@
+use momento::{
+    cache::{Get, GetValue},
+    IntoBytes,
+};
 use uuid::Uuid;
 
 pub fn unique_string(prefix: impl Into<String>) -> String {
@@ -35,6 +39,13 @@ impl TestScalar {
 
     pub fn value(&self) -> &str {
         &self.value
+    }
+
+    // todo use `into` after getting to sorted sets
+    pub fn to_get_hit(&self) -> Get {
+        Get::Hit {
+            value: GetValue::new(self.value().into_bytes()),
+        }
     }
 }
 

--- a/tests/cache/scalar.rs
+++ b/tests/cache/scalar.rs
@@ -41,7 +41,7 @@ mod get_set_delete {
         let result = client.get(cache_name, item.key()).await?;
         assert_eq!(
             result,
-            item.to_get_hit(),
+            Get::from(&item),
             "Expected hit for key '{}' in cache {}, got {:?}",
             item.key(),
             cache_name,

--- a/tests/cache/scalar.rs
+++ b/tests/cache/scalar.rs
@@ -1,8 +1,96 @@
-use momento::{cache::Delete, MomentoErrorCode, MomentoResult};
+use momento::{
+    cache::{Delete, Get, Set, SetRequest},
+    MomentoErrorCode, MomentoResult,
+};
 use momento_test_util::{unique_cache_name, unique_key, TestScalar, CACHE_TEST_STATE};
 
 mod get_set_delete {
+    use std::time::Duration;
+
     use super::*;
+
+    #[tokio::test]
+    async fn get_set_string() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = CACHE_TEST_STATE.cache_name.as_str();
+        let item = TestScalar::new();
+
+        // Getting a key that doesn't exist should return a miss
+        let result = client.get(cache_name, item.key()).await?;
+        assert_eq!(
+            result,
+            Get::Miss,
+            "Expected miss for key '{}' in cache {}, got {:?}",
+            item.key(),
+            cache_name,
+            result
+        );
+
+        // Setting a key should return a hit
+        let result = client.set(cache_name, item.key(), item.value()).await?;
+        assert_eq!(
+            result,
+            Set {},
+            "Expected successful Set of key '{}' in cache {}, got {:?}",
+            item.key(),
+            cache_name,
+            result
+        );
+
+        // Getting the key should return a hit with the value
+        let result = client.get(cache_name, item.key()).await?;
+        assert_eq!(
+            result,
+            item.to_get_hit(),
+            "Expected hit for key '{}' in cache {}, got {:?}",
+            item.key(),
+            cache_name,
+            result
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn set_with_nonnegative_ttl_is_ok() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = CACHE_TEST_STATE.cache_name.as_str();
+        for ttl in [0, 1] {
+            let item = TestScalar::new();
+            let set_request =
+                SetRequest::new(cache_name, item.key(), item.value()).ttl(Duration::from_secs(ttl));
+            let result = client.send_request(set_request).await?;
+            assert_eq!(result, Set {});
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn set_with_ttl_is_miss_after_expiration() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = CACHE_TEST_STATE.cache_name.as_str();
+        let item = TestScalar::new();
+        let ttl = Duration::from_secs(1);
+        let set_request = SetRequest::new(cache_name, item.key(), item.value()).ttl(ttl);
+        let result = client.send_request(set_request).await?;
+        assert_eq!(result, Set {});
+
+        // Wait for the TTL to expire
+        tokio::time::sleep(ttl).await;
+
+        // Getting the key should return a miss
+        let result = client.get(cache_name, item.key()).await?;
+        assert_eq!(
+            result,
+            Get::Miss,
+            "Expected miss for key '{}' in cache {}, got {:?}",
+            item.key(),
+            cache_name,
+            result
+        );
+
+        Ok(())
+    }
 
     #[tokio::test]
     async fn delete_invalid_cache_name() -> MomentoResult<()> {
@@ -96,6 +184,25 @@ mod increment {
         // Incrementing by a negative number should decrement the value
         let result = client.increment(cache_name, key, -2).await?;
         assert_eq!(result.value, 0);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fails_when_value_is_not_an_integer() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = CACHE_TEST_STATE.cache_name.as_str();
+        let item = TestScalar::new();
+
+        // Set a non-string value
+        client.set(cache_name, item.key(), item.value()).await?;
+
+        // Incrementing the key should fail
+        let result = client
+            .increment(cache_name, item.key(), 1)
+            .await
+            .unwrap_err();
+        assert_eq!(result.error_code, MomentoErrorCode::FailedPreconditionError);
 
         Ok(())
     }

--- a/tests/cache/sorted_set.rs
+++ b/tests/cache/sorted_set.rs
@@ -22,6 +22,25 @@ async fn assert_fetched_sorted_set_eq(
     Ok(())
 }
 
+async fn assert_fetched_sorted_set_eq_after_sorting(
+    sorted_set_fetch_result: SortedSetFetch,
+    expected: Vec<(String, f64)>,
+) -> MomentoResult<()> {
+    let mut sorted_set_fetch_result = sorted_set_fetch_result;
+    match &mut sorted_set_fetch_result {
+        SortedSetFetch::Hit { elements } => {
+            elements
+                .elements
+                .sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+        }
+        _ => {}
+    }
+
+    let mut expected = expected;
+    expected.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+    assert_fetched_sorted_set_eq(sorted_set_fetch_result, expected).await
+}
+
 mod sorted_set_fetch_by_rank {
     use super::*;
 
@@ -333,7 +352,7 @@ mod sorted_set_put_elements {
                 .map(|e| (e.value, e.score))
                 .collect::<Vec<_>>();
 
-            assert_fetched_sorted_set_eq(result, expected).await?;
+            assert_fetched_sorted_set_eq_after_sorting(result, expected).await?;
 
             Ok(())
         }

--- a/tests/cache/sorted_set.rs
+++ b/tests/cache/sorted_set.rs
@@ -7,72 +7,76 @@ use momento::cache::{
 };
 use momento::{CacheClient, MomentoErrorCode, MomentoResult};
 
-use momento_test_util::{unique_key, CACHE_TEST_STATE};
+use momento_test_util::{unique_cache_name, unique_key, TestSortedSet, CACHE_TEST_STATE};
 
 mod sorted_set_fetch_by_rank {
-    use momento_test_util::unique_cache_name;
-
     use super::*;
 
     #[tokio::test]
     async fn happy_path() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = &CACHE_TEST_STATE.cache_name;
-        let sorted_set_name = unique_key();
-        let to_put = vec![
-            ("1".to_string(), 0.0),
-            ("2".to_string(), 1.0),
-            ("3".to_string(), 0.5),
-            ("4".to_string(), 2.0),
-            ("5".to_string(), 1.5),
-        ];
+        let item = TestSortedSet {
+            name: unique_key(),
+            elements: vec![
+                ("1".to_string(), 0.0),
+                ("2".to_string(), 1.0),
+                ("3".to_string(), 0.5),
+                ("4".to_string(), 2.0),
+                ("5".to_string(), 1.5),
+            ],
+        };
 
         let result = client
-            .sorted_set_fetch_by_rank(cache_name, sorted_set_name.clone(), Ascending, None, None)
+            .sorted_set_fetch_by_rank(cache_name, item.name(), Ascending, None, None)
             .await?;
         assert_eq!(result, SortedSetFetch::Miss);
 
         client
-            .sorted_set_put_elements(cache_name, sorted_set_name.clone(), to_put)
+            .sorted_set_put_elements(cache_name, item.name(), item.elements().to_vec())
             .await?;
 
         // Full set ascending, end index larger than set
-        let fetch_request = SortedSetFetchByRankRequest::new(cache_name, sorted_set_name.clone())
+        let fetch_request = SortedSetFetchByRankRequest::new(cache_name, item.name())
             .order(Ascending)
             .start_rank(0)
             .end_rank(6);
 
         let result = client.send_request(fetch_request).await?;
 
-        match result {
-            SortedSetFetch::Hit { elements } => {
-                assert_eq!(elements.len(), 5);
-                let string_elements: Vec<String> =
-                    elements.into_strings()?.into_iter().map(|e| e.0).collect();
+        let expected: SortedSetFetch = vec![
+            ("1".to_string(), 0.0),
+            ("3".to_string(), 0.5),
+            ("2".to_string(), 1.0),
+            ("5".to_string(), 1.5),
+            ("4".to_string(), 2.0),
+        ]
+        .into();
 
-                assert_eq!(string_elements, vec!["1", "3", "2", "5", "4"])
-            }
-            _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
-        }
+        assert_eq!(
+            result, expected,
+            "Expected SortedSetFetch::Hit to be equal to {:?}, but got {:?}",
+            expected, result
+        );
 
         // Partial set descending
-        let fetch_request = SortedSetFetchByRankRequest::new(cache_name, sorted_set_name)
+        let fetch_request = SortedSetFetchByRankRequest::new(cache_name, item.name())
             .order(Descending)
             .start_rank(1)
             .end_rank(4);
 
         let result = client.send_request(fetch_request).await?;
-
-        match result {
-            SortedSetFetch::Hit { elements } => {
-                assert_eq!(elements.len(), 3);
-                let string_elements: Vec<String> =
-                    elements.into_strings()?.into_iter().map(|e| e.0).collect();
-
-                assert_eq!(string_elements, vec!["5", "2", "3"])
-            }
-            _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
-        }
+        let expected: SortedSetFetch = vec![
+            ("5".to_string(), 1.5),
+            ("2".to_string(), 1.0),
+            ("3".to_string(), 0.5),
+        ]
+        .into();
+        assert_eq!(
+            result, expected,
+            "Expected SortedSetFetch::Hit to be equal to {:?}, but got {:?}",
+            expected, result
+        );
         Ok(())
     }
 
@@ -92,88 +96,92 @@ mod sorted_set_fetch_by_rank {
 }
 
 mod sorted_set_fetch_by_score {
-    use momento_test_util::unique_cache_name;
-
     use super::*;
 
     #[tokio::test]
     async fn happy_path() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = &CACHE_TEST_STATE.cache_name;
-        let sorted_set_name = unique_key();
-        let sorted_set_name = sorted_set_name.as_str();
-        let to_put = vec![
-            ("1".to_string(), 0.0),
-            ("2".to_string(), 1.0),
-            ("3".to_string(), 0.5),
-            ("4".to_string(), 2.0),
-            ("5".to_string(), 1.5),
-        ];
+        let item = TestSortedSet {
+            name: unique_key(),
+            elements: vec![
+                ("1".to_string(), 0.0),
+                ("2".to_string(), 1.0),
+                ("3".to_string(), 0.5),
+                ("4".to_string(), 2.0),
+                ("5".to_string(), 1.5),
+            ],
+        };
 
         let result = client
-            .sorted_set_fetch_by_score(cache_name, sorted_set_name, Ascending)
+            .sorted_set_fetch_by_score(cache_name, item.name(), Ascending)
             .await?;
         assert_eq!(result, SortedSetFetch::Miss);
 
         client
-            .sorted_set_put_elements(cache_name, sorted_set_name, to_put)
+            .sorted_set_put_elements(cache_name, item.name(), item.elements().to_vec())
             .await?;
 
         // Full set ascending, end score larger than set
-        let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
+        let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, item.name())
             .order(Ascending)
             .min_score(0.0)
             .max_score(9.9);
 
         let result = client.send_request(fetch_request).await?;
+        let expected: SortedSetFetch = vec![
+            ("1".to_string(), 0.0),
+            ("3".to_string(), 0.5),
+            ("2".to_string(), 1.0),
+            ("5".to_string(), 1.5),
+            ("4".to_string(), 2.0),
+        ]
+        .into();
 
-        match result {
-            SortedSetFetch::Hit { elements } => {
-                assert_eq!(elements.len(), 5);
-                let string_elements: Vec<String> =
-                    elements.into_strings()?.into_iter().map(|e| e.0).collect();
-
-                assert_eq!(string_elements, vec!["1", "3", "2", "5", "4"])
-            }
-            _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
-        }
+        assert_eq!(
+            result, expected,
+            "Expected SortedSetFetch::Hit to be equal to {:?}, but got {:?}",
+            expected, result
+        );
 
         // Partial set descending
-        let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
+        let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, item.name())
             .order(Descending)
             .min_score(0.1)
             .max_score(1.9);
 
         let result = client.send_request(fetch_request).await?;
+        let expected: SortedSetFetch = vec![
+            ("5".to_string(), 1.5),
+            ("2".to_string(), 1.0),
+            ("3".to_string(), 0.5),
+        ]
+        .into();
 
-        match result {
-            SortedSetFetch::Hit { elements } => {
-                assert_eq!(elements.len(), 3);
-                let string_elements: Vec<String> =
-                    elements.into_strings()?.into_iter().map(|e| e.0).collect();
-
-                assert_eq!(string_elements, vec!["5", "2", "3"])
-            }
-            _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
-        }
+        assert_eq!(
+            result, expected,
+            "Expected SortedSetFetch::Hit to be equal to {:?}, but got {:?}",
+            expected, result
+        );
 
         // Partial set limited by offset and count
-        let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
+        let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, item.name())
             .offset(1)
             .count(3);
 
         let result = client.send_request(fetch_request).await?;
+        let expected: SortedSetFetch = vec![
+            ("3".to_string(), 0.5),
+            ("2".to_string(), 1.0),
+            ("5".to_string(), 1.5),
+        ]
+        .into();
 
-        match result {
-            SortedSetFetch::Hit { elements } => {
-                assert_eq!(elements.len(), 3);
-                let string_elements: Vec<String> =
-                    elements.into_strings()?.into_iter().map(|e| e.0).collect();
-
-                assert_eq!(string_elements, vec!["3", "2", "5"])
-            }
-            _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
-        }
+        assert_eq!(
+            result, expected,
+            "Expected SortedSetFetch::Hit to be equal to {:?}, but got {:?}",
+            expected, result
+        );
         Ok(())
     }
 
@@ -204,41 +212,37 @@ mod sorted_set_increment_score {}
 mod sorted_set_remove_element {}
 
 mod sorted_set_put_element {
-    use momento_test_util::unique_cache_name;
-
     use super::*;
 
     #[tokio::test]
     async fn happy_path() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = &CACHE_TEST_STATE.cache_name;
-        let sorted_set_name = unique_key();
-        let sorted_set_name = sorted_set_name.as_str();
-        let value = "value";
-        let score = 1.0;
+        let item = TestSortedSet::new();
 
         let result = client
-            .sorted_set_fetch_by_rank(cache_name, sorted_set_name, Ascending, None, None)
+            .sorted_set_fetch_by_rank(cache_name, item.name(), Ascending, None, None)
             .await?;
         assert_eq!(result, SortedSetFetch::Miss);
 
         client
-            .sorted_set_put_element(cache_name, sorted_set_name, "value", 1.0)
+            .sorted_set_put_element(
+                cache_name,
+                item.name(),
+                item.elements[0].0.clone(),
+                item.elements[0].1,
+            )
             .await?;
 
         let result = client
-            .sorted_set_fetch_by_rank(cache_name, sorted_set_name, Ascending, None, None)
+            .sorted_set_fetch_by_rank(cache_name, item.name(), Ascending, None, None)
             .await?;
-
-        match result {
-            SortedSetFetch::Hit { elements } => {
-                assert_eq!(elements.len(), 1);
-                let string_elements = elements.into_strings()?;
-                assert_eq!(string_elements[0].0, value);
-                assert_eq!(string_elements[0].1, score)
-            }
-            _ => panic!("Expected SortedSetFetch::Hit, but got {:?}", result),
-        }
+        let expected: SortedSetFetch = vec![item.elements[0].clone()].into();
+        assert_eq!(
+            result, expected,
+            "Expected SortedSetFetch::Hit to be equal to {:?}, but got {:?}",
+            expected, result
+        );
         Ok(())
     }
 
@@ -308,15 +312,18 @@ mod sorted_set_put_elements {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = &CACHE_TEST_STATE.cache_name;
 
+        // Test putting multiple elements as a vector
         let to_put = vec![("element1".to_string(), 1.0), ("element2".to_string(), 2.0)];
         test_put_elements_happy_path(client, cache_name, to_put).await?;
 
+        // Test putting multiple elements as a hashmap
         let to_put = std::collections::HashMap::from([
             ("element1".to_string(), 1.0),
             ("element2".to_string(), 2.0),
         ]);
         test_put_elements_happy_path(client, cache_name, to_put).await?;
 
+        // Test passing a vec of `SortedSetElement`s
         let to_put = vec![("element1".to_string(), 1.0), ("element2".to_string(), 2.0)];
         test_put_elements_happy_path(client, cache_name, to_put).await?;
 


### PR DESCRIPTION
We audit test coverage for `get`, `set`, and `sorted sets` and add tests as needed. We also implement traits and conveniences that will make future integration test authorship easier. In particular:

- For each test data type, we implement the `From` trait paired with the corresponding cache hit response. That way we can use the test data directly in an assertion without the need to massage it in the right form.
- We extract asserting a collection fetch is equal to test data. Both unpacking the actual result, massaging the expected reuslt, and comparing contain a lot of boilerplate. The sorted set tests demonstrate this pattern.