### PR TITLE
fix: replace usage of unreachable macro with returning an UnknownError

### DIFF
--- a/src/cache/requests/dictionary/dictionary_fetch.rs
+++ b/src/cache/requests/dictionary/dictionary_fetch.rs
@@ -1,5 +1,5 @@
 use crate::cache::requests::MomentoRequest;
-use crate::utils::{parse_string, prep_request_with_timeout, return_unknown_error};
+use crate::utils::{parse_string, prep_request_with_timeout};
 use crate::{CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult};
 use momento_protos::cache_client::{
     dictionary_fetch_response::Dictionary as DictionaryProto,
@@ -90,7 +90,7 @@ impl<D: IntoBytes> MomentoRequest for DictionaryFetchRequest<D> {
                     value: DictionaryFetchValue::new(raw_item),
                 })
             }
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "DictionaryFetch",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/list/list_fetch.rs
+++ b/src/cache/requests/list/list_fetch.rs
@@ -10,7 +10,7 @@ use momento_protos::{
 
 use crate::{
     cache::MomentoRequest,
-    utils::{parse_string, prep_request_with_timeout},
+    utils::{parse_string, prep_request_with_timeout, return_unknown_error},
     CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult,
 };
 
@@ -110,12 +110,10 @@ impl<L: IntoBytes> MomentoRequest for ListFetchRequest<L> {
                     raw_item: found.values,
                 },
             }),
