### PR TITLE
refactor: rename sorted set fetch hit elements field and document response

### DIFF
--- a/src/cache/requests/dictionary/dictionary_fetch.rs
+++ b/src/cache/requests/dictionary/dictionary_fetch.rs
@@ -109,7 +109,6 @@ impl<D: IntoBytes> MomentoRequest for DictionaryFetchRequest<D> {
 ///    DictionaryFetch::Hit { value } => value.try_into().expect("I stored strings!"),
 ///   DictionaryFetch::Miss => panic!("I expected a hit!"),
 /// };
-///
 /// # Ok(())
 /// }
 /// ```

--- a/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
+++ b/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
@@ -32,7 +32,7 @@ use crate::{
 /// # let fetch_response = SortedSetFetch::Hit { value: SortedSetElements::default() };
 /// use std::convert::TryInto;
 /// let item: Vec<(Vec<u8>, f64)> = match fetch_response {
-///  SortedSetFetch::Hit { value } => value.try_into().expect("I stored bytes!"),
+///  SortedSetFetch::Hit { value } => value.into(),
 ///  SortedSetFetch::Miss => panic!("I expected a hit!"),
 /// };
 /// ```
@@ -64,7 +64,6 @@ pub enum SortedSetFetch {
     Miss,
 }
 
-/// Response object for a [SortedSetFetchByScoreRequest] or a [SortedSetFetchByRankRequest].
 impl SortedSetFetch {
     pub(crate) fn from_fetch_response(response: SortedSetFetchResponse) -> MomentoResult<Self> {
         match response.sorted_set {
@@ -173,11 +172,9 @@ impl SortedSetElements {
     }
 }
 
-impl TryFrom<SortedSetElements> for Vec<(Vec<u8>, f64)> {
-    type Error = MomentoError;
-
-    fn try_from(value: SortedSetElements) -> Result<Self, Self::Error> {
-        Ok(value.elements)
+impl From<SortedSetElements> for Vec<(Vec<u8>, f64)> {
+    fn from(value: SortedSetElements) -> Self {
+        value.elements
     }
 }
 

--- a/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
+++ b/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
@@ -8,7 +8,7 @@ use crate::{
     MomentoResult, {ErrorSource, MomentoError, MomentoErrorCode},
 };
 
-/// Response object for a SortedSetFetchByScoreRequest or a SortedSetFetchByRankRequest.
+/// Response object for a [SortedSetFetchByScoreRequest](crate::cache::SortedSetFetchByScoreRequest) or a [SortedSetFetchByRankRequest](crate::cache::SortedSetFetchByRankRequest).
 ///
 /// If you'd like to handle misses you can simply match and handle your response:
 /// ```

--- a/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
+++ b/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
@@ -8,7 +8,7 @@ use crate::{
     MomentoResult, {ErrorSource, MomentoError, MomentoErrorCode},
 };
 
-/// Response object for a [SortedSetFetchByScoreRequest] or a [SortedSetFetchByRankRequest].
+/// Response object for a SortedSetFetchByScoreRequest or a SortedSetFetchByRankRequest.
 ///
 /// If you'd like to handle misses you can simply match and handle your response:
 /// ```

--- a/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
+++ b/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
@@ -8,6 +8,56 @@ use crate::{
     MomentoResult, {ErrorSource, MomentoError, MomentoErrorCode},
 };
 
+/// Response object for a [SortedSetFetchByScoreRequest] or a [SortedSetFetchByRankRequest].
+///
+/// If you'd like to handle misses you can simply match and handle your response:
+/// ```
+/// fn main() -> anyhow::Result<()> {
+/// # use momento::cache::{SortedSetFetch, SortedSetElements};
+/// # use momento::MomentoResult;
+/// # let fetch_response = SortedSetFetch::Hit { value: SortedSetElements::default() };
+/// use std::convert::TryInto;
+/// let item: Vec<(String, f64)> = match fetch_response {
+///   SortedSetFetch::Hit { value } => value.try_into().expect("I stored strings!"),
+///   SortedSetFetch::Miss => panic!("I expected a hit!"),
+/// };
+/// # Ok(())
+/// }
+/// ```
+///
+/// Or, if you're storing raw bytes you can get at them simply:
+/// ```
+/// # use momento::cache::{SortedSetFetch, SortedSetElements};
+/// # use momento::MomentoResult;
+/// # let fetch_response = SortedSetFetch::Hit { value: SortedSetElements::default() };
+/// use std::convert::TryInto;
+/// let item: Vec<(Vec<u8>, f64)> = match fetch_response {
+///  SortedSetFetch::Hit { value } => value.try_into().expect("I stored bytes!"),
+///  SortedSetFetch::Miss => panic!("I expected a hit!"),
+/// };
+/// ```
+///
+/// You can cast your result directly into a Result<Vec<(String, f64)>, MomentoError> suitable for
+/// ?-propagation if you know you are expecting a Vec<(String, f64)> item.
+///
+/// Of course, a Miss in this case will be turned into an Error. If that's what you want, then
+/// this is what you're after:
+/// ```
+/// # use momento::cache::{SortedSetFetch, SortedSetElements};
+/// # use momento::MomentoResult;
+/// # let fetch_response = SortedSetFetch::Hit { value: SortedSetElements::default() };
+/// use std::convert::TryInto;
+/// let item: MomentoResult<Vec<(String, f64)>> = fetch_response.try_into();
+/// ```
+///
+/// You can also go straight into a `Vec<(Vec<u8>, f64)>` if you prefer:
+/// ```
+/// # use momento::cache::{SortedSetFetch, SortedSetElements};
+/// # use momento::MomentoResult;
+/// # let fetch_response = SortedSetFetch::Hit { value: SortedSetElements::default() };
+/// use std::convert::TryInto;
+/// let item: MomentoResult<Vec<(Vec<u8>, f64)>> = fetch_response.try_into();
+/// ```
 #[derive(Debug, PartialEq)]
 pub enum SortedSetFetch {
     Hit { value: SortedSetElements },
@@ -100,7 +150,7 @@ impl From<Vec<(String, f64)>> for SortedSetFetch {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Default)]
 pub struct SortedSetElements {
     pub elements: Vec<(Vec<u8>, f64)>,
 }

--- a/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
+++ b/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
@@ -10,7 +10,7 @@ use crate::{
 
 #[derive(Debug, PartialEq)]
 pub enum SortedSetFetch {
-    Hit { elements: SortedSetElements },
+    Hit { value: SortedSetElements },
     Miss,
 }
 
@@ -22,7 +22,7 @@ impl SortedSetFetch {
             Some(SortedSet::Missing(_)) => Ok(SortedSetFetch::Miss),
             Some(SortedSet::Found(elements)) => match elements.elements {
                 None => Ok(SortedSetFetch::Hit {
-                    elements: SortedSetElements::new(Vec::new()),
+                    value: SortedSetElements::new(Vec::new()),
                 }),
                 Some(elements) => match elements {
                     Elements::ValuesWithScores(values_with_scores) => {
@@ -32,7 +32,7 @@ impl SortedSetFetch {
                             .map(|element| (element.value, element.score))
                             .collect();
                         Ok(SortedSetFetch::Hit {
-                            elements: SortedSetElements::new(elements),
+                            value: SortedSetElements::new(elements),
                         })
                     }
                     Elements::Values(_) => Err(MomentoError {
@@ -60,7 +60,7 @@ impl TryFrom<SortedSetFetch> for Vec<(Vec<u8>, f64)> {
 
     fn try_from(value: SortedSetFetch) -> Result<Self, Self::Error> {
         match value {
-            SortedSetFetch::Hit { elements } => Ok(elements.elements),
+            SortedSetFetch::Hit { value: elements } => Ok(elements.elements),
             SortedSetFetch::Miss => Err(MomentoError {
                 message: "sorted set was not found".into(),
                 error_code: MomentoErrorCode::Miss,
@@ -76,7 +76,7 @@ impl TryFrom<SortedSetFetch> for Vec<(String, f64)> {
 
     fn try_from(value: SortedSetFetch) -> Result<Self, Self::Error> {
         match value {
-            SortedSetFetch::Hit { elements } => elements.into_strings(),
+            SortedSetFetch::Hit { value: elements } => elements.into_strings(),
             SortedSetFetch::Miss => Err(MomentoError {
                 message: "sorted set was not found".into(),
                 error_code: MomentoErrorCode::Miss,
@@ -90,7 +90,7 @@ impl TryFrom<SortedSetFetch> for Vec<(String, f64)> {
 impl From<Vec<(String, f64)>> for SortedSetFetch {
     fn from(elements: Vec<(String, f64)>) -> Self {
         SortedSetFetch::Hit {
-            elements: SortedSetElements::new(
+            value: SortedSetElements::new(
                 elements
                     .into_iter()
                     .map(|(element, score)| (element.into_bytes(), score))

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -592,8 +592,8 @@ impl CacheClient {
     /// ).await?;
     ///
     /// match fetch_response {
-    ///     SortedSetFetch::Hit{ elements } => {
-    ///         match elements.into_strings() {
+    ///     SortedSetFetch::Hit{ value } => {
+    ///         match value.into_strings() {
     ///             Ok(vec) => {
     ///                 println!("Fetched elements: {:?}", vec);
     ///             }
@@ -668,8 +668,8 @@ impl CacheClient {
     /// ).await?;
     ///
     /// match fetch_response {
-    ///     SortedSetFetch::Hit{ elements } => {
-    ///         match elements.into_strings() {
+    ///     SortedSetFetch::Hit{ value } => {
+    ///         match value.into_strings() {
     ///             Ok(vec) => {
     ///                 println!("Fetched elements: {:?}", vec);
     ///             }

--- a/test-util/src/test_data.rs
+++ b/test-util/src/test_data.rs
@@ -92,6 +92,12 @@ impl Default for TestDictionary {
     }
 }
 
+impl Default for TestDictionary {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct TestSet {
     pub name: String,

--- a/test-util/src/test_data.rs
+++ b/test-util/src/test_data.rs
@@ -159,7 +159,7 @@ impl Default for TestSortedSet {
 impl From<&TestSortedSet> for SortedSetFetch {
     fn from(test_sorted_set: &TestSortedSet) -> Self {
         SortedSetFetch::Hit {
-            elements: SortedSetElements::new(
+            value: SortedSetElements::new(
                 test_sorted_set
                     .value()
                     .iter()

--- a/test-util/src/test_data.rs
+++ b/test-util/src/test_data.rs
@@ -92,12 +92,6 @@ impl Default for TestDictionary {
     }
 }
 
-impl Default for TestDictionary {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[derive(Debug, PartialEq, Clone)]
 pub struct TestSet {
     pub name: String,

--- a/tests/cache/sorted_set.rs
+++ b/tests/cache/sorted_set.rs
@@ -32,11 +32,11 @@ fn assert_fetched_sorted_set_eq_after_sorting(
     };
 
     let sorted_set_fetch_result = match sorted_set_fetch_result {
-        SortedSetFetch::Hit { elements } => {
-            let mut elements = elements.elements.clone();
+        SortedSetFetch::Hit { value } => {
+            let mut elements = value.elements.clone();
             elements.sort_by(sort_by_score);
             SortedSetFetch::Hit {
-                elements: SortedSetElements { elements },
+                value: SortedSetElements { elements },
             }
         }
         _ => sorted_set_fetch_result,


### PR DESCRIPTION
In order to be in line with other our standard, we rename the hit
field from elements to value.

In addition we document `SortedSetFetch` and correct the `TryFrom`
on `SortedSetElements` to derive `From` instead.