### PR TITLE
feat: add list collection

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -49,6 +49,7 @@ pub use requests::list::list_concatenate_back::{ListConcatenateBack, ListConcate
 pub use requests::list::list_concatenate_front::{
     ListConcatenateFront, ListConcatenateFrontRequest,
 };
+pub use requests::list::list_fetch::{ListFetch, ListFetchRequest};
 pub use requests::list::list_length::{ListLength, ListLengthRequest};
 
 // Similar re-exporting with config::configuration and config::configurations

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -45,6 +45,10 @@ pub use requests::sorted_set::sorted_set_put_elements::{
     IntoSortedSetElements, SortedSetElement, SortedSetPutElements, SortedSetPutElementsRequest,
 };
 
+pub use requests::list::list_concatenate_back::{ListConcatenateBack, ListConcatenateBackRequest};
+pub use requests::list::list_concatenate_front::{
+    ListConcatenateFront, ListConcatenateFrontRequest,
+};
 pub use requests::list::list_length::{ListLength, ListLengthRequest};
 
 // Similar re-exporting with config::configuration and config::configurations

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -51,6 +51,9 @@ pub use requests::list::list_concatenate_front::{
 };
 pub use requests::list::list_fetch::{ListFetch, ListFetchRequest};
 pub use requests::list::list_length::{ListLength, ListLengthRequest};
+pub use requests::list::list_pop_back::{ListPopBack, ListPopBackRequest};
+pub use requests::list::list_pop_front::{ListPopFront, ListPopFrontRequest};
+pub use requests::list::list_remove_value::{ListRemoveValue, ListRemoveValueRequest};
 
 // Similar re-exporting with config::configuration and config::configurations
 // so import paths can be simpmlified to "momento::cache::Configuration" and

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -49,10 +49,10 @@ pub use requests::list::list_concatenate_back::{ListConcatenateBack, ListConcate
 pub use requests::list::list_concatenate_front::{
     ListConcatenateFront, ListConcatenateFrontRequest,
 };
-pub use requests::list::list_fetch::{ListFetch, ListFetchRequest};
+pub use requests::list::list_fetch::{ListFetch, ListFetchRequest, ListFetchValue};
 pub use requests::list::list_length::{ListLength, ListLengthRequest};
-pub use requests::list::list_pop_back::{ListPopBack, ListPopBackRequest};
-pub use requests::list::list_pop_front::{ListPopFront, ListPopFrontRequest};
+pub use requests::list::list_pop_back::{ListPopBack, ListPopBackRequest, ListPopBackValue};
+pub use requests::list::list_pop_front::{ListPopFront, ListPopFrontRequest, ListPopFrontValue};
 pub use requests::list::list_remove_value::{ListRemoveValue, ListRemoveValueRequest};
 
 // Similar re-exporting with config::configuration and config::configurations

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -45,6 +45,8 @@ pub use requests::sorted_set::sorted_set_put_elements::{
     IntoSortedSetElements, SortedSetElement, SortedSetPutElements, SortedSetPutElementsRequest,
 };
 
+pub use requests::list::list_length::{ListLength, ListLengthRequest};
+
 // Similar re-exporting with config::configuration and config::configurations
 // so import paths can be simpmlified to "momento::cache::Configuration" and
 // "use momento::cache::configurations::laptop"

--- a/src/cache/requests/list/list_concatenate_back.rs
+++ b/src/cache/requests/list/list_concatenate_back.rs
@@ -6,6 +6,9 @@ use crate::{
 
 /// Adds multiple elements to the back of the given list. Creates the list if it does not already exist.
 ///
+/// Appends the supplied list to the end of an existing list. For example, if you have a list [1, 2, 3]
+/// and listConcatenateBack [4, 5, 6], you will create [1, 2, 3, 4, 5, 6].
+///
 /// # Arguments
 /// * `cache_name` - name of cache
 /// * `list_name` - name of the list

--- a/src/cache/requests/list/list_concatenate_back.rs
+++ b/src/cache/requests/list/list_concatenate_back.rs
@@ -1,0 +1,100 @@
+use crate::{
+    cache::{CollectionTtl, MomentoRequest},
+    utils::prep_request_with_timeout,
+    CacheClient, IntoBytes, MomentoResult,
+};
+
+/// Adds multiple elements to the back of the given list. Creates the list if it does not already exist.
+///
+/// # Arguments
+/// * `cache_name` - name of cache
+/// * `list_name` - name of the list
+/// * `values` - list of values to add to the back of the list
+///
+/// # Optional Arguments
+///
+/// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
+/// * `truncate_front_to_size` - If the list exceeds this length, remove excess from the front of the list.
+///
+/// # Examples
+/// Assumes that a CacheClient named `cache_client` has been created and is available.
+/// ```
+/// # fn main() -> anyhow::Result<()> {
+/// # use momento_test_util::create_doctest_cache_client;
+/// # tokio_test::block_on(async {
+/// use momento::cache::{ListConcatenateBack, ListConcatenateBackRequest};
+/// # let (cache_client, cache_name) = create_doctest_cache_client();
+/// let list_name = "list-name";
+/// let concat_back_request = ListConcatenateBackRequest::new(cache_name, list_name, vec!["value1", "value2"]);
+///
+/// match cache_client.send_request(concat_back_request).await {
+///     Ok(_) => println!("Elements added to list"),
+///     Err(e) => eprintln!("Error adding elements to list: {}", e),
+/// }
+/// # Ok(())
+/// # })
+/// # }
+/// ```
+pub struct ListConcatenateBackRequest<L: IntoBytes, V: IntoBytes> {
+    cache_name: String,
+    list_name: L,
+    values: Vec<V>,
+    collection_ttl: Option<CollectionTtl>,
+    truncate_front_to_size: Option<u32>,
+}
+
+impl<L: IntoBytes, V: IntoBytes> ListConcatenateBackRequest<L, V> {
+    pub fn new(cache_name: impl Into<String>, list_name: L, values: Vec<V>) -> Self {
+        Self {
+            cache_name: cache_name.into(),
+            list_name,
+            values,
+            collection_ttl: None,
+            truncate_front_to_size: None,
+        }
+    }
+
+    /// Set the time-to-live for the collection.
+    pub fn ttl(mut self, collection_ttl: CollectionTtl) -> Self {
+        self.collection_ttl = Some(collection_ttl);
+        self
+    }
+
+    /// If the list exceeds this length, remove excess from the front of the list.
+    pub fn truncate_back_to_size(mut self, truncate_front_to_size: u32) -> Self {
+        self.truncate_front_to_size = Some(truncate_front_to_size);
+        self
+    }
+}
+
+impl<L: IntoBytes, V: IntoBytes> MomentoRequest for ListConcatenateBackRequest<L, V> {
+    type Response = ListConcatenateBack;
+
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListConcatenateBack> {
+        let collection_ttl = self.collection_ttl.unwrap_or_default();
+        let values = self.values;
+        let list_name = self.list_name.into_bytes();
+        let cache_name = &self.cache_name;
+        let request = prep_request_with_timeout(
+            cache_name,
+            cache_client.configuration.deadline_millis(),
+            momento_protos::cache_client::ListConcatenateBackRequest {
+                list_name,
+                values: values.into_iter().map(|v| v.into_bytes()).collect(),
+                ttl_milliseconds: cache_client.expand_ttl_ms(collection_ttl.ttl())?,
+                refresh_ttl: collection_ttl.refresh(),
+                truncate_front_to_size: self.truncate_front_to_size.unwrap_or(0),
+            },
+        )?;
+
+        let _ = cache_client
+            .data_client
+            .clone()
+            .list_concatenate_back(request)
+            .await?;
+        Ok(ListConcatenateBack {})
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ListConcatenateBack {}

--- a/src/cache/requests/list/list_concatenate_front.rs
+++ b/src/cache/requests/list/list_concatenate_front.rs
@@ -1,0 +1,100 @@
+use crate::{
+    cache::{CollectionTtl, MomentoRequest},
+    utils::prep_request_with_timeout,
+    CacheClient, IntoBytes, MomentoResult,
+};
+
+/// Adds multiple elements to the front of the given list. Creates the list if it does not already exist.
+///
+/// # Arguments
+/// * `cache_name` - name of cache
+/// * `list_name` - name of the list
+/// * `values` - list of values to add to the front of the list
+///
+/// # Optional Arguments
+///
+/// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
+/// * `truncate_back_to_size` - If the list exceeds this length, remove excess from the back of the list.
+///
+/// # Examples
+/// Assumes that a CacheClient named `cache_client` has been created and is available.
+/// ```
+/// # fn main() -> anyhow::Result<()> {
+/// # use momento_test_util::create_doctest_cache_client;
+/// # tokio_test::block_on(async {
+/// use momento::cache::{ListConcatenateFront, ListConcatenateFrontRequest};
+/// # let (cache_client, cache_name) = create_doctest_cache_client();
+/// let list_name = "list-name";
+/// let concat_front_request = ListConcatenateFrontRequest::new(cache_name, list_name, vec!["value1", "value2"]);
+///
+/// match cache_client.send_request(concat_front_request).await {
+///     Ok(_) => println!("Elements added to list"),
+///     Err(e) => eprintln!("Error adding elements to list: {}", e),
+/// }
+/// # Ok(())
+/// # })
+/// # }
+/// ```
+pub struct ListConcatenateFrontRequest<L: IntoBytes, V: IntoBytes> {
+    cache_name: String,
+    list_name: L,
+    values: Vec<V>,
+    collection_ttl: Option<CollectionTtl>,
+    truncate_back_to_size: Option<u32>,
+}
+
+impl<L: IntoBytes, V: IntoBytes> ListConcatenateFrontRequest<L, V> {
+    pub fn new(cache_name: impl Into<String>, list_name: L, values: Vec<V>) -> Self {
+        Self {
+            cache_name: cache_name.into(),
+            list_name,
+            values,
+            collection_ttl: None,
+            truncate_back_to_size: None,
+        }
+    }
+
+    /// Set the time-to-live for the collection.
+    pub fn ttl(mut self, collection_ttl: CollectionTtl) -> Self {
+        self.collection_ttl = Some(collection_ttl);
+        self
+    }
+
+    /// If the list exceeds this length, remove excess from the back of the list.
+    pub fn truncate_back_to_size(mut self, truncate_back_to_size: u32) -> Self {
+        self.truncate_back_to_size = Some(truncate_back_to_size);
+        self
+    }
+}
+
+impl<L: IntoBytes, V: IntoBytes> MomentoRequest for ListConcatenateFrontRequest<L, V> {
+    type Response = ListConcatenateFront;
+
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListConcatenateFront> {
+        let collection_ttl = self.collection_ttl.unwrap_or_default();
+        let values = self.values;
+        let list_name = self.list_name.into_bytes();
+        let cache_name = &self.cache_name;
+        let request = prep_request_with_timeout(
+            cache_name,
+            cache_client.configuration.deadline_millis(),
+            momento_protos::cache_client::ListConcatenateFrontRequest {
+                list_name,
+                values: values.into_iter().map(|v| v.into_bytes()).collect(),
+                ttl_milliseconds: cache_client.expand_ttl_ms(collection_ttl.ttl())?,
+                refresh_ttl: collection_ttl.refresh(),
+                truncate_back_to_size: self.truncate_back_to_size.unwrap_or(0),
+            },
+        )?;
+
+        let _ = cache_client
+            .data_client
+            .clone()
+            .list_concatenate_front(request)
+            .await?;
+        Ok(ListConcatenateFront {})
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ListConcatenateFront {}

--- a/src/cache/requests/list/list_concatenate_front.rs
+++ b/src/cache/requests/list/list_concatenate_front.rs
@@ -6,6 +6,9 @@ use crate::{
 
 /// Adds multiple elements to the front of the given list. Creates the list if it does not already exist.
 ///
+/// Prepends the supplied list to the front of an existing list. For example, if you have a list [1, 2, 3]
+/// and listConcatenateFront [4, 5, 6], you will create [4, 5, 6, 1, 2, 3].
+///
 /// # Arguments
 /// * `cache_name` - name of cache
 /// * `list_name` - name of the list

--- a/src/cache/requests/list/list_fetch.rs
+++ b/src/cache/requests/list/list_fetch.rs
@@ -1,0 +1,173 @@
+use std::convert::TryFrom;
+
+use momento_protos::{cache_client::{list_fetch_request::{EndIndex, StartIndex}, list_fetch_response}, common::Unbounded};
+
+use crate::{
+    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoError,
+    MomentoErrorCode, MomentoResult,
+};
+
+/// Gets a list item from a cache with optional slices.
+///
+/// # Arguments
+/// * `cache_name` - name of cache
+/// * `list_name` - name of the list
+///
+/// # Optional Arguments
+///
+/// * `start_index` - The starting inclusive element of the list to fetch. Default is 0.
+/// * `end_index` - The ending exclusive element of the list to fetch. Default is end of list.
+/// 
+/// # Examples
+/// Assumes that a CacheClient named `cache_client` has been created and is available.
+/// ```
+/// # fn main() -> anyhow::Result<()> {
+/// # use momento_test_util::create_doctest_cache_client;
+/// # tokio_test::block_on(async {
+/// use std::convert::TryInto;
+/// use momento::cache::{ListFetch, ListFetchRequest};
+/// use momento::MomentoErrorCode;
+/// # let (cache_client, cache_name) = create_doctest_cache_client();
+/// let list_name = "list-name";
+/// # cache_client.list_concatenate_front(&cache_name, list_name, vec!["value1", "value2"]).await;
+///
+/// let fetch_request = ListFetchRequest::new(cache_name, list_name).start_index(1).end_index(3);
+/// let fetched_values: Vec<String> = cache_client.send_request(fetch_request).await?.try_into().expect("Expected a list fetch!");
+/// # Ok(())
+/// # })
+/// # }
+/// ```
+pub struct ListFetchRequest<K: IntoBytes> {
+    cache_name: String,
+    list_name: K,
+    start_index: Option<i32>,
+    end_index: Option<i32>,
+}
+
+impl<K: IntoBytes> ListFetchRequest<K> {
+    pub fn new(cache_name: impl Into<String>, list_name: K) -> Self {
+        Self {
+            cache_name: cache_name.into(),
+            list_name,
+            start_index: None,
+            end_index: None,
+        }
+    }
+
+    /// Set the starting inclusive element of the list to fetch.
+    pub fn start_index(mut self, start_index: i32) -> Self {
+        self.start_index = Some(start_index);
+        self
+    }
+
+    /// Set the ending exclusive element of the list to fetch.
+    pub fn end_index(mut self, end_index: i32) -> Self {
+        self.end_index = Some(end_index);
+        self
+    }
+}
+
+impl<K: IntoBytes> MomentoRequest for ListFetchRequest<K> {
+    type Response = ListFetch;
+
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListFetch> {
+        let start_index = match self.start_index {
+            Some(start) => Some(StartIndex::InclusiveStart(start)),
+            None => Some(StartIndex::UnboundedStart(Unbounded {})),
+        };
+        let end_index = match self.end_index {
+            Some(end) => Some(EndIndex::ExclusiveEnd(end)),
+            None => Some(EndIndex::UnboundedEnd(Unbounded {})),
+        };
+        let request = prep_request_with_timeout(
+            &self.cache_name,
+            cache_client.configuration.deadline_millis(),
+            momento_protos::cache_client::ListFetchRequest {
+                list_name: self.list_name.into_bytes(),
+                start_index,
+                end_index,
+            },
+        )?;
+
+        let response = cache_client
+            .data_client
+            .clone()
+            .list_fetch(request)
+            .await?
+            .into_inner();
+
+        match response.list {
+            Some(list_fetch_response::List::Missing(_)) => Ok(ListFetch::Miss),
+            Some(list_fetch_response::List::Found(found)) => Ok(ListFetch::Hit {
+                values: found.values,
+            }),
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// Response for a list fetch operation.
+///
+/// If you'd like to handle misses you can simply match and handle your response:
+/// ```
+/// # use momento::MomentoResult;
+/// # use momento::cache::ListFetch;
+/// use std::convert::TryInto;
+/// # let values = vec!["abc", "123"].iter().map(|s| s.as_bytes().to_vec()).collect();
+/// # let response = ListFetch::Hit { values: values };
+/// let fetched_values: Vec<String> = match response {
+///     ListFetch::Hit { values } => values.into_iter().map(|v| String::from_utf8(v).unwrap()).collect(),
+///     ListFetch::Miss => return // probably you'll do something else here
+/// };
+/// ```
+///
+/// You can cast your result directly into a Result<Vec<String>, MomentoError> suitable for
+/// ?-propagation if you know you are expecting a ListFetch::Hit.
+///
+/// Of course, a Miss in this case will be turned into an Error. If that's what you want, then
+/// this is what you're after:
+/// ```
+/// # use momento::MomentoResult;
+/// # use momento::cache::ListFetch;
+/// use std::convert::TryInto;
+/// # let values = vec!["abc", "123"].iter().map(|s| s.as_bytes().to_vec()).collect();
+/// # let response = ListFetch::Hit { values: values };
+/// let fetched_values: Vec<String> = response.try_into().expect("Expected to fetch a list of strings!");
+/// ```
+#[derive(Debug, PartialEq, Eq)]
+pub enum ListFetch {
+    Hit { values: Vec<Vec<u8>> },
+    Miss,
+}
+
+impl TryFrom<ListFetch> for Vec<Vec<u8>> {
+    type Error = MomentoError;
+
+    fn try_from(value: ListFetch) -> Result<Self, Self::Error> {
+        match value {
+            ListFetch::Hit { values } => Ok(values),
+            ListFetch::Miss => Err(MomentoError {
+                message: "list fetch response was a miss".into(),
+                error_code: MomentoErrorCode::Miss,
+                inner_error: None,
+                details: None,
+            }),
+        }
+    }
+}
+
+impl TryFrom<ListFetch> for Vec<String> {
+    type Error = MomentoError;
+
+    fn try_from(value: ListFetch) -> Result<Self, Self::Error> {
+        match value {
+            ListFetch::Hit { values } => Ok(values.into_iter().map(|v| String::from_utf8(v).unwrap()).collect()),
+            ListFetch::Miss => Err(MomentoError {
+                message: "sorted set was not found".into(),
+                error_code: MomentoErrorCode::Miss,
+                inner_error: None,
+                details: None,
+            }),
+        }
+    }
+}

--- a/src/cache/requests/list/list_fetch.rs
+++ b/src/cache/requests/list/list_fetch.rs
@@ -127,7 +127,7 @@ impl<L: IntoBytes> MomentoRequest for ListFetchRequest<L> {
 /// };
 /// ```
 ///
-/// You can cast your result directly into a Result<Vec<String>, MomentoError> suitable for
+/// You can cast your result directly into a `Result<Vec<String>, MomentoError>` suitable for
 /// ?-propagation if you know you are expecting a ListFetch::Hit.
 ///
 /// Of course, a Miss in this case will be turned into an Error. If that's what you want, then

--- a/src/cache/requests/list/list_fetch.rs
+++ b/src/cache/requests/list/list_fetch.rs
@@ -23,7 +23,7 @@ use crate::{
 /// # Optional Arguments
 ///
 /// * `start_index` - The starting inclusive element of the list to fetch. Default is 0.
-/// * `end_index` - The ending exclusive element of the list to fetch. Default is end of list.
+/// * `end_index` - The ending exclusive element of the list to fetch. Default is up to and including end of list.
 ///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.

--- a/src/cache/requests/list/list_fetch.rs
+++ b/src/cache/requests/list/list_fetch.rs
@@ -110,7 +110,12 @@ impl<L: IntoBytes> MomentoRequest for ListFetchRequest<L> {
                     raw_item: found.values,
                 },
             }),
-            _ => unreachable!(),
+            _ => Err(MomentoError {
+                message: "Unknown error has occurred, unable to parse list_fetch_response".into(),
+                error_code: MomentoErrorCode::UnknownError,
+                inner_error: None,
+                details: None,
+            }),
         }
     }
 }

--- a/src/cache/requests/list/list_fetch.rs
+++ b/src/cache/requests/list/list_fetch.rs
@@ -43,15 +43,15 @@ use crate::{
 /// # })
 /// # }
 /// ```
-pub struct ListFetchRequest<K: IntoBytes> {
+pub struct ListFetchRequest<L: IntoBytes> {
     cache_name: String,
-    list_name: K,
+    list_name: L,
     start_index: Option<i32>,
     end_index: Option<i32>,
 }
 
-impl<K: IntoBytes> ListFetchRequest<K> {
-    pub fn new(cache_name: impl Into<String>, list_name: K) -> Self {
+impl<L: IntoBytes> ListFetchRequest<L> {
+    pub fn new(cache_name: impl Into<String>, list_name: L) -> Self {
         Self {
             cache_name: cache_name.into(),
             list_name,
@@ -73,7 +73,7 @@ impl<K: IntoBytes> ListFetchRequest<K> {
     }
 }
 
-impl<K: IntoBytes> MomentoRequest for ListFetchRequest<K> {
+impl<L: IntoBytes> MomentoRequest for ListFetchRequest<L> {
     type Response = ListFetch;
 
     async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListFetch> {

--- a/src/cache/requests/list/list_length.rs
+++ b/src/cache/requests/list/list_length.rs
@@ -70,7 +70,12 @@ impl<L: IntoBytes> MomentoRequest for ListLengthRequest<L> {
             Some(list_length_response::List::Found(found)) => Ok(ListLength::Hit {
                 length: found.length,
             }),
-            _ => unreachable!(),
+            _ => Err(MomentoError {
+                message: "Unknown error has occurred, unable to parse list_fetch_response".into(),
+                error_code: MomentoErrorCode::UnknownError,
+                inner_error: None,
+                details: None,
+            }),
         }
     }
 }

--- a/src/cache/requests/list/list_length.rs
+++ b/src/cache/requests/list/list_length.rs
@@ -32,13 +32,13 @@ use crate::{
 /// # })
 /// # }
 /// ```
-pub struct ListLengthRequest<K: IntoBytes> {
+pub struct ListLengthRequest<L: IntoBytes> {
     cache_name: String,
-    list_name: K,
+    list_name: L,
 }
 
-impl<K: IntoBytes> ListLengthRequest<K> {
-    pub fn new(cache_name: impl Into<String>, list_name: K) -> Self {
+impl<L: IntoBytes> ListLengthRequest<L> {
+    pub fn new(cache_name: impl Into<String>, list_name: L) -> Self {
         Self {
             cache_name: cache_name.into(),
             list_name,
@@ -46,7 +46,7 @@ impl<K: IntoBytes> ListLengthRequest<K> {
     }
 }
 
-impl<K: IntoBytes> MomentoRequest for ListLengthRequest<K> {
+impl<L: IntoBytes> MomentoRequest for ListLengthRequest<L> {
     type Response = ListLength;
 
     async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListLength> {

--- a/src/cache/requests/list/list_length.rs
+++ b/src/cache/requests/list/list_length.rs
@@ -80,7 +80,7 @@ impl<L: IntoBytes> MomentoRequest for ListLengthRequest<L> {
 /// If you'd like to handle misses you can simply match and handle your response:
 /// ```
 /// # use momento::MomentoResult;
-/// # use momento::cache::ListLength;
+/// use momento::cache::ListLength;
 /// use std::convert::TryInto;
 /// # let response = ListLength::Hit { length: 5 };
 /// let length: u32 = match response {
@@ -96,7 +96,7 @@ impl<L: IntoBytes> MomentoRequest for ListLengthRequest<L> {
 /// this is what you're after:
 /// ```
 /// # use momento::MomentoResult;
-/// # use momento::cache::ListLength;
+/// use momento::cache::ListLength;
 /// use std::convert::TryInto;
 /// # let response = ListLength::Hit { length: 5 };
 /// let length: MomentoResult<u32> = response.try_into();

--- a/src/cache/requests/list/list_length.rs
+++ b/src/cache/requests/list/list_length.rs
@@ -1,0 +1,72 @@
+use std::convert::TryFrom;
+
+use momento_protos::cache_client::list_length_response;
+
+use crate::{cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult};
+
+/// TODO
+pub struct ListLengthRequest<K: IntoBytes> {
+  cache_name: String,
+  list_name: K,
+}
+
+impl<K: IntoBytes> ListLengthRequest<K> {
+  pub fn new(cache_name: impl Into<String>, list_name: K) -> Self {
+      Self {
+          cache_name: cache_name.into(),
+          list_name,
+      }
+  }
+}
+
+impl<K: IntoBytes> MomentoRequest for ListLengthRequest<K> {
+  type Response = ListLength;
+
+  async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListLength> {
+      let request = prep_request_with_timeout(
+          &self.cache_name,
+          cache_client.configuration.deadline_millis(),
+          momento_protos::cache_client::ListLengthRequest {
+              list_name: self.list_name.into_bytes(),
+          },
+      )?;
+
+      let response = cache_client
+          .data_client
+          .clone()
+          .list_length(request)
+          .await?
+          .into_inner();
+
+      match response.list {
+          Some(list_length_response::List::Missing(_)) => Ok(ListLength::Miss),
+          Some(list_length_response::List::Found(found)) => Ok(ListLength::Hit {
+              length: found.length,
+          }),
+          _ => unreachable!(),
+      }
+  }
+}
+
+/// TODO
+#[derive(Debug, PartialEq, Eq)]
+pub enum ListLength {
+    Hit { length: u32 },
+    Miss,
+}
+
+impl TryFrom<ListLength> for u32 {
+  type Error = MomentoError;
+
+  fn try_from(value: ListLength) -> Result<Self, Self::Error> {
+      match value {
+        ListLength::Hit { length } => Ok(length),
+        ListLength::Miss => Err(MomentoError {
+              message: "list length response was a miss".into(),
+              error_code: MomentoErrorCode::Miss,
+              inner_error: None,
+              details: None,
+          }),
+      }
+  }
+}

--- a/src/cache/requests/list/list_length.rs
+++ b/src/cache/requests/list/list_length.rs
@@ -2,53 +2,105 @@ use std::convert::TryFrom;
 
 use momento_protos::cache_client::list_length_response;
 
-use crate::{cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult};
+use crate::{
+    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoError,
+    MomentoErrorCode, MomentoResult,
+};
 
-/// TODO
+/// Gets the number of elements in the given list.
+///
+/// # Arguments
+/// * `cache_name` - name of cache
+/// * `list_name` - name of the list
+///
+/// # Examples
+/// Assumes that a CacheClient named `cache_client` has been created and is available.
+/// ```
+/// # fn main() -> anyhow::Result<()> {
+/// # use momento_test_util::create_doctest_cache_client;
+/// # tokio_test::block_on(async {
+/// use std::convert::TryInto;
+/// use momento::cache::{ListLength, ListLengthRequest};
+/// use momento::MomentoErrorCode;
+/// # let (cache_client, cache_name) = create_doctest_cache_client();
+/// let list_name = "list-name";
+/// # cache_client.list_concatenate_front(&cache_name, list_name, vec!["value1", "value2"]).await;
+///
+/// let length_request = ListLengthRequest::new(cache_name, list_name);
+/// let length: u32 = cache_client.send_request(length_request).await?.try_into().expect("Expected a list length!");
+/// # Ok(())
+/// # })
+/// # }
+/// ```
 pub struct ListLengthRequest<K: IntoBytes> {
-  cache_name: String,
-  list_name: K,
+    cache_name: String,
+    list_name: K,
 }
 
 impl<K: IntoBytes> ListLengthRequest<K> {
-  pub fn new(cache_name: impl Into<String>, list_name: K) -> Self {
-      Self {
-          cache_name: cache_name.into(),
-          list_name,
-      }
-  }
+    pub fn new(cache_name: impl Into<String>, list_name: K) -> Self {
+        Self {
+            cache_name: cache_name.into(),
+            list_name,
+        }
+    }
 }
 
 impl<K: IntoBytes> MomentoRequest for ListLengthRequest<K> {
-  type Response = ListLength;
+    type Response = ListLength;
 
-  async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListLength> {
-      let request = prep_request_with_timeout(
-          &self.cache_name,
-          cache_client.configuration.deadline_millis(),
-          momento_protos::cache_client::ListLengthRequest {
-              list_name: self.list_name.into_bytes(),
-          },
-      )?;
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListLength> {
+        let request = prep_request_with_timeout(
+            &self.cache_name,
+            cache_client.configuration.deadline_millis(),
+            momento_protos::cache_client::ListLengthRequest {
+                list_name: self.list_name.into_bytes(),
+            },
+        )?;
 
-      let response = cache_client
-          .data_client
-          .clone()
-          .list_length(request)
-          .await?
-          .into_inner();
+        let response = cache_client
+            .data_client
+            .clone()
+            .list_length(request)
+            .await?
+            .into_inner();
 
-      match response.list {
-          Some(list_length_response::List::Missing(_)) => Ok(ListLength::Miss),
-          Some(list_length_response::List::Found(found)) => Ok(ListLength::Hit {
-              length: found.length,
-          }),
-          _ => unreachable!(),
-      }
-  }
+        match response.list {
+            Some(list_length_response::List::Missing(_)) => Ok(ListLength::Miss),
+            Some(list_length_response::List::Found(found)) => Ok(ListLength::Hit {
+                length: found.length,
+            }),
+            _ => unreachable!(),
+        }
+    }
 }
 
-/// TODO
+/// Response for a list length operation.
+///
+/// If you'd like to handle misses you can simply match and handle your response:
+/// ```
+/// # use momento::MomentoResult;
+/// # use momento::cache::ListLength;
+/// use std::convert::TryInto;
+/// # let response = ListLength::Hit { length: 5 };
+/// let length: u32 = match response {
+///     ListLength::Hit { length } => length.try_into().expect("Expected a list length!"),
+///     ListLength::Miss => return // probably you'll do something else here
+/// };
+/// ```
+///
+/// You can cast your result directly into a Result<u32, MomentoError> suitable for
+/// ?-propagation if you know you are expecting a ListLength::Hit.
+///
+/// Of course, a Miss in this case will be turned into an Error. If that's what you want, then
+/// this is what you're after:
+/// ```
+/// # use momento::MomentoResult;
+/// # use momento::cache::ListLength;
+/// use std::convert::TryInto;
+/// # let response = ListLength::Hit { length: 5 };
+/// let length: MomentoResult<u32> = response.try_into();
+/// ```
 #[derive(Debug, PartialEq, Eq)]
 pub enum ListLength {
     Hit { length: u32 },
@@ -56,17 +108,17 @@ pub enum ListLength {
 }
 
 impl TryFrom<ListLength> for u32 {
-  type Error = MomentoError;
+    type Error = MomentoError;
 
-  fn try_from(value: ListLength) -> Result<Self, Self::Error> {
-      match value {
-        ListLength::Hit { length } => Ok(length),
-        ListLength::Miss => Err(MomentoError {
-              message: "list length response was a miss".into(),
-              error_code: MomentoErrorCode::Miss,
-              inner_error: None,
-              details: None,
-          }),
-      }
-  }
+    fn try_from(value: ListLength) -> Result<Self, Self::Error> {
+        match value {
+            ListLength::Hit { length } => Ok(length),
+            ListLength::Miss => Err(MomentoError {
+                message: "list length response was a miss".into(),
+                error_code: MomentoErrorCode::Miss,
+                inner_error: None,
+                details: None,
+            }),
+        }
+    }
 }

--- a/src/cache/requests/list/list_pop_back.rs
+++ b/src/cache/requests/list/list_pop_back.rs
@@ -1,0 +1,142 @@
+use std::convert::TryFrom;
+
+use momento_protos::cache_client::list_pop_back_response;
+
+use crate::{
+    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoError,
+    MomentoErrorCode, MomentoResult,
+};
+
+/// Remove and return the last element from a list item.
+///
+/// # Arguments
+/// * `cache_name` - name of cache
+/// * `list_name` - name of the list
+///
+/// # Examples
+/// Assumes that a CacheClient named `cache_client` has been created and is available.
+/// ```
+/// # fn main() -> anyhow::Result<()> {
+/// # use momento_test_util::create_doctest_cache_client;
+/// # tokio_test::block_on(async {
+/// use std::convert::TryInto;
+/// use momento::cache::{ListPopBack, ListPopBackRequest};
+/// use momento::MomentoErrorCode;
+/// # let (cache_client, cache_name) = create_doctest_cache_client();
+/// let list_name = "list-name";
+/// # cache_client.list_concatenate_front(&cache_name, list_name, vec!["value1", "value2"]).await;
+///
+/// let pop_back_request = ListPopBackRequest::new(cache_name, list_name);
+/// let popped_value: String = cache_client.send_request(pop_back_request).await?.try_into().expect("Expected a popped list value!");
+/// # Ok(())
+/// # })
+/// # }
+/// ```
+pub struct ListPopBackRequest<L: IntoBytes> {
+    cache_name: String,
+    list_name: L,
+}
+
+impl<L: IntoBytes> ListPopBackRequest<L> {
+    pub fn new(cache_name: impl Into<String>, list_name: L) -> Self {
+        Self {
+            cache_name: cache_name.into(),
+            list_name,
+        }
+    }
+}
+
+impl<L: IntoBytes> MomentoRequest for ListPopBackRequest<L> {
+    type Response = ListPopBack;
+
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListPopBack> {
+        let request = prep_request_with_timeout(
+            &self.cache_name,
+            cache_client.configuration.deadline_millis(),
+            momento_protos::cache_client::ListPopBackRequest {
+                list_name: self.list_name.into_bytes(),
+            },
+        )?;
+
+        let response = cache_client
+            .data_client
+            .clone()
+            .list_pop_back(request)
+            .await?
+            .into_inner();
+
+        match response.list {
+            Some(list_pop_back_response::List::Missing(_)) => Ok(ListPopBack::Miss),
+            Some(list_pop_back_response::List::Found(found)) => {
+                Ok(ListPopBack::Hit { value: found.back })
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// Response for a list pop back operation.
+///
+/// If you'd like to handle misses you can simply match and handle your response:
+/// ```
+/// # use momento::MomentoResult;
+/// # use momento::cache::ListPopBack;
+/// use std::convert::TryInto;
+/// # let response = ListPopBack::Hit { value: "hi".into() };
+/// let popped_value: String = match response {
+///     ListPopBack::Hit { value } => String::from_utf8(value).expect("Expected a valid UTF-8 string"),
+///     ListPopBack::Miss => return // probably you'll do something else here
+/// };
+/// ```
+///
+/// You can cast your result directly into a Result<u32, MomentoError> suitable for
+/// ?-propagation if you know you are expecting a ListPopBack::Hit.
+///
+/// Of course, a Miss in this case will be turned into an Error. If that's what you want, then
+/// this is what you're after:
+/// ```
+/// # use momento::MomentoResult;
+/// # use momento::cache::ListPopBack;
+/// use std::convert::TryInto;
+/// # let response = ListPopBack::Hit { value: "hi".into() };
+/// let popped_value: MomentoResult<String> = response.try_into();
+/// ```
+#[derive(Debug, PartialEq, Eq)]
+pub enum ListPopBack {
+    Hit { value: Vec<u8> },
+    Miss,
+}
+
+impl TryFrom<ListPopBack> for Vec<u8> {
+    type Error = MomentoError;
+
+    fn try_from(value: ListPopBack) -> Result<Self, Self::Error> {
+        match value {
+            ListPopBack::Hit { value } => Ok(value),
+            ListPopBack::Miss => Err(MomentoError {
+                message: "list length response was a miss".into(),
+                error_code: MomentoErrorCode::Miss,
+                inner_error: None,
+                details: None,
+            }),
+        }
+    }
+}
+
+impl TryFrom<ListPopBack> for String {
+    type Error = MomentoError;
+
+    fn try_from(value: ListPopBack) -> Result<Self, Self::Error> {
+        match value {
+            ListPopBack::Hit { value } => {
+                Ok(String::from_utf8(value).expect("Expected a valid UTF-8 string"))
+            }
+            ListPopBack::Miss => Err(MomentoError {
+                message: "list length response was a miss".into(),
+                error_code: MomentoErrorCode::Miss,
+                inner_error: None,
+                details: None,
+            }),
+        }
+    }
+}

--- a/src/cache/requests/list/list_pop_back.rs
+++ b/src/cache/requests/list/list_pop_back.rs
@@ -71,7 +71,12 @@ impl<L: IntoBytes> MomentoRequest for ListPopBackRequest<L> {
             Some(list_pop_back_response::List::Found(found)) => Ok(ListPopBack::Hit {
                 value: ListPopBackValue::new(found.back),
             }),
-            _ => unreachable!(),
+            _ => Err(MomentoError {
+                message: "Unknown error has occurred, unable to parse list_fetch_response".into(),
+                error_code: MomentoErrorCode::UnknownError,
+                inner_error: None,
+                details: None,
+            }),
         }
     }
 }

--- a/src/cache/requests/list/list_pop_front.rs
+++ b/src/cache/requests/list/list_pop_front.rs
@@ -71,7 +71,12 @@ impl<L: IntoBytes> MomentoRequest for ListPopFrontRequest<L> {
             Some(list_pop_front_response::List::Found(found)) => Ok(ListPopFront::Hit {
                 value: ListPopFrontValue::new(found.front),
             }),
-            _ => unreachable!(),
+            _ => Err(MomentoError {
+                message: "Unknown error has occurred, unable to parse list_fetch_response".into(),
+                error_code: MomentoErrorCode::UnknownError,
+                inner_error: None,
+                details: None,
+            }),
         }
     }
 }

--- a/src/cache/requests/list/list_pop_front.rs
+++ b/src/cache/requests/list/list_pop_front.rs
@@ -1,0 +1,142 @@
+use std::convert::TryFrom;
+
+use momento_protos::cache_client::list_pop_front_response;
+
+use crate::{
+    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoError,
+    MomentoErrorCode, MomentoResult,
+};
+
+/// Remove and return the first element from a list item.
+///
+/// # Arguments
+/// * `cache_name` - name of cache
+/// * `list_name` - name of the list
+///
+/// # Examples
+/// Assumes that a CacheClient named `cache_client` has been created and is available.
+/// ```
+/// # fn main() -> anyhow::Result<()> {
+/// # use momento_test_util::create_doctest_cache_client;
+/// # tokio_test::block_on(async {
+/// use std::convert::TryInto;
+/// use momento::cache::{ListPopFront, ListPopFrontRequest};
+/// use momento::MomentoErrorCode;
+/// # let (cache_client, cache_name) = create_doctest_cache_client();
+/// let list_name = "list-name";
+/// # cache_client.list_concatenate_front(&cache_name, list_name, vec!["value1", "value2"]).await;
+///
+/// let pop_front_request = ListPopFrontRequest::new(cache_name, list_name);
+/// let popped_value: String = cache_client.send_request(pop_front_request).await?.try_into().expect("Expected a popped list value!");
+/// # Ok(())
+/// # })
+/// # }
+/// ```
+pub struct ListPopFrontRequest<L: IntoBytes> {
+    cache_name: String,
+    list_name: L,
+}
+
+impl<L: IntoBytes> ListPopFrontRequest<L> {
+    pub fn new(cache_name: impl Into<String>, list_name: L) -> Self {
+        Self {
+            cache_name: cache_name.into(),
+            list_name,
+        }
+    }
+}
+
+impl<L: IntoBytes> MomentoRequest for ListPopFrontRequest<L> {
+    type Response = ListPopFront;
+
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListPopFront> {
+        let request = prep_request_with_timeout(
+            &self.cache_name,
+            cache_client.configuration.deadline_millis(),
+            momento_protos::cache_client::ListPopFrontRequest {
+                list_name: self.list_name.into_bytes(),
+            },
+        )?;
+
+        let response = cache_client
+            .data_client
+            .clone()
+            .list_pop_front(request)
+            .await?
+            .into_inner();
+
+        match response.list {
+            Some(list_pop_front_response::List::Missing(_)) => Ok(ListPopFront::Miss),
+            Some(list_pop_front_response::List::Found(found)) => {
+                Ok(ListPopFront::Hit { value: found.front })
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// Response for a list pop front operation.
+///
+/// If you'd like to handle misses you can simply match and handle your response:
+/// ```
+/// # use momento::MomentoResult;
+/// # use momento::cache::ListPopFront;
+/// use std::convert::TryInto;
+/// # let response = ListPopFront::Hit { value: "hi".into() };
+/// let popped_value: String = match response {
+///     ListPopFront::Hit { value } => String::from_utf8(value).expect("Expected a valid UTF-8 string"),
+///     ListPopFront::Miss => return // probably you'll do something else here
+/// };
+/// ```
+///
+/// You can cast your result directly into a Result<u32, MomentoError> suitable for
+/// ?-propagation if you know you are expecting a ListPopFront::Hit.
+///
+/// Of course, a Miss in this case will be turned into an Error. If that's what you want, then
+/// this is what you're after:
+/// ```
+/// # use momento::MomentoResult;
+/// # use momento::cache::ListPopFront;
+/// use std::convert::TryInto;
+/// # let response = ListPopFront::Hit { value: "hi".into() };
+/// let popped_value: MomentoResult<String> = response.try_into();
+/// ```
+#[derive(Debug, PartialEq, Eq)]
+pub enum ListPopFront {
+    Hit { value: Vec<u8> },
+    Miss,
+}
+
+impl TryFrom<ListPopFront> for Vec<u8> {
+    type Error = MomentoError;
+
+    fn try_from(value: ListPopFront) -> Result<Self, Self::Error> {
+        match value {
+            ListPopFront::Hit { value } => Ok(value),
+            ListPopFront::Miss => Err(MomentoError {
+                message: "list length response was a miss".into(),
+                error_code: MomentoErrorCode::Miss,
+                inner_error: None,
+                details: None,
+            }),
+        }
+    }
+}
+
+impl TryFrom<ListPopFront> for String {
+    type Error = MomentoError;
+
+    fn try_from(value: ListPopFront) -> Result<Self, Self::Error> {
+        match value {
+            ListPopFront::Hit { value } => {
+                Ok(String::from_utf8(value).expect("Expected a valid UTF-8 string"))
+            }
+            ListPopFront::Miss => Err(MomentoError {
+                message: "list length response was a miss".into(),
+                error_code: MomentoErrorCode::Miss,
+                inner_error: None,
+                details: None,
+            }),
+        }
+    }
+}

--- a/src/cache/requests/list/list_remove_value.rs
+++ b/src/cache/requests/list/list_remove_value.rs
@@ -1,0 +1,75 @@
+use momento_protos::cache_client::list_remove_request::Remove;
+
+use crate::{
+    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoResult,
+};
+
+/// Remove all elements in a list item equal to a particular value.
+///
+/// # Arguments
+/// * `cache_name` - name of cache
+/// * `list_name` - name of the list
+/// * `value` - value to remove
+///
+/// # Examples
+/// Assumes that a CacheClient named `cache_client` has been created and is available.
+/// ```
+/// # fn main() -> anyhow::Result<()> {
+/// # use momento_test_util::create_doctest_cache_client;
+/// # tokio_test::block_on(async {
+/// use momento::cache::{ListRemoveValue, ListRemoveValueRequest};
+/// use momento::MomentoErrorCode;
+/// # let (cache_client, cache_name) = create_doctest_cache_client();
+/// let list_name = "list-name";
+/// # cache_client.list_concatenate_front(&cache_name, list_name, vec!["value1", "value2"]).await;
+///
+/// let remove_request = ListRemoveValueRequest::new(cache_name, list_name, "value1");
+/// match cache_client.send_request(remove_request).await {
+///     Ok(ListRemoveValue {}) => println!("Successfully removed value"),
+///     Err(e) => eprintln!("Error removing value: {:?}", e),
+/// }
+/// # Ok(())
+/// # })
+/// # }
+/// ```
+pub struct ListRemoveValueRequest<L: IntoBytes, V: IntoBytes> {
+    cache_name: String,
+    list_name: L,
+    value: V,
+}
+
+impl<L: IntoBytes, V: IntoBytes> ListRemoveValueRequest<L, V> {
+    pub fn new(cache_name: impl Into<String>, list_name: L, value: V) -> Self {
+        Self {
+            cache_name: cache_name.into(),
+            list_name,
+            value,
+        }
+    }
+}
+
+impl<L: IntoBytes, V: IntoBytes> MomentoRequest for ListRemoveValueRequest<L, V> {
+    type Response = ListRemoveValue;
+
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListRemoveValue> {
+        let request = prep_request_with_timeout(
+            &self.cache_name,
+            cache_client.configuration.deadline_millis(),
+            momento_protos::cache_client::ListRemoveRequest {
+                list_name: self.list_name.into_bytes(),
+                remove: Some(Remove::AllElementsWithValue(self.value.into_bytes())),
+            },
+        )?;
+
+        cache_client
+            .data_client
+            .clone()
+            .list_remove(request)
+            .await?
+            .into_inner();
+        Ok(ListRemoveValue {})
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ListRemoveValue {}

--- a/src/cache/requests/list/mod.rs
+++ b/src/cache/requests/list/mod.rs
@@ -2,3 +2,6 @@ pub mod list_concatenate_back;
 pub mod list_concatenate_front;
 pub mod list_fetch;
 pub mod list_length;
+pub mod list_pop_back;
+pub mod list_pop_front;
+pub mod list_remove_value;

--- a/src/cache/requests/list/mod.rs
+++ b/src/cache/requests/list/mod.rs
@@ -1,3 +1,4 @@
 pub mod list_concatenate_back;
 pub mod list_concatenate_front;
 pub mod list_length;
+pub mod list_fetch;

--- a/src/cache/requests/list/mod.rs
+++ b/src/cache/requests/list/mod.rs
@@ -1,0 +1,1 @@
+pub mod list_length;

--- a/src/cache/requests/list/mod.rs
+++ b/src/cache/requests/list/mod.rs
@@ -1,1 +1,3 @@
+pub mod list_concatenate_back;
+pub mod list_concatenate_front;
 pub mod list_length;

--- a/src/cache/requests/list/mod.rs
+++ b/src/cache/requests/list/mod.rs
@@ -1,4 +1,4 @@
 pub mod list_concatenate_back;
 pub mod list_concatenate_front;
-pub mod list_length;
 pub mod list_fetch;
+pub mod list_length;

--- a/src/cache/requests/mod.rs
+++ b/src/cache/requests/mod.rs
@@ -3,6 +3,7 @@ pub mod delete_cache;
 pub mod flush_cache;
 pub mod list_caches;
 
+pub mod list;
 pub mod scalar;
 pub mod set;
 pub mod sorted_set;

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -7,7 +7,19 @@ use tonic::codegen::InterceptedService;
 use tonic::transport::Channel;
 
 use crate::cache::{
-    Configuration, CreateCache, CreateCacheRequest, DecreaseTtl, DecreaseTtlRequest, Delete, DeleteCache, DeleteCacheRequest, DeleteRequest, FlushCache, FlushCacheRequest, Get, GetRequest, IncreaseTtl, IncreaseTtlRequest, Increment, IncrementRequest, IntoSortedSetElements, ItemGetTtl, ItemGetTtlRequest, ItemGetType, ItemGetTypeRequest, KeyExists, KeyExistsRequest, KeysExist, KeysExistRequest, ListCaches, ListCachesRequest, ListConcatenateBack, ListConcatenateBackRequest, ListConcatenateFront, ListConcatenateFrontRequest, ListFetch, ListFetchRequest, ListLength, ListLengthRequest, MomentoRequest, Set, SetAddElements, SetAddElementsRequest, SetIfAbsent, SetIfAbsentOrEqual, SetIfAbsentOrEqualRequest, SetIfAbsentRequest, SetIfEqual, SetIfEqualRequest, SetIfNotEqual, SetIfNotEqualRequest, SetIfPresent, SetIfPresentAndNotEqual, SetIfPresentAndNotEqualRequest, SetIfPresentRequest, SetRequest, SortedSetFetch, SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest, SortedSetOrder, SortedSetPutElement, SortedSetPutElementRequest, SortedSetPutElements, SortedSetPutElementsRequest, UpdateTtl, UpdateTtlRequest
+    Configuration, CreateCache, CreateCacheRequest, DecreaseTtl, DecreaseTtlRequest, Delete,
+    DeleteCache, DeleteCacheRequest, DeleteRequest, FlushCache, FlushCacheRequest, Get, GetRequest,
+    IncreaseTtl, IncreaseTtlRequest, Increment, IncrementRequest, IntoSortedSetElements,
+    ItemGetTtl, ItemGetTtlRequest, ItemGetType, ItemGetTypeRequest, KeyExists, KeyExistsRequest,
+    KeysExist, KeysExistRequest, ListCaches, ListCachesRequest, ListConcatenateBack,
+    ListConcatenateBackRequest, ListConcatenateFront, ListConcatenateFrontRequest, ListFetch,
+    ListFetchRequest, ListLength, ListLengthRequest, MomentoRequest, Set, SetAddElements,
+    SetAddElementsRequest, SetIfAbsent, SetIfAbsentOrEqual, SetIfAbsentOrEqualRequest,
+    SetIfAbsentRequest, SetIfEqual, SetIfEqualRequest, SetIfNotEqual, SetIfNotEqualRequest,
+    SetIfPresent, SetIfPresentAndNotEqual, SetIfPresentAndNotEqualRequest, SetIfPresentRequest,
+    SetRequest, SortedSetFetch, SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest,
+    SortedSetOrder, SortedSetPutElement, SortedSetPutElementRequest, SortedSetPutElements,
+    SortedSetPutElementsRequest, UpdateTtl, UpdateTtlRequest,
 };
 use crate::grpc::header_interceptor::HeaderInterceptor;
 
@@ -1328,7 +1340,7 @@ impl CacheClient {
     }
 
     /// Gets a list item from a cache with optional slices.
-    /// 
+    ///
     /// # Arguments
     /// * `cache_name` - name of cache
     /// * `list_name` - name of the list
@@ -1339,7 +1351,7 @@ impl CacheClient {
     ///
     /// * `start_index` - The starting inclusive element of the list to fetch. Default is 0.
     /// * `end_index` - The ending exclusive element of the list to fetch. Default is end of list.
-    /// 
+    ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
     /// ```

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -4,7 +4,8 @@ mod test_utils;
 
 pub use crate::cache_test_state::CACHE_TEST_STATE;
 pub use crate::test_data::{
-    unique_cache_name, unique_key, unique_string, unique_value, TestScalar, TestSet, TestSortedSet,
+    unique_cache_name, unique_key, unique_string, unique_value, TestList, TestScalar, TestSet,
+    TestSortedSet,
 };
 pub use crate::test_utils::{
     create_doctest_cache_client, doctest, get_test_cache_name, get_test_credential_provider,

--- a/test-util/src/test_data.rs
+++ b/test-util/src/test_data.rs
@@ -1,5 +1,5 @@
 use momento::{
-    cache::{Get, GetValue, ListFetch, SortedSetElements, SortedSetFetch},
+    cache::{Get, GetValue, ListFetch, ListFetchValue, SortedSetElements, SortedSetFetch},
     IntoBytes,
 };
 use uuid::Uuid;
@@ -161,11 +161,13 @@ impl Default for TestList {
 impl From<&TestList> for ListFetch {
     fn from(test_list: &TestList) -> Self {
         ListFetch::Hit {
-            values: test_list
-                .values()
-                .iter()
-                .map(|v| v.as_bytes().to_vec())
-                .collect(),
+            values: ListFetchValue::new(
+                test_list
+                    .values()
+                    .iter()
+                    .map(|v| v.as_bytes().to_vec())
+                    .collect(),
+            ),
         }
     }
 }

--- a/test-util/src/test_data.rs
+++ b/test-util/src/test_data.rs
@@ -1,5 +1,5 @@
 use momento::{
-    cache::{Get, GetValue, SortedSetElements, SortedSetFetch},
+    cache::{Get, GetValue, ListFetch, SortedSetElements, SortedSetFetch},
     IntoBytes,
 };
 use uuid::Uuid;
@@ -125,6 +125,47 @@ impl From<&TestSortedSet> for SortedSetFetch {
                     .map(|(element, score)| (element.as_bytes().to_vec(), *score))
                     .collect(),
             ),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct TestList {
+    pub name: String,
+    pub values: Vec<String>,
+}
+
+impl TestList {
+    pub fn new() -> Self {
+        Self {
+            name: unique_key(),
+            values: vec![unique_value(), unique_value()],
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn values(&self) -> &Vec<String> {
+        &self.values
+    }
+}
+
+impl Default for TestList {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<&TestList> for ListFetch {
+    fn from(test_list: &TestList) -> Self {
+        ListFetch::Hit {
+            values: test_list
+                .values()
+                .iter()
+                .map(|v| v.as_bytes().to_vec())
+                .collect(),
         }
     }
 }

--- a/tests/cache/list.rs
+++ b/tests/cache/list.rs
@@ -1,11 +1,12 @@
 use momento::cache::{
     CollectionTtl, ListConcatenateBack, ListConcatenateBackRequest, ListConcatenateFront,
-    ListConcatenateFrontRequest, ListFetch, ListLength,
+    ListConcatenateFrontRequest, ListFetch, ListLength, ListPopBack, ListPopFront, ListRemoveValue,
 };
 use momento::{MomentoErrorCode, MomentoResult};
 
 use momento_test_util::{unique_cache_name, TestList, CACHE_TEST_STATE};
 
+use std::convert::TryInto;
 use std::time::Duration;
 
 fn assert_list_eq(list_fetch_result: ListFetch, expected: Vec<String>) -> MomentoResult<()> {
@@ -299,4 +300,203 @@ mod list_fetch {
     }
 }
 
+mod list_pop_back {
+    use std::convert::TryInto;
 
+    use super::*;
+
+    #[tokio::test]
+    async fn nonexistent_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_cache_name();
+
+        let result = client.list_pop_back(cache_name, "list").await.unwrap_err();
+
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn nonexistent_list() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let list_name = unique_cache_name();
+
+        let result = client.list_pop_back(cache_name, list_name).await?;
+
+        assert_eq!(result, ListPopBack::Miss {});
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn happy_path() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let test_list = TestList::default();
+
+        // Concatenates some values first
+        let result = client
+            .list_concatenate_back(cache_name, test_list.name(), test_list.values().to_vec())
+            .await?;
+        assert_eq!(result, ListConcatenateBack {});
+
+        // Pop first value from the back
+        let popped_first: String = client
+            .list_pop_back(cache_name, test_list.name())
+            .await?
+            .try_into()
+            .expect("Expected a popped list value!");
+        assert_eq!(popped_first, test_list.values().last().unwrap().to_string());
+
+        // Pop second value from the back
+        let popped_second: String = client
+            .list_pop_back(cache_name, test_list.name())
+            .await?
+            .try_into()
+            .expect("Expected a popped list value!");
+        assert_eq!(
+            popped_second,
+            test_list.values().first().unwrap().to_string()
+        );
+
+        Ok(())
+    }
+}
+
+mod list_pop_front {
+    use super::*;
+
+    #[tokio::test]
+    async fn nonexistent_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_cache_name();
+
+        let result = client.list_pop_front(cache_name, "list").await.unwrap_err();
+
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn nonexistent_list() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let list_name = unique_cache_name();
+
+        let result = client.list_pop_front(cache_name, list_name).await?;
+
+        assert_eq!(result, ListPopFront::Miss {});
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn happy_path() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let test_list = TestList::default();
+
+        // Concatenates some values first
+        let result = client
+            .list_concatenate_back(cache_name, test_list.name(), test_list.values().to_vec())
+            .await?;
+        assert_eq!(result, ListConcatenateBack {});
+
+        // Pop first value from the front
+        let popped_first: String = client
+            .list_pop_front(cache_name, test_list.name())
+            .await?
+            .try_into()
+            .expect("Expected a popped list value!");
+        assert_eq!(
+            popped_first,
+            test_list.values().first().unwrap().to_string()
+        );
+
+        // Pop second value from the front
+        let popped_second: String = client
+            .list_pop_front(cache_name, test_list.name())
+            .await?
+            .try_into()
+            .expect("Expected a popped list value!");
+        assert_eq!(
+            popped_second,
+            test_list.values().last().unwrap().to_string()
+        );
+
+        Ok(())
+    }
+}
+
+mod list_remove {
+    use super::*;
+
+    #[tokio::test]
+    async fn nonexistent_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_cache_name();
+
+        let result = client
+            .list_remove_value(cache_name, "list", "value")
+            .await
+            .unwrap_err();
+
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn nonexistent_list() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let list_name = unique_cache_name();
+
+        let result = client
+            .list_remove_value(cache_name, list_name, "value")
+            .await?;
+
+        assert_eq!(result, ListRemoveValue {});
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn happy_path() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let test_list = TestList::default();
+
+        // Concatenates some values first
+        let result = client
+            .list_concatenate_back(cache_name, test_list.name(), test_list.values().to_vec())
+            .await?;
+        assert_eq!(result, ListConcatenateBack {});
+
+        let first_value = test_list
+            .values()
+            .first()
+            .expect("Expected first value from TestList")
+            .to_string();
+        let second_value = test_list
+            .values()
+            .last()
+            .expect("Expected last value from TestList")
+            .to_string();
+
+        // Remove one of the values and only the other should remain
+        let result = client
+            .list_remove_value(cache_name, test_list.name(), first_value)
+            .await?;
+        assert_eq!(result, ListRemoveValue {});
+        assert_list_eq(
+            client.list_fetch(cache_name, test_list.name()).await?,
+            vec![second_value],
+        )?;
+
+        Ok(())
+    }
+}

--- a/tests/cache/list.rs
+++ b/tests/cache/list.rs
@@ -1,0 +1,302 @@
+use momento::cache::{
+    CollectionTtl, ListConcatenateBack, ListConcatenateBackRequest, ListConcatenateFront,
+    ListConcatenateFrontRequest, ListFetch, ListLength,
+};
+use momento::{MomentoErrorCode, MomentoResult};
+
+use momento_test_util::{unique_cache_name, TestList, CACHE_TEST_STATE};
+
+use std::time::Duration;
+
+fn assert_list_eq(list_fetch_result: ListFetch, expected: Vec<String>) -> MomentoResult<()> {
+    let expected: ListFetch = expected.into();
+    assert_eq!(
+        list_fetch_result, expected,
+        "Expected ListFetch::Hit to be equal to {:?}, but got {:?}",
+        expected, list_fetch_result
+    );
+    Ok(())
+}
+
+mod list_concatenate_back {
+    use super::*;
+
+    #[tokio::test]
+    async fn nonexistent_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_cache_name();
+
+        let result = client
+            .list_concatenate_back(cache_name, "list", vec!["value1", "value2"])
+            .await
+            .unwrap_err();
+
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn happy_path() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let test_list = TestList::default();
+
+        // Concatenates string values
+        let result = client
+            .list_concatenate_back(cache_name, test_list.name(), test_list.values().to_vec())
+            .await?;
+        assert_eq!(result, ListConcatenateBack {});
+        assert_list_eq(
+            client.list_fetch(cache_name, test_list.name()).await?,
+            test_list.values().to_vec(),
+        )?;
+
+        // Concatenates byte values
+        let result = client
+            .list_concatenate_back(
+                cache_name,
+                test_list.name(),
+                test_list.values().iter().map(|v| v.as_bytes()).collect(),
+            )
+            .await?;
+        assert_eq!(result, ListConcatenateBack {});
+        assert_list_eq(
+            client.list_fetch(cache_name, test_list.name()).await?,
+            [test_list.values().to_vec(), test_list.values().to_vec()].concat(),
+        )?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn happy_path_with_optional_arguments() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let test_list = TestList::default();
+
+        // Concatenates with truncation and collection ttl
+        let request = ListConcatenateBackRequest::new(
+            cache_name.to_string(),
+            test_list.name(),
+            [test_list.values().to_vec(), test_list.values().to_vec()].concat(),
+        )
+        .truncate_back_to_size(2)
+        .ttl(CollectionTtl::new(Some(Duration::from_secs(3)), false));
+        let result = client.send_request(request).await?;
+        assert_eq!(result, ListConcatenateBack {});
+
+        // Should have truncated to only 2 elements
+        assert_list_eq(
+            client.list_fetch(cache_name, test_list.name()).await?,
+            test_list.values().to_vec(),
+        )?;
+
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        // Expect a miss after collection ttl expires
+        let result = client.list_fetch(cache_name, test_list.name()).await?;
+        assert_eq!(result, ListFetch::Miss);
+
+        Ok(())
+    }
+}
+
+mod list_concatenate_front {
+    use super::*;
+
+    #[tokio::test]
+    async fn nonexistent_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_cache_name();
+
+        let result = client
+            .list_concatenate_front(cache_name, "list", vec!["value1", "value2"])
+            .await
+            .unwrap_err();
+
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn happy_path() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let test_list = TestList::default();
+
+        // Concatenates string values
+        let result = client
+            .list_concatenate_front(cache_name, test_list.name(), test_list.values().to_vec())
+            .await?;
+        assert_eq!(result, ListConcatenateFront {});
+        assert_list_eq(
+            client.list_fetch(cache_name, test_list.name()).await?,
+            test_list.values().to_vec(),
+        )?;
+
+        // Concatenates byte values
+        let result = client
+            .list_concatenate_front(
+                cache_name,
+                test_list.name(),
+                test_list.values().iter().map(|v| v.as_bytes()).collect(),
+            )
+            .await?;
+        assert_eq!(result, ListConcatenateFront {});
+        assert_list_eq(
+            client.list_fetch(cache_name, test_list.name()).await?,
+            [test_list.values().to_vec(), test_list.values().to_vec()].concat(),
+        )?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn happy_path_with_optional_arguments() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let test_list = TestList::default();
+
+        // Concatenates with truncation and collection ttl
+        let request = ListConcatenateFrontRequest::new(
+            cache_name.to_string(),
+            test_list.name(),
+            [test_list.values().to_vec(), test_list.values().to_vec()].concat(),
+        )
+        .truncate_back_to_size(2)
+        .ttl(CollectionTtl::new(Some(Duration::from_secs(3)), false));
+        let result = client.send_request(request).await?;
+        assert_eq!(result, ListConcatenateFront {});
+
+        // Should have truncated to only 2 elements
+        assert_list_eq(
+            client.list_fetch(cache_name, test_list.name()).await?,
+            test_list.values().to_vec(),
+        )?;
+
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        // Expect a miss after collection ttl expires
+        let result = client.list_fetch(cache_name, test_list.name()).await?;
+        assert_eq!(result, ListFetch::Miss);
+
+        Ok(())
+    }
+}
+
+mod list_length {
+    use super::*;
+
+    #[tokio::test]
+    async fn nonexistent_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_cache_name();
+
+        let result = client.list_length(cache_name, "list").await.unwrap_err();
+
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn nonexistent_list() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let list_name = unique_cache_name();
+
+        let result = client.list_length(cache_name, list_name).await?;
+
+        assert_eq!(result, ListLength::Miss {});
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn happy_path() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let test_list = TestList::default();
+
+        // Concatenates some values first
+        let result = client
+            .list_concatenate_back(cache_name, test_list.name(), test_list.values().to_vec())
+            .await?;
+        assert_eq!(result, ListConcatenateBack {});
+
+        // Fetch list length
+        let result = client.list_length(cache_name, test_list.name()).await?;
+        assert_eq!(result, ListLength::Hit { length: 2 });
+
+        Ok(())
+    }
+}
+
+mod list_fetch {
+    use momento::cache::ListFetchRequest;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn nonexistent_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_cache_name();
+
+        let result = client.list_fetch(cache_name, "list").await.unwrap_err();
+
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn nonexistent_list() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let list_name = unique_cache_name();
+
+        let result = client.list_fetch(cache_name, list_name).await?;
+
+        assert_eq!(result, ListFetch::Miss {});
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn happy_path() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let list1 = TestList::default();
+        let list2 = TestList::default();
+
+        // Concatenates some values first
+        let result = client
+            .list_concatenate_back(
+                cache_name,
+                list1.name(),
+                [list1.values().to_vec(), list2.values().to_vec()].concat(),
+            )
+            .await?;
+        assert_eq!(result, ListConcatenateBack {});
+
+        // Fetch entire list
+        let fetch_full_list = client.list_fetch(cache_name, list1.name()).await?;
+        assert_list_eq(
+            fetch_full_list,
+            [list1.values().to_vec(), list2.values().to_vec()].concat(),
+        )?;
+
+        // Fetch a list slice
+        let request = ListFetchRequest::new(cache_name, list1.name())
+            .start_index(2)
+            .end_index(4);
+        let fetch_slice = client.send_request(request).await?;
+        assert_list_eq(fetch_slice, list2.values().to_vec())?;
+
+        Ok(())
+    }
+}
+
+

--- a/tests/cache/mod.rs
+++ b/tests/cache/mod.rs
@@ -1,6 +1,7 @@
 mod control;
 mod item;
 mod key_existence;
+mod list;
 mod scalar;
 mod sorted_set;
 mod ttl;


### PR DESCRIPTION
Addresses #165 

Prioritized getting these APIs implemented:

- listConcatenateBack
- listConcatenateFront
- listFetch
- listLength
- listPopBack
- listPopFront
- listRemoveValue

listPushFront and listPushBack were also implemented in the simple_cache_client but seemed less urgent to include them here since the same functionality can be done using the concatenate methods.