-            _ => Err(MomentoError {
-                message: "Unknown error has occurred, unable to parse list_fetch_response".into(),
-                error_code: MomentoErrorCode::UnknownError,
-                inner_error: None,
-                details: None,
-            }),
+            _ => Err(return_unknown_error(
+                "ListFetch",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/list/list_fetch.rs
+++ b/src/cache/requests/list/list_fetch.rs
@@ -10,7 +10,7 @@ use momento_protos::{
 
 use crate::{
     cache::MomentoRequest,
-    utils::{parse_string, prep_request_with_timeout, return_unknown_error},
+    utils::{parse_string, prep_request_with_timeout},
     CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult,
 };
 
@@ -110,7 +110,7 @@ impl<L: IntoBytes> MomentoRequest for ListFetchRequest<L> {
                     raw_item: found.values,
                 },
             }),
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "ListFetch",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/list/list_length.rs
+++ b/src/cache/requests/list/list_length.rs
@@ -3,9 +3,8 @@ use std::convert::TryFrom;
 use momento_protos::cache_client::list_length_response;
 
 use crate::{
-    cache::MomentoRequest,
-    utils::prep_request_with_timeout,
-    CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult,
+    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoError,
+    MomentoErrorCode, MomentoResult,
 };
 
 /// Gets the number of elements in the given list.

--- a/src/cache/requests/list/list_length.rs
+++ b/src/cache/requests/list/list_length.rs
@@ -4,7 +4,7 @@ use momento_protos::cache_client::list_length_response;
 
 use crate::{
     cache::MomentoRequest,
-    utils::{prep_request_with_timeout, return_unknown_error},
+    utils::prep_request_with_timeout,
     CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult,
 };
 
@@ -71,7 +71,7 @@ impl<L: IntoBytes> MomentoRequest for ListLengthRequest<L> {
             Some(list_length_response::List::Found(found)) => Ok(ListLength::Hit {
                 length: found.length,
             }),
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "ListLength",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/list/list_length.rs
+++ b/src/cache/requests/list/list_length.rs
@@ -3,8 +3,9 @@ use std::convert::TryFrom;
 use momento_protos::cache_client::list_length_response;
 
 use crate::{
-    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoError,
-    MomentoErrorCode, MomentoResult,
+    cache::MomentoRequest,
+    utils::{prep_request_with_timeout, return_unknown_error},
+    CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult,
 };
 
 /// Gets the number of elements in the given list.
@@ -70,12 +71,10 @@ impl<L: IntoBytes> MomentoRequest for ListLengthRequest<L> {
             Some(list_length_response::List::Found(found)) => Ok(ListLength::Hit {
                 length: found.length,
             }),
-            _ => Err(MomentoError {
-                message: "Unknown error has occurred, unable to parse list_fetch_response".into(),
-                error_code: MomentoErrorCode::UnknownError,
-                inner_error: None,
-                details: None,
-            }),
+            _ => Err(return_unknown_error(
+                "ListLength",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/list/list_pop_back.rs
+++ b/src/cache/requests/list/list_pop_back.rs
@@ -4,7 +4,7 @@ use momento_protos::cache_client::list_pop_back_response;
 
 use crate::{
     cache::MomentoRequest,
-    utils::{parse_string, prep_request_with_timeout, return_unknown_error},
+    utils::{parse_string, prep_request_with_timeout},
     CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult,
 };
 
@@ -71,7 +71,7 @@ impl<L: IntoBytes> MomentoRequest for ListPopBackRequest<L> {
             Some(list_pop_back_response::List::Found(found)) => Ok(ListPopBack::Hit {
                 value: ListPopBackValue::new(found.back),
             }),
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "ListPopBack",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/list/list_pop_back.rs
+++ b/src/cache/requests/list/list_pop_back.rs
@@ -4,7 +4,7 @@ use momento_protos::cache_client::list_pop_back_response;
 
 use crate::{
     cache::MomentoRequest,
-    utils::{parse_string, prep_request_with_timeout},
+    utils::{parse_string, prep_request_with_timeout, return_unknown_error},
     CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult,
 };
 
@@ -71,12 +71,10 @@ impl<L: IntoBytes> MomentoRequest for ListPopBackRequest<L> {
             Some(list_pop_back_response::List::Found(found)) => Ok(ListPopBack::Hit {
                 value: ListPopBackValue::new(found.back),
             }),
-            _ => Err(MomentoError {
-                message: "Unknown error has occurred, unable to parse list_fetch_response".into(),
-                error_code: MomentoErrorCode::UnknownError,
-                inner_error: None,
-                details: None,
-            }),
+            _ => Err(return_unknown_error(
+                "ListPopBack",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/list/list_pop_front.rs
+++ b/src/cache/requests/list/list_pop_front.rs
@@ -4,7 +4,7 @@ use momento_protos::cache_client::list_pop_front_response;
 
 use crate::{
     cache::MomentoRequest,
-    utils::{parse_string, prep_request_with_timeout},
+    utils::{parse_string, prep_request_with_timeout, return_unknown_error},
     CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult,
 };
 
@@ -71,12 +71,10 @@ impl<L: IntoBytes> MomentoRequest for ListPopFrontRequest<L> {
             Some(list_pop_front_response::List::Found(found)) => Ok(ListPopFront::Hit {
                 value: ListPopFrontValue::new(found.front),
             }),
-            _ => Err(MomentoError {
-                message: "Unknown error has occurred, unable to parse list_fetch_response".into(),
-                error_code: MomentoErrorCode::UnknownError,
-                inner_error: None,
-                details: None,
-            }),
+            _ => Err(return_unknown_error(
+                "ListPopFront",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/list/list_pop_front.rs
+++ b/src/cache/requests/list/list_pop_front.rs
@@ -4,7 +4,7 @@ use momento_protos::cache_client::list_pop_front_response;
 
 use crate::{
     cache::MomentoRequest,
-    utils::{parse_string, prep_request_with_timeout, return_unknown_error},
+    utils::{parse_string, prep_request_with_timeout},
     CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult,
 };
 
@@ -71,7 +71,7 @@ impl<L: IntoBytes> MomentoRequest for ListPopFrontRequest<L> {
             Some(list_pop_front_response::List::Found(found)) => Ok(ListPopFront::Hit {
                 value: ListPopFrontValue::new(found.front),
             }),
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "ListPopFront",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/scalar/decrease_ttl.rs
+++ b/src/cache/requests/scalar/decrease_ttl.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use momento_protos::cache_client::update_ttl_request::UpdateTtl::DecreaseToMilliseconds;
 use momento_protos::cache_client::update_ttl_response::{self};
 
-use crate::utils::return_unknown_error;
+use crate::MomentoError;
 use crate::{
     cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoResult,
 };
@@ -79,7 +79,7 @@ impl<K: IntoBytes> MomentoRequest for DecreaseTtlRequest<K> {
             Some(update_ttl_response::Result::Missing(_)) => Ok(DecreaseTtl::Miss),
             Some(update_ttl_response::Result::Set(_)) => Ok(DecreaseTtl::Set),
             Some(update_ttl_response::Result::NotSet(_)) => Ok(DecreaseTtl::NotSet),
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "DecreaseTtl",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/scalar/decrease_ttl.rs
+++ b/src/cache/requests/scalar/decrease_ttl.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use momento_protos::cache_client::update_ttl_request::UpdateTtl::DecreaseToMilliseconds;
 use momento_protos::cache_client::update_ttl_response::{self};
 
+use crate::utils::return_unknown_error;
 use crate::{
     cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoResult,
 };
@@ -78,7 +79,10 @@ impl<K: IntoBytes> MomentoRequest for DecreaseTtlRequest<K> {
             Some(update_ttl_response::Result::Missing(_)) => Ok(DecreaseTtl::Miss),
             Some(update_ttl_response::Result::Set(_)) => Ok(DecreaseTtl::Set),
             Some(update_ttl_response::Result::NotSet(_)) => Ok(DecreaseTtl::NotSet),
-            _ => unreachable!(),
+            _ => Err(return_unknown_error(
+                "DecreaseTtl",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/scalar/get.rs
+++ b/src/cache/requests/scalar/get.rs
@@ -2,6 +2,7 @@ use crate::cache::requests::MomentoRequest;
 use crate::cache_client::CacheClient;
 use crate::utils::parse_string;
 use crate::utils::prep_request_with_timeout;
+use crate::utils::return_unknown_error;
 use crate::MomentoErrorCode;
 use crate::{IntoBytes, MomentoError, MomentoResult};
 use momento_protos::cache_client::ECacheResult;
@@ -78,7 +79,10 @@ impl<K: IntoBytes> MomentoRequest for GetRequest<K> {
                 },
             }),
             ECacheResult::Miss => Ok(Get::Miss),
-            _ => unreachable!(),
+            _ => Err(return_unknown_error(
+                "Get",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/scalar/get.rs
+++ b/src/cache/requests/scalar/get.rs
@@ -2,7 +2,6 @@ use crate::cache::requests::MomentoRequest;
 use crate::cache_client::CacheClient;
 use crate::utils::parse_string;
 use crate::utils::prep_request_with_timeout;
-use crate::utils::return_unknown_error;
 use crate::MomentoErrorCode;
 use crate::{IntoBytes, MomentoError, MomentoResult};
 use momento_protos::cache_client::ECacheResult;
@@ -79,7 +78,7 @@ impl<K: IntoBytes> MomentoRequest for GetRequest<K> {
                 },
             }),
             ECacheResult::Miss => Ok(Get::Miss),
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "Get",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/scalar/increase_ttl.rs
+++ b/src/cache/requests/scalar/increase_ttl.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use momento_protos::cache_client::update_ttl_request::UpdateTtl::IncreaseToMilliseconds;
 use momento_protos::cache_client::update_ttl_response::{self};
 
-use crate::utils::return_unknown_error;
+use crate::MomentoError;
 use crate::{
     cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoResult,
 };
@@ -79,7 +79,7 @@ impl<K: IntoBytes> MomentoRequest for IncreaseTtlRequest<K> {
             Some(update_ttl_response::Result::Missing(_)) => Ok(IncreaseTtl::Miss),
             Some(update_ttl_response::Result::Set(_)) => Ok(IncreaseTtl::Set),
             Some(update_ttl_response::Result::NotSet(_)) => Ok(IncreaseTtl::NotSet),
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "IncreaseTtl",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/scalar/increase_ttl.rs
+++ b/src/cache/requests/scalar/increase_ttl.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use momento_protos::cache_client::update_ttl_request::UpdateTtl::IncreaseToMilliseconds;
 use momento_protos::cache_client::update_ttl_response::{self};
 
+use crate::utils::return_unknown_error;
 use crate::{
     cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoResult,
 };
@@ -78,7 +79,10 @@ impl<K: IntoBytes> MomentoRequest for IncreaseTtlRequest<K> {
             Some(update_ttl_response::Result::Missing(_)) => Ok(IncreaseTtl::Miss),
             Some(update_ttl_response::Result::Set(_)) => Ok(IncreaseTtl::Set),
             Some(update_ttl_response::Result::NotSet(_)) => Ok(IncreaseTtl::NotSet),
-            _ => unreachable!(),
+            _ => Err(return_unknown_error(
+                "IncreaseTtl",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/scalar/item_get_ttl.rs
+++ b/src/cache/requests/scalar/item_get_ttl.rs
@@ -4,8 +4,9 @@ use std::time::Duration;
 use momento_protos::cache_client::item_get_ttl_response::{self};
 
 use crate::{
-    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoError,
-    MomentoErrorCode, MomentoResult,
+    cache::MomentoRequest,
+    utils::{prep_request_with_timeout, return_unknown_error},
+    CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult,
 };
 
 /// Return the remaining ttl of the key in the cache.
@@ -72,7 +73,10 @@ impl<K: IntoBytes> MomentoRequest for ItemGetTtlRequest<K> {
             Some(item_get_ttl_response::Result::Found(found)) => Ok(ItemGetTtl::Hit {
                 remaining_ttl: Duration::from_millis(found.remaining_ttl_millis),
             }),
-            _ => unreachable!(),
+            _ => Err(return_unknown_error(
+                "ItemGetTtl",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/scalar/item_get_ttl.rs
+++ b/src/cache/requests/scalar/item_get_ttl.rs
@@ -5,7 +5,7 @@ use momento_protos::cache_client::item_get_ttl_response::{self};
 
 use crate::{
     cache::MomentoRequest,
-    utils::{prep_request_with_timeout, return_unknown_error},
+    utils::prep_request_with_timeout,
     CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult,
 };
 
@@ -73,7 +73,7 @@ impl<K: IntoBytes> MomentoRequest for ItemGetTtlRequest<K> {
             Some(item_get_ttl_response::Result::Found(found)) => Ok(ItemGetTtl::Hit {
                 remaining_ttl: Duration::from_millis(found.remaining_ttl_millis),
             }),
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "ItemGetTtl",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/scalar/item_get_ttl.rs
+++ b/src/cache/requests/scalar/item_get_ttl.rs
@@ -4,9 +4,8 @@ use std::time::Duration;
 use momento_protos::cache_client::item_get_ttl_response::{self};
 
 use crate::{
-    cache::MomentoRequest,
-    utils::prep_request_with_timeout,
-    CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult,
+    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoError,
+    MomentoErrorCode, MomentoResult,
 };
 
 /// Return the remaining ttl of the key in the cache.

--- a/src/cache/requests/scalar/item_get_type.rs
+++ b/src/cache/requests/scalar/item_get_type.rs
@@ -4,7 +4,7 @@ use momento_protos::cache_client::item_get_type_response::{self};
 
 use crate::{
     cache::MomentoRequest,
-    utils::{prep_request_with_timeout, return_unknown_error},
+    utils::prep_request_with_timeout,
     CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult,
 };
 
@@ -90,7 +90,7 @@ impl<K: IntoBytes> MomentoRequest for ItemGetTypeRequest<K> {
                     }
                 },
             }),
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "ItemGetType",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/scalar/item_get_type.rs
+++ b/src/cache/requests/scalar/item_get_type.rs
@@ -3,9 +3,8 @@ use std::convert::TryFrom;
 use momento_protos::cache_client::item_get_type_response::{self};
 
 use crate::{
-    cache::MomentoRequest,
-    utils::prep_request_with_timeout,
-    CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult,
+    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoError,
+    MomentoErrorCode, MomentoResult,
 };
 
 /// Return the type of the key in the cache.

--- a/src/cache/requests/scalar/item_get_type.rs
+++ b/src/cache/requests/scalar/item_get_type.rs
@@ -3,8 +3,9 @@ use std::convert::TryFrom;
 use momento_protos::cache_client::item_get_type_response::{self};
 
 use crate::{
-    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoError,
-    MomentoErrorCode, MomentoResult,
+    cache::MomentoRequest,
+    utils::{prep_request_with_timeout, return_unknown_error},
+    CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult,
 };
 
 /// Return the type of the key in the cache.
@@ -89,7 +90,10 @@ impl<K: IntoBytes> MomentoRequest for ItemGetTypeRequest<K> {
                     }
                 },
             }),
-            _ => unreachable!(),
+            _ => Err(return_unknown_error(
+                "ItemGetType",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/scalar/key_exists.rs
+++ b/src/cache/requests/scalar/key_exists.rs
@@ -1,5 +1,5 @@
 use crate::cache::MomentoRequest;
-use crate::utils::prep_request_with_timeout;
+use crate::utils::{prep_request_with_timeout, return_unknown_error};
 use crate::{CacheClient, IntoBytes, MomentoResult};
 
 /// Request to check if a key exists in a cache.
@@ -67,7 +67,10 @@ impl<K: IntoBytes> MomentoRequest for KeyExistsRequest<K> {
 
         match response.exists.first() {
             Some(exists) => Ok(KeyExists { exists: *exists }),
-            _ => unreachable!(),
+            _ => Err(return_unknown_error(
+                "KeyExists",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/scalar/key_exists.rs
+++ b/src/cache/requests/scalar/key_exists.rs
@@ -1,6 +1,6 @@
 use crate::cache::MomentoRequest;
-use crate::utils::{prep_request_with_timeout, return_unknown_error};
-use crate::{CacheClient, IntoBytes, MomentoResult};
+use crate::utils::prep_request_with_timeout;
+use crate::{CacheClient, IntoBytes, MomentoError, MomentoResult};
 
 /// Request to check if a key exists in a cache.
 ///
@@ -67,7 +67,7 @@ impl<K: IntoBytes> MomentoRequest for KeyExistsRequest<K> {
 
         match response.exists.first() {
             Some(exists) => Ok(KeyExists { exists: *exists }),
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "KeyExists",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/scalar/set_if_absent.rs
+++ b/src/cache/requests/scalar/set_if_absent.rs
@@ -3,7 +3,7 @@ use momento_protos::cache_client::set_if_response;
 
 use crate::cache::requests::MomentoRequest;
 use crate::cache_client::CacheClient;
-use crate::utils::prep_request_with_timeout;
+use crate::utils::{prep_request_with_timeout, return_unknown_error};
 use crate::{IntoBytes, MomentoResult};
 use std::time::Duration;
 
@@ -99,7 +99,10 @@ impl<K: IntoBytes, V: IntoBytes> MomentoRequest for SetIfAbsentRequest<K, V> {
         match response.result {
             Some(set_if_response::Result::Stored(_)) => Ok(SetIfAbsent::Stored),
             Some(set_if_response::Result::NotStored(_)) => Ok(SetIfAbsent::NotStored),
-            _ => unreachable!(),
+            _ => Err(return_unknown_error(
+                "SetIfAbsent",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/scalar/set_if_absent.rs
+++ b/src/cache/requests/scalar/set_if_absent.rs
@@ -3,8 +3,8 @@ use momento_protos::cache_client::set_if_response;
 
 use crate::cache::requests::MomentoRequest;
 use crate::cache_client::CacheClient;
-use crate::utils::{prep_request_with_timeout, return_unknown_error};
-use crate::{IntoBytes, MomentoResult};
+use crate::utils::prep_request_with_timeout;
+use crate::{IntoBytes, MomentoError, MomentoResult};
 use std::time::Duration;
 
 /// Request to set associate the given key with the given value if key is not already present in the cache.
@@ -99,7 +99,7 @@ impl<K: IntoBytes, V: IntoBytes> MomentoRequest for SetIfAbsentRequest<K, V> {
         match response.result {
             Some(set_if_response::Result::Stored(_)) => Ok(SetIfAbsent::Stored),
             Some(set_if_response::Result::NotStored(_)) => Ok(SetIfAbsent::NotStored),
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "SetIfAbsent",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/scalar/set_if_absent_or_equal.rs
+++ b/src/cache/requests/scalar/set_if_absent_or_equal.rs
@@ -3,7 +3,7 @@ use momento_protos::cache_client::set_if_response;
 
 use crate::cache::requests::MomentoRequest;
 use crate::cache_client::CacheClient;
-use crate::utils::prep_request_with_timeout;
+use crate::utils::{prep_request_with_timeout, return_unknown_error};
 use crate::{IntoBytes, MomentoResult};
 use std::time::Duration;
 
@@ -108,7 +108,10 @@ impl<K: IntoBytes, V: IntoBytes, E: IntoBytes> MomentoRequest
         match response.result {
             Some(set_if_response::Result::Stored(_)) => Ok(SetIfAbsentOrEqual::Stored),
             Some(set_if_response::Result::NotStored(_)) => Ok(SetIfAbsentOrEqual::NotStored),
-            _ => unreachable!(),
+            _ => Err(return_unknown_error(
+                "SetIfAbsentOrEqual",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/scalar/set_if_absent_or_equal.rs
+++ b/src/cache/requests/scalar/set_if_absent_or_equal.rs
@@ -3,8 +3,8 @@ use momento_protos::cache_client::set_if_response;
 
 use crate::cache::requests::MomentoRequest;
 use crate::cache_client::CacheClient;
-use crate::utils::{prep_request_with_timeout, return_unknown_error};
-use crate::{IntoBytes, MomentoResult};
+use crate::utils::prep_request_with_timeout;
+use crate::{IntoBytes, MomentoError, MomentoResult};
 use std::time::Duration;
 
 /// Request to associate the given key with the given value if the key does not already
@@ -108,7 +108,7 @@ impl<K: IntoBytes, V: IntoBytes, E: IntoBytes> MomentoRequest
         match response.result {
             Some(set_if_response::Result::Stored(_)) => Ok(SetIfAbsentOrEqual::Stored),
             Some(set_if_response::Result::NotStored(_)) => Ok(SetIfAbsentOrEqual::NotStored),
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "SetIfAbsentOrEqual",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/scalar/set_if_equal.rs
+++ b/src/cache/requests/scalar/set_if_equal.rs
@@ -3,8 +3,8 @@ use momento_protos::cache_client::set_if_response;
 
 use crate::cache::requests::MomentoRequest;
 use crate::cache_client::CacheClient;
-use crate::utils::{prep_request_with_timeout, return_unknown_error};
-use crate::{IntoBytes, MomentoResult};
+use crate::utils::prep_request_with_timeout;
+use crate::{IntoBytes, MomentoError, MomentoResult};
 use std::time::Duration;
 
 /// Request to associate the given key with the given value if the key is present
@@ -106,7 +106,7 @@ impl<K: IntoBytes, V: IntoBytes, E: IntoBytes> MomentoRequest for SetIfEqualRequ
         match response.result {
             Some(set_if_response::Result::Stored(_)) => Ok(SetIfEqual::Stored),
             Some(set_if_response::Result::NotStored(_)) => Ok(SetIfEqual::NotStored),
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "SetIfEqual",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/scalar/set_if_equal.rs
+++ b/src/cache/requests/scalar/set_if_equal.rs
@@ -3,7 +3,7 @@ use momento_protos::cache_client::set_if_response;
 
 use crate::cache::requests::MomentoRequest;
 use crate::cache_client::CacheClient;
-use crate::utils::prep_request_with_timeout;
+use crate::utils::{prep_request_with_timeout, return_unknown_error};
 use crate::{IntoBytes, MomentoResult};
 use std::time::Duration;
 
@@ -106,7 +106,10 @@ impl<K: IntoBytes, V: IntoBytes, E: IntoBytes> MomentoRequest for SetIfEqualRequ
         match response.result {
             Some(set_if_response::Result::Stored(_)) => Ok(SetIfEqual::Stored),
             Some(set_if_response::Result::NotStored(_)) => Ok(SetIfEqual::NotStored),
-            _ => unreachable!(),
+            _ => Err(return_unknown_error(
+                "SetIfEqual",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/scalar/set_if_not_equal.rs
+++ b/src/cache/requests/scalar/set_if_not_equal.rs
@@ -3,8 +3,8 @@ use momento_protos::cache_client::set_if_response;
 
 use crate::cache::requests::MomentoRequest;
 use crate::cache_client::CacheClient;
-use crate::utils::{prep_request_with_timeout, return_unknown_error};
-use crate::{IntoBytes, MomentoResult};
+use crate::utils::prep_request_with_timeout;
+use crate::{IntoBytes, MomentoError, MomentoResult};
 use std::time::Duration;
 
 /// Request to associate the given key with the given value if the key does not already exist
@@ -106,7 +106,7 @@ impl<K: IntoBytes, V: IntoBytes, E: IntoBytes> MomentoRequest for SetIfNotEqualR
         match response.result {
             Some(set_if_response::Result::Stored(_)) => Ok(SetIfNotEqual::Stored),
             Some(set_if_response::Result::NotStored(_)) => Ok(SetIfNotEqual::NotStored),
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "SetIfNotEqual",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/scalar/set_if_not_equal.rs
+++ b/src/cache/requests/scalar/set_if_not_equal.rs
@@ -3,7 +3,7 @@ use momento_protos::cache_client::set_if_response;
 
 use crate::cache::requests::MomentoRequest;
 use crate::cache_client::CacheClient;
-use crate::utils::prep_request_with_timeout;
+use crate::utils::{prep_request_with_timeout, return_unknown_error};
 use crate::{IntoBytes, MomentoResult};
 use std::time::Duration;
 
@@ -106,7 +106,10 @@ impl<K: IntoBytes, V: IntoBytes, E: IntoBytes> MomentoRequest for SetIfNotEqualR
         match response.result {
             Some(set_if_response::Result::Stored(_)) => Ok(SetIfNotEqual::Stored),
             Some(set_if_response::Result::NotStored(_)) => Ok(SetIfNotEqual::NotStored),
-            _ => unreachable!(),
+            _ => Err(return_unknown_error(
+                "SetIfNotEqual",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/scalar/set_if_present.rs
+++ b/src/cache/requests/scalar/set_if_present.rs
@@ -3,7 +3,7 @@ use momento_protos::cache_client::set_if_response;
 
 use crate::cache::requests::MomentoRequest;
 use crate::cache_client::CacheClient;
-use crate::utils::prep_request_with_timeout;
+use crate::utils::{prep_request_with_timeout, return_unknown_error};
 use crate::{IntoBytes, MomentoResult};
 use std::time::Duration;
 
@@ -99,7 +99,10 @@ impl<K: IntoBytes, V: IntoBytes> MomentoRequest for SetIfPresentRequest<K, V> {
         match response.result {
             Some(set_if_response::Result::Stored(_)) => Ok(SetIfPresent::Stored),
             Some(set_if_response::Result::NotStored(_)) => Ok(SetIfPresent::NotStored),
-            _ => unreachable!(),
+            _ => Err(return_unknown_error(
+                "SetIfPresent",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/scalar/set_if_present.rs
+++ b/src/cache/requests/scalar/set_if_present.rs
@@ -3,8 +3,8 @@ use momento_protos::cache_client::set_if_response;
 
 use crate::cache::requests::MomentoRequest;
 use crate::cache_client::CacheClient;
-use crate::utils::{prep_request_with_timeout, return_unknown_error};
-use crate::{IntoBytes, MomentoResult};
+use crate::utils::prep_request_with_timeout;
+use crate::{IntoBytes, MomentoError, MomentoResult};
 use std::time::Duration;
 
 /// Request to set associate the given key with the given value if key is present in the cache.
@@ -99,7 +99,7 @@ impl<K: IntoBytes, V: IntoBytes> MomentoRequest for SetIfPresentRequest<K, V> {
         match response.result {
             Some(set_if_response::Result::Stored(_)) => Ok(SetIfPresent::Stored),
             Some(set_if_response::Result::NotStored(_)) => Ok(SetIfPresent::NotStored),
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "SetIfPresent",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/scalar/set_if_present_and_not_equal.rs
+++ b/src/cache/requests/scalar/set_if_present_and_not_equal.rs
@@ -3,7 +3,7 @@ use momento_protos::cache_client::set_if_response;
 
 use crate::cache::requests::MomentoRequest;
 use crate::cache_client::CacheClient;
-use crate::utils::prep_request_with_timeout;
+use crate::utils::{prep_request_with_timeout, return_unknown_error};
 use crate::{IntoBytes, MomentoResult};
 use std::time::Duration;
 
@@ -110,7 +110,10 @@ impl<K: IntoBytes, V: IntoBytes, E: IntoBytes> MomentoRequest
         match response.result {
             Some(set_if_response::Result::Stored(_)) => Ok(SetIfPresentAndNotEqual::Stored),
             Some(set_if_response::Result::NotStored(_)) => Ok(SetIfPresentAndNotEqual::NotStored),
-            _ => unreachable!(),
+            _ => Err(return_unknown_error(
+                "SetIfPresentAndNotEqual",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/scalar/set_if_present_and_not_equal.rs
+++ b/src/cache/requests/scalar/set_if_present_and_not_equal.rs
@@ -3,8 +3,8 @@ use momento_protos::cache_client::set_if_response;
 
 use crate::cache::requests::MomentoRequest;
 use crate::cache_client::CacheClient;
-use crate::utils::{prep_request_with_timeout, return_unknown_error};
-use crate::{IntoBytes, MomentoResult};
+use crate::utils::prep_request_with_timeout;
+use crate::{IntoBytes, MomentoError, MomentoResult};
 use std::time::Duration;
 
 /// Request to associate the given key with the given value if the key exists in the
@@ -110,7 +110,7 @@ impl<K: IntoBytes, V: IntoBytes, E: IntoBytes> MomentoRequest
         match response.result {
             Some(set_if_response::Result::Stored(_)) => Ok(SetIfPresentAndNotEqual::Stored),
             Some(set_if_response::Result::NotStored(_)) => Ok(SetIfPresentAndNotEqual::NotStored),
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "SetIfPresentAndNotEqual",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/scalar/update_ttl.rs
+++ b/src/cache/requests/scalar/update_ttl.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use momento_protos::cache_client::update_ttl_request::UpdateTtl::OverwriteToMilliseconds;
 use momento_protos::cache_client::update_ttl_response::{self};
 
+use crate::utils::return_unknown_error;
 use crate::{
     cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoResult,
 };
@@ -76,7 +77,10 @@ impl<K: IntoBytes> MomentoRequest for UpdateTtlRequest<K> {
         match response.result {
             Some(update_ttl_response::Result::Missing(_)) => Ok(UpdateTtl::Miss),
             Some(update_ttl_response::Result::Set(_)) => Ok(UpdateTtl::Set),
-            _ => unreachable!(),
+            _ => Err(return_unknown_error(
+                "UpdateTtl",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/scalar/update_ttl.rs
+++ b/src/cache/requests/scalar/update_ttl.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use momento_protos::cache_client::update_ttl_request::UpdateTtl::OverwriteToMilliseconds;
 use momento_protos::cache_client::update_ttl_response::{self};
 
-use crate::utils::return_unknown_error;
+use crate::MomentoError;
 use crate::{
     cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoResult,
 };
@@ -77,7 +77,7 @@ impl<K: IntoBytes> MomentoRequest for UpdateTtlRequest<K> {
         match response.result {
             Some(update_ttl_response::Result::Missing(_)) => Ok(UpdateTtl::Miss),
             Some(update_ttl_response::Result::Set(_)) => Ok(UpdateTtl::Set),
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "UpdateTtl",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
+++ b/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
@@ -5,7 +5,7 @@ use momento_protos::cache_client::sorted_set_fetch_response::SortedSet;
 use momento_protos::cache_client::SortedSetFetchResponse;
 
 use crate::{
-    MomentoResult, {ErrorSource, MomentoError, MomentoErrorCode},
+    utils::return_unknown_error, ErrorSource, MomentoError, MomentoErrorCode, MomentoResult,
 };
 
 #[derive(Debug, PartialEq)]
@@ -18,7 +18,6 @@ pub enum SortedSetFetch {
 impl SortedSetFetch {
     pub(crate) fn from_fetch_response(response: SortedSetFetchResponse) -> MomentoResult<Self> {
         match response.sorted_set {
-            None => Ok(SortedSetFetch::Miss),
             Some(SortedSet::Missing(_)) => Ok(SortedSetFetch::Miss),
             Some(SortedSet::Found(elements)) => match elements.elements {
                 None => Ok(SortedSetFetch::Hit {
@@ -51,6 +50,10 @@ impl SortedSetFetch {
                     }),
                 },
             },
+            _ => Err(return_unknown_error(
+                "SortedSetFetch",
+                Some(format!("{:#?}", response)),
+            )),
         }
     }
 }

--- a/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
+++ b/src/cache/requests/sorted_set/sorted_set_fetch_response.rs
@@ -4,9 +4,7 @@ use momento_protos::cache_client::sorted_set_fetch_response::found::Elements;
 use momento_protos::cache_client::sorted_set_fetch_response::SortedSet;
 use momento_protos::cache_client::SortedSetFetchResponse;
 
-use crate::{
-    utils::return_unknown_error, ErrorSource, MomentoError, MomentoErrorCode, MomentoResult,
-};
+use crate::{ErrorSource, MomentoError, MomentoErrorCode, MomentoResult};
 
 #[derive(Debug, PartialEq)]
 pub enum SortedSetFetch {
@@ -50,7 +48,7 @@ impl SortedSetFetch {
                     }),
                 },
             },
-            _ => Err(return_unknown_error(
+            _ => Err(MomentoError::unknown_error(
                 "SortedSetFetch",
                 Some(format!("{:#?}", response)),
             )),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -72,6 +72,20 @@ pub struct MomentoError {
     pub details: Option<MomentoGrpcErrorDetails>,
 }
 
+impl MomentoError {
+    pub(crate) fn unknown_error(method_name: &str, details: Option<String>) -> Self {
+        Self {
+            message: "Unknown error has occurred, unable to parse ".to_string()
+                + method_name
+                + " : "
+                + details.as_deref().unwrap_or(""),
+            error_code: MomentoErrorCode::UnknownError,
+            inner_error: None,
+            details: None,
+        }
+    }
+}
+
 trait ErrorDetails {
     fn message(&self) -> &String;
     fn error_code(&self) -> &MomentoErrorCode;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -152,3 +152,15 @@ pub(crate) fn parse_string(raw: Vec<u8>) -> MomentoResult<String> {
         details: None,
     })
 }
+
+pub(crate) fn return_unknown_error(method_name: &str, details: Option<String>) -> MomentoError {
+    MomentoError {
+        message: "Unknown error has occurred, unable to parse ".to_string()
+            + method_name
+            + " : "
+            + details.as_deref().unwrap_or(""),
+        error_code: MomentoErrorCode::UnknownError,
+        inner_error: None,
+        details: None,
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -152,15 +152,3 @@ pub(crate) fn parse_string(raw: Vec<u8>) -> MomentoResult<String> {
         details: None,
     })
 }
-
-pub(crate) fn return_unknown_error(method_name: &str, details: Option<String>) -> MomentoError {
-    MomentoError {
-        message: "Unknown error has occurred, unable to parse ".to_string()
-            + method_name
-            + " : "
-            + details.as_deref().unwrap_or(""),
-        error_code: MomentoErrorCode::UnknownError,
-        inner_error: None,
-        details: None,
-    }
-}


### PR DESCRIPTION
Addresses https://github.com/momentohq/client-sdk-rust/issues/239

Also caught a couple instances where None was being caught but returned a Miss; updated those to return UnknownError as well