### PR TITLE
chore: extract lists of IntoBytes into an IntoBytesIterable trait

### DIFF
--- a/src/cache/requests/dictionary/dictionary_get_fields.rs
+++ b/src/cache/requests/dictionary/dictionary_get_fields.rs
@@ -1,7 +1,9 @@
 use super::dictionary_get_field::{DictionaryGetField, DictionaryGetFieldValue};
 use crate::cache::requests::MomentoRequest;
 use crate::utils::{parse_string, prep_request_with_timeout};
-use crate::{CacheClient, IntoBytes, MomentoError, MomentoErrorCode, MomentoResult};
+use crate::{
+    CacheClient, IntoBytes, IntoBytesIterable, MomentoError, MomentoErrorCode, MomentoResult,
+};
 use momento_protos::cache_client::{
     dictionary_get_response::Dictionary as DictionaryProto,
     DictionaryGetRequest as DictionaryGetRequestProto, ECacheResult,
@@ -52,14 +54,14 @@ use std::convert::{TryFrom, TryInto};
 /// # }
 /// ```
 #[derive(Debug, PartialEq, Eq)]
-pub struct DictionaryGetFieldsRequest<D: IntoBytes, F: IntoBytes + Clone> {
+pub struct DictionaryGetFieldsRequest<D: IntoBytes, F: IntoBytesIterable + Clone> {
     cache_name: String,
     dictionary_name: D,
-    fields: Vec<F>,
+    fields: F,
 }
 
-impl<D: IntoBytes, F: IntoBytes + Clone> DictionaryGetFieldsRequest<D, F> {
-    pub fn new(cache_name: impl Into<String>, dictionary_name: D, fields: Vec<F>) -> Self {
+impl<D: IntoBytes, F: IntoBytesIterable + Clone> DictionaryGetFieldsRequest<D, F> {
+    pub fn new(cache_name: impl Into<String>, dictionary_name: D, fields: F) -> Self {
         Self {
             cache_name: cache_name.into(),
             dictionary_name,
@@ -68,7 +70,9 @@ impl<D: IntoBytes, F: IntoBytes + Clone> DictionaryGetFieldsRequest<D, F> {
     }
 }
 
-impl<D: IntoBytes, F: IntoBytes + Clone> MomentoRequest for DictionaryGetFieldsRequest<D, F> {
+impl<D: IntoBytes, F: IntoBytesIterable + Clone> MomentoRequest
+    for DictionaryGetFieldsRequest<D, F>
+{
     type Response = DictionaryGetFields<F>;
 
     async fn send(self, cache_client: &CacheClient) -> MomentoResult<Self::Response> {
@@ -77,12 +81,7 @@ impl<D: IntoBytes, F: IntoBytes + Clone> MomentoRequest for DictionaryGetFieldsR
             cache_client.configuration.deadline_millis(),
             DictionaryGetRequestProto {
                 dictionary_name: self.dictionary_name.into_bytes(),
-                fields: self
-                    .fields
-                    .clone()
-                    .into_iter()
-                    .map(|field| field.into_bytes())
-                    .collect(),
+                fields: self.fields.clone().into_bytes(),
             },
         )?;
 
@@ -183,15 +182,15 @@ impl<D: IntoBytes, F: IntoBytes + Clone> MomentoRequest for DictionaryGetFieldsR
 /// ```
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum DictionaryGetFields<F: IntoBytes> {
+pub enum DictionaryGetFields<F: IntoBytesIterable> {
     Hit {
-        fields: Vec<F>,
+        fields: F,
         responses: Vec<DictionaryGetField>,
     },
     Miss,
 }
 
-impl Default for DictionaryGetFields<String> {
+impl<F: IntoBytes> Default for DictionaryGetFields<Vec<F>> {
     fn default() -> Self {
         DictionaryGetFields::Hit {
             fields: vec![],
@@ -200,7 +199,7 @@ impl Default for DictionaryGetFields<String> {
     }
 }
 
-impl<F: IntoBytes> TryFrom<DictionaryGetFields<F>> for HashMap<String, String> {
+impl<F: IntoBytesIterable> TryFrom<DictionaryGetFields<F>> for HashMap<String, String> {
     type Error = MomentoError;
 
     fn try_from(value: DictionaryGetFields<F>) -> Result<Self, Self::Error> {
@@ -209,7 +208,8 @@ impl<F: IntoBytes> TryFrom<DictionaryGetFields<F>> for HashMap<String, String> {
                 fields, responses, ..
             } => {
                 let mut result = HashMap::new();
-                for (field, response) in fields.into_iter().zip(responses.into_iter()) {
+                for (field, response) in fields.into_bytes().into_iter().zip(responses.into_iter())
+                {
                     match response {
                         DictionaryGetField::Hit { value } => {
                             let key: String = parse_string(field.into_bytes())?;
@@ -227,7 +227,7 @@ impl<F: IntoBytes> TryFrom<DictionaryGetFields<F>> for HashMap<String, String> {
     }
 }
 
-impl<F: IntoBytes> TryFrom<DictionaryGetFields<F>> for HashMap<Vec<u8>, Vec<u8>> {
+impl<F: IntoBytesIterable> TryFrom<DictionaryGetFields<F>> for HashMap<Vec<u8>, Vec<u8>> {
     type Error = MomentoError;
 
     fn try_from(value: DictionaryGetFields<F>) -> Result<Self, Self::Error> {
@@ -236,7 +236,8 @@ impl<F: IntoBytes> TryFrom<DictionaryGetFields<F>> for HashMap<Vec<u8>, Vec<u8>>
                 fields, responses, ..
             } => {
                 let mut result = HashMap::new();
-                for (field, response) in fields.into_iter().zip(responses.into_iter()) {
+                for (field, response) in fields.into_bytes().into_iter().zip(responses.into_iter())
+                {
                     match response {
                         DictionaryGetField::Hit { value } => {
                             result.insert(field.into_bytes(), value.into());

--- a/src/cache/requests/dictionary/dictionary_get_fields.rs
+++ b/src/cache/requests/dictionary/dictionary_get_fields.rs
@@ -134,7 +134,7 @@ impl<D: IntoBytes, F: IntoBytesIterable + Clone> MomentoRequest
 /// # use std::collections::HashMap;
 /// # use momento::cache::DictionaryGetFields;
 /// # use momento::MomentoResult;
-/// # let fetch_response = DictionaryGetFields::default();
+/// # let fetch_response: DictionaryGetFields<Vec<String>> = DictionaryGetFields::default();
 /// use std::convert::TryInto;
 /// let item: HashMap<String, String> = match fetch_response {
 ///   DictionaryGetFields::Hit { .. } => fetch_response.try_into().expect("I stored strings!"),
@@ -149,7 +149,7 @@ impl<D: IntoBytes, F: IntoBytesIterable + Clone> MomentoRequest
 /// # use std::collections::HashMap;
 /// # use momento::cache::DictionaryGetFields;
 /// # use momento::MomentoResult;
-/// # let fetch_response = DictionaryGetFields::default();
+/// # let fetch_response: DictionaryGetFields<Vec<String>> = DictionaryGetFields::default();
 /// use std::convert::TryInto;
 /// let item: HashMap<Vec<u8>, Vec<u8>> = match fetch_response {
 ///  DictionaryGetFields::Hit { .. } => fetch_response.try_into().expect("I stored raw bytes!"),
@@ -166,7 +166,7 @@ impl<D: IntoBytes, F: IntoBytesIterable + Clone> MomentoRequest
 /// # use std::collections::HashMap;
 /// # use momento::cache::DictionaryGetFields;
 /// # use momento::MomentoResult;
-/// # let fetch_response = DictionaryGetFields::default();
+/// # let fetch_response: DictionaryGetFields<Vec<String>> = DictionaryGetFields::default();
 /// use std::convert::TryInto;
 /// let item: MomentoResult<HashMap<String, String>> = fetch_response.try_into();
 /// ```
@@ -176,7 +176,7 @@ impl<D: IntoBytes, F: IntoBytesIterable + Clone> MomentoRequest
 /// # use std::collections::HashMap;
 /// # use momento::cache::DictionaryGetFields;
 /// # use momento::MomentoResult;
-/// # let fetch_response = DictionaryGetFields::default();
+/// # let fetch_response: DictionaryGetFields<Vec<String>> = DictionaryGetFields::default();
 /// use std::convert::TryInto;
 /// let item: MomentoResult<HashMap<Vec<u8>, Vec<u8>>> = fetch_response.try_into();
 /// ```

--- a/src/cache/requests/sorted_set/sorted_set_remove_elements.rs
+++ b/src/cache/requests/sorted_set/sorted_set_remove_elements.rs
@@ -3,7 +3,7 @@ use momento_protos::cache_client::SortedSetRemoveRequest;
 
 use crate::cache::requests::MomentoRequest;
 use crate::utils::prep_request_with_timeout;
-use crate::{CacheClient, IntoBytes, MomentoResult};
+use crate::{CacheClient, IntoBytes, IntoBytesIterable, MomentoResult};
 
 /// Remove multiple elements from the sorted set.
 ///
@@ -36,14 +36,14 @@ use crate::{CacheClient, IntoBytes, MomentoResult};
 /// # })
 /// # }
 /// ```
-pub struct SortedSetRemoveElementsRequest<S: IntoBytes, V: IntoBytes> {
+pub struct SortedSetRemoveElementsRequest<S: IntoBytes, V: IntoBytesIterable> {
     cache_name: String,
     sorted_set_name: S,
-    values: Vec<V>,
+    values: V,
 }
 
-impl<S: IntoBytes, V: IntoBytes> SortedSetRemoveElementsRequest<S, V> {
-    pub fn new(cache_name: impl Into<String>, sorted_set_name: S, values: Vec<V>) -> Self {
+impl<S: IntoBytes, V: IntoBytesIterable> SortedSetRemoveElementsRequest<S, V> {
+    pub fn new(cache_name: impl Into<String>, sorted_set_name: S, values: V) -> Self {
         Self {
             cache_name: cache_name.into(),
             sorted_set_name,
@@ -52,11 +52,11 @@ impl<S: IntoBytes, V: IntoBytes> SortedSetRemoveElementsRequest<S, V> {
     }
 }
 
-impl<S: IntoBytes, V: IntoBytes> MomentoRequest for SortedSetRemoveElementsRequest<S, V> {
+impl<S: IntoBytes, V: IntoBytesIterable> MomentoRequest for SortedSetRemoveElementsRequest<S, V> {
     type Response = SortedSetRemoveElements;
 
     async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetRemoveElements> {
-        let values = self.values.into_iter().map(|v| v.into_bytes()).collect();
+        let values = self.values.into_bytes();
         let set_name = self.sorted_set_name.into_bytes();
         let cache_name = &self.cache_name;
         let request = prep_request_with_timeout(

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -393,11 +393,11 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    pub async fn dictionary_get_fields<F: IntoBytes + Clone>(
+    pub async fn dictionary_get_fields<F: IntoBytesIterable + Clone>(
         &self,
         cache_name: impl Into<String>,
         dictionary_name: impl IntoBytes,
-        fields: Vec<F>,
+        fields: F,
     ) -> MomentoResult<DictionaryGetFields<F>> {
         let request = DictionaryGetFieldsRequest::new(cache_name, dictionary_name, fields);
         request.send(self).await

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -1858,7 +1858,7 @@ impl CacheClient {
         &self,
         cache_name: impl Into<String>,
         list_name: impl IntoBytes,
-        values: Vec<impl IntoBytes>,
+        values: impl IntoBytesIterable,
     ) -> MomentoResult<ListConcatenateBack> {
         let request = ListConcatenateBackRequest::new(cache_name, list_name, values);
         request.send(self).await

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -627,11 +627,11 @@ impl CacheClient {
     /// ```
     /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SetAddElementsRequest]
     /// which will allow you to set [optional arguments](SetAddElementsRequest#optional-arguments) as well.
-    pub async fn set_add_elements<E: IntoBytes>(
+    pub async fn set_add_elements<E: IntoBytesIterable>(
         &self,
         cache_name: impl Into<String>,
         set_name: impl IntoBytes,
-        elements: Vec<E>,
+        elements: E,
     ) -> MomentoResult<SetAddElements> {
         let request = SetAddElementsRequest::new(cache_name, set_name, elements);
         request.send(self).await

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -1808,7 +1808,7 @@ impl CacheClient {
         &self,
         cache_name: impl Into<String>,
         list_name: impl IntoBytes,
-        values: Vec<impl IntoBytes>,
+        values: impl IntoBytesIterable,
     ) -> MomentoResult<ListConcatenateFront> {
         let request = ListConcatenateFrontRequest::new(cache_name, list_name, values);
         request.send(self).await

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -475,11 +475,11 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    pub async fn dictionary_remove_fields<F: IntoBytes>(
+    pub async fn dictionary_remove_fields<F: IntoBytesIterable>(
         &self,
         cache_name: impl Into<String>,
         dictionary_name: impl IntoBytes,
-        fields: Vec<F>,
+        fields: F,
     ) -> MomentoResult<DictionaryRemoveFields> {
         let request = DictionaryRemoveFieldsRequest::new(cache_name, dictionary_name, fields);
         request.send(self).await

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -986,11 +986,11 @@ impl CacheClient {
     /// # }
     /// ```
     /// You can also use the [send_request](CacheClient::send_request) method to remove elements using a [SortedSetRemoveElementsRequest].
-    pub async fn sorted_set_remove_elements(
+    pub async fn sorted_set_remove_elements<V: IntoBytesIterable>(
         &self,
         cache_name: impl Into<String>,
         sorted_set_name: impl IntoBytes,
-        values: Vec<impl IntoBytes>,
+        values: V,
     ) -> MomentoResult<SortedSetRemoveElements> {
         let request = SortedSetRemoveElementsRequest::new(cache_name, sorted_set_name, values);
         request.send(self).await

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -33,6 +33,7 @@ use crate::cache::{
 use crate::grpc::header_interceptor::HeaderInterceptor;
 
 use crate::cache_client_builder::{CacheClientBuilder, NeedsDefaultTtl};
+use crate::utils::IntoBytesIterable;
 use crate::{utils, IntoBytes, MomentoResult};
 
 /// Client to perform operations on a Momento cache.
@@ -1175,7 +1176,7 @@ impl CacheClient {
     pub async fn keys_exist(
         &self,
         cache_name: impl Into<String>,
-        keys: Vec<impl IntoBytes>,
+        keys: impl IntoBytesIterable,
     ) -> MomentoResult<KeysExist> {
         let request = KeysExistRequest::new(cache_name, keys);
         request.send(self).await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,10 +22,10 @@ mod utils;
 pub use self::errors::*;
 pub use crate::credential_provider::CredentialProvider;
 pub use crate::response::simple_cache_client_sorted_set;
-pub use crate::simple_cache_client::{
-    Fields, IntoBytes, SimpleCacheClient, SimpleCacheClientBuilder,
-};
+pub use crate::simple_cache_client::{Fields, SimpleCacheClient, SimpleCacheClientBuilder};
 
 pub use crate::cache_client::CacheClient;
 
 pub type MomentoResult<T> = Result<T, MomentoError>;
+
+pub use crate::utils::IntoBytes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,4 +28,4 @@ pub use crate::cache_client::CacheClient;
 
 pub type MomentoResult<T> = Result<T, MomentoError>;
 
-pub use crate::utils::IntoBytes;
+pub use crate::utils::{IntoBytes, IntoBytesIterable};

--- a/src/simple_cache_client.rs
+++ b/src/simple_cache_client.rs
@@ -16,14 +16,6 @@ use std::ops::RangeBounds;
 use std::time::{Duration, UNIX_EPOCH};
 use tonic::{codegen::InterceptedService, transport::Channel, Request};
 
-use crate::response::{
-    DictionaryFetch, DictionaryGet, DictionaryPairs, Get, GetValue, ListCacheEntry, MomentoCache,
-    MomentoCreateSigningKeyResponse, MomentoDeleteResponse, MomentoDictionaryDeleteResponse,
-    MomentoDictionaryIncrementResponse, MomentoDictionarySetResponse, MomentoFlushCacheResponse,
-    MomentoListCacheResponse, MomentoListFetchResponse, MomentoListSigningKeyResult,
-    MomentoSetDifferenceResponse, MomentoSetFetchResponse, MomentoSetResponse, MomentoSigningKey,
-    MomentoSortedSetFetchResponse, SortedSetFetch,
-};
 use crate::utils;
 use crate::{
     cache::CollectionTtl,
@@ -38,19 +30,19 @@ use crate::{
     utils::{is_cache_name_valid, request_meta_data},
 };
 use crate::{grpc::header_interceptor::HeaderInterceptor, utils::connect_channel_lazily};
+use crate::{
+    response::{
+        DictionaryFetch, DictionaryGet, DictionaryPairs, Get, GetValue, ListCacheEntry,
+        MomentoCache, MomentoCreateSigningKeyResponse, MomentoDeleteResponse,
+        MomentoDictionaryDeleteResponse, MomentoDictionaryIncrementResponse,
+        MomentoDictionarySetResponse, MomentoFlushCacheResponse, MomentoListCacheResponse,
+        MomentoListFetchResponse, MomentoListSigningKeyResult, MomentoSetDifferenceResponse,
+        MomentoSetFetchResponse, MomentoSetResponse, MomentoSigningKey,
+        MomentoSortedSetFetchResponse, SortedSetFetch,
+    },
+    IntoBytes,
+};
 use crate::{utils::user_agent, MomentoResult};
-pub trait IntoBytes: Send {
-    fn into_bytes(self) -> Vec<u8>;
-}
-
-impl<T: Send> IntoBytes for T
-where
-    T: Into<Vec<u8>>,
-{
-    fn into_bytes(self) -> Vec<u8> {
-        self.into()
-    }
-}
 
 #[derive(Clone)]
 pub struct SimpleCacheClientBuilder {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -165,3 +165,16 @@ where
         self.into()
     }
 }
+
+pub trait IntoBytesIterable: Send {
+    fn into_bytes(self) -> Vec<Vec<u8>>;
+}
+
+impl<T: Send> IntoBytesIterable for Vec<T>
+where
+    T: IntoBytes,
+{
+    fn into_bytes(self) -> Vec<Vec<u8>> {
+        self.into_iter().map(|item| item.into_bytes()).collect()
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -153,6 +153,8 @@ pub(crate) fn parse_string(raw: Vec<u8>) -> MomentoResult<String> {
     })
 }
 
+/// Convenience trait for converting strings into bytes and allowing
+/// methods to accept either string or byte values.
 pub trait IntoBytes: Send {
     fn into_bytes(self) -> Vec<u8>;
 }
@@ -166,6 +168,8 @@ where
     }
 }
 
+/// Convenience trait for converting a list of IntoBytes items into
+/// a list of byte values.
 pub trait IntoBytesIterable: Send {
     fn into_bytes(self) -> Vec<Vec<u8>>;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -259,15 +259,15 @@ mod tests {
         assert_eq!(error.message, "Key ID cannot be empty");
     }
 
-    #[test]
-    fn test_connect_channel_lazily() {
+    #[tokio::test]
+    async fn test_connect_channel_lazily() {
         let uri_string = "http://localhost:50051";
         let result = connect_channel_lazily(uri_string);
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_connect_channel_lazily_configurable() {
+    #[tokio::test]
+    async fn test_connect_channel_lazily_configurable() {
         let uri_string = "http://localhost:50051";
         let grpc_config = GrpcConfiguration {
             keep_alive_while_idle: Some(true),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -152,3 +152,16 @@ pub(crate) fn parse_string(raw: Vec<u8>) -> MomentoResult<String> {
         details: None,
     })
 }
+
+pub trait IntoBytes: Send {
+    fn into_bytes(self) -> Vec<u8>;
+}
+
+impl<T: Send> IntoBytes for T
+where
+    T: Into<Vec<u8>>,
+{
+    fn into_bytes(self) -> Vec<u8> {
+        self.into()
+    }
+}

--- a/tests/cache/dictionary.rs
+++ b/tests/cache/dictionary.rs
@@ -328,7 +328,7 @@ mod dictionary_length {
             .dictionary_remove_fields(
                 cache_name,
                 item1.name(),
-                item1.value().keys().cloned().collect(),
+                item1.value().keys().cloned().collect::<Vec<_>>(),
             )
             .await?;
         assert_eq!(response, DictionaryRemoveFields {});

--- a/tests/cache/dictionary.rs
+++ b/tests/cache/dictionary.rs
@@ -92,7 +92,7 @@ mod dictionary_get_fields {
             .dictionary_get_fields(
                 cache_name,
                 item.name(),
-                item.value().keys().cloned().collect::<Vec<_>>(),
+                item.value().keys().cloned().collect::<Vec<String>>(),
             )
             .await?;
         match result {
@@ -158,7 +158,7 @@ mod dictionary_remove_fields {
             .dictionary_remove_fields(
                 cache_name,
                 item.name(),
-                item.value().keys().cloned().collect::<Vec<_>>(),
+                item.value().keys().cloned().collect::<Vec<String>>(),
             )
             .await?;
         assert_eq!(response, DictionaryRemoveFields {});
@@ -328,7 +328,7 @@ mod dictionary_length {
             .dictionary_remove_fields(
                 cache_name,
                 item1.name(),
-                item1.value().keys().cloned().collect::<Vec<_>>(),
+                item1.value().keys().cloned().collect::<Vec<String>>(),
             )
             .await?;
         assert_eq!(response, DictionaryRemoveFields {});

--- a/tests/cache/dictionary.rs
+++ b/tests/cache/dictionary.rs
@@ -158,7 +158,7 @@ mod dictionary_remove_fields {
             .dictionary_remove_fields(
                 cache_name,
                 item.name(),
-                item.value().keys().cloned().collect(),
+                item.value().keys().cloned().collect::<Vec<_>>(),
             )
             .await?;
         assert_eq!(response, DictionaryRemoveFields {});

--- a/tests/cache/dictionary.rs
+++ b/tests/cache/dictionary.rs
@@ -92,7 +92,7 @@ mod dictionary_get_fields {
             .dictionary_get_fields(
                 cache_name,
                 item.name(),
-                item.value().keys().cloned().collect(),
+                item.value().keys().cloned().collect::<Vec<_>>(),
             )
             .await?;
         match result {

--- a/tests/cache/key_existence.rs
+++ b/tests/cache/key_existence.rs
@@ -104,7 +104,10 @@ mod keys_exists {
             .await?;
 
         let result = client
-            .keys_exist(cache_name, items.iter().map(|item| item.key()).collect())
+            .keys_exist(
+                cache_name,
+                items.iter().map(|item| item.key()).collect::<Vec<_>>(),
+            )
             .await?;
 
         let keys_list: Vec<bool> = result.clone().into();

--- a/tests/cache/key_existence.rs
+++ b/tests/cache/key_existence.rs
@@ -106,7 +106,10 @@ mod keys_exists {
         let result = client
             .keys_exist(
                 cache_name,
-                items.iter().map(|item| item.key()).collect::<Vec<_>>(),
+                items
+                    .iter()
+                    .map(|item| item.key().to_string())
+                    .collect::<Vec<String>>(),
             )
             .await?;
 

--- a/tests/cache/list.rs
+++ b/tests/cache/list.rs
@@ -58,7 +58,11 @@ mod list_concatenate_back {
             .list_concatenate_back(
                 cache_name,
                 test_list.name(),
-                test_list.values().iter().map(|v| v.as_bytes()).collect(),
+                test_list
+                    .values()
+                    .iter()
+                    .map(|v| v.as_bytes())
+                    .collect::<Vec<_>>(),
             )
             .await?;
         assert_eq!(result, ListConcatenateBack {});

--- a/tests/cache/list.rs
+++ b/tests/cache/list.rs
@@ -43,7 +43,6 @@ mod list_concatenate_back {
         let cache_name = &CACHE_TEST_STATE.cache_name;
         let test_list = TestList::default();
 
-        // Concatenates string values
         let result = client
             .list_concatenate_back(cache_name, test_list.name(), test_list.values().to_vec())
             .await?;
@@ -51,24 +50,6 @@ mod list_concatenate_back {
         assert_list_eq(
             client.list_fetch(cache_name, test_list.name()).await?,
             test_list.values().to_vec(),
-        )?;
-
-        // Concatenates byte values
-        let result = client
-            .list_concatenate_back(
-                cache_name,
-                test_list.name(),
-                test_list
-                    .values()
-                    .iter()
-                    .map(|v| v.as_bytes())
-                    .collect::<Vec<_>>(),
-            )
-            .await?;
-        assert_eq!(result, ListConcatenateBack {});
-        assert_list_eq(
-            client.list_fetch(cache_name, test_list.name()).await?,
-            [test_list.values().to_vec(), test_list.values().to_vec()].concat(),
         )?;
 
         Ok(())
@@ -139,24 +120,6 @@ mod list_concatenate_front {
         assert_list_eq(
             client.list_fetch(cache_name, test_list.name()).await?,
             test_list.values().to_vec(),
-        )?;
-
-        // Concatenates byte values
-        let result = client
-            .list_concatenate_front(
-                cache_name,
-                test_list.name(),
-                test_list
-                    .values()
-                    .iter()
-                    .map(|v| v.as_bytes())
-                    .collect::<Vec<_>>(),
-            )
-            .await?;
-        assert_eq!(result, ListConcatenateFront {});
-        assert_list_eq(
-            client.list_fetch(cache_name, test_list.name()).await?,
-            [test_list.values().to_vec(), test_list.values().to_vec()].concat(),
         )?;
 
         Ok(())

--- a/tests/cache/list.rs
+++ b/tests/cache/list.rs
@@ -142,7 +142,11 @@ mod list_concatenate_front {
             .list_concatenate_front(
                 cache_name,
                 test_list.name(),
-                test_list.values().iter().map(|v| v.as_bytes()).collect(),
+                test_list
+                    .values()
+                    .iter()
+                    .map(|v| v.as_bytes())
+                    .collect::<Vec<_>>(),
             )
             .await?;
         assert_eq!(result, ListConcatenateFront {});


### PR DESCRIPTION
Addresses #245 

First pass at abstracting the `Vec<IntoBytes>` instances into `IntoBytesIterable`

Also moved `IntoBytes` out of the `simple_cache_client` file and into `utils` instead