### PR TITLE
feat: implement dictionary_remove_field

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -18,6 +18,9 @@ pub use requests::dictionary::dictionary_get_fields::{
     DictionaryGetFields, DictionaryGetFieldsRequest,
 };
 pub use requests::dictionary::dictionary_length::{DictionaryLength, DictionaryLengthRequest};
+pub use requests::dictionary::dictionary_remove_field::{
+    DictionaryRemoveField, DictionaryRemoveFieldRequest,
+};
 pub use requests::dictionary::dictionary_remove_fields::{
     DictionaryRemoveFields, DictionaryRemoveFieldsRequest,
 };

--- a/src/cache/requests/dictionary/dictionary_remove_field.rs
+++ b/src/cache/requests/dictionary/dictionary_remove_field.rs
@@ -1,0 +1,85 @@
+use crate::{
+    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoError,
+};
+use momento_protos::cache_client::{
+    dictionary_delete_request as DictionaryFieldSelector,
+    DictionaryDeleteRequest as DictionaryRemoveFieldsRequestProto,
+};
+
+/// Remove a field from a dictionary.
+///
+/// # Arguments
+/// * `cache_name` - The name of the cache containing the dictionary.
+/// * `dictionary_name` - The name of the dictionary to remove field from.
+/// * `field` - The field to remove.
+///
+/// # Examples
+/// Assumes that a CacheClient named `cache_client` has been created and is available.
+/// ```
+/// # fn main() -> anyhow::Result<()> {
+/// # use momento_test_util::create_doctest_cache_client;
+/// # tokio_test::block_on(async {
+/// use momento::cache::{DictionaryRemoveField, DictionaryRemoveFieldRequest};
+/// # let (cache_client, cache_name) = create_doctest_cache_client();
+/// let dictionary_name = "dictionary";
+/// let field = "field";
+///
+/// let remove_field_request = DictionaryRemoveFieldRequest::new(
+///   cache_name,
+///   dictionary_name,
+///   field
+/// );
+///
+/// match cache_client.send_request(remove_field_request).await {
+///   Ok(DictionaryRemoveField {}) => println!("Field removed from dictionary"),
+///   Err(e) => eprintln!("Error removing field from dictionary: {}", e),
+/// }
+/// # Ok(())
+/// # })
+/// # }
+/// ```
+pub struct DictionaryRemoveFieldRequest<D: IntoBytes, F: IntoBytes> {
+    cache_name: String,
+    dictionary_name: D,
+    field: F,
+}
+
+impl<D: IntoBytes, F: IntoBytes> DictionaryRemoveFieldRequest<D, F> {
+    pub fn new(cache_name: impl Into<String>, dictionary_name: D, field: F) -> Self {
+        Self {
+            cache_name: cache_name.into(),
+            dictionary_name,
+            field,
+        }
+    }
+}
+
+impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryRemoveFieldRequest<D, F> {
+    type Response = DictionaryRemoveField;
+
+    async fn send(self, cache_client: &CacheClient) -> Result<Self::Response, MomentoError> {
+        let fields_to_delete = DictionaryFieldSelector::Some {
+            fields: vec![self.field.into_bytes()],
+        };
+        let request = prep_request_with_timeout(
+            &self.cache_name,
+            cache_client.configuration.deadline_millis(),
+            DictionaryRemoveFieldsRequestProto {
+                dictionary_name: self.dictionary_name.into_bytes(),
+                delete: Some(DictionaryFieldSelector::Delete::Some(fields_to_delete)),
+            },
+        )?;
+
+        cache_client
+            .data_client
+            .clone()
+            .dictionary_delete(request)
+            .await?
+            .into_inner();
+
+        Ok(DictionaryRemoveField {})
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct DictionaryRemoveField {}

--- a/src/cache/requests/dictionary/mod.rs
+++ b/src/cache/requests/dictionary/mod.rs
@@ -2,6 +2,7 @@ pub mod dictionary_fetch;
 pub mod dictionary_get_field;
 pub mod dictionary_get_fields;
 pub mod dictionary_length;
+pub mod dictionary_remove_field;
 pub mod dictionary_remove_fields;
 pub mod dictionary_set_field;
 pub mod dictionary_set_fields;

--- a/src/cache_client.rs
+++ b/src/cache_client.rs
@@ -10,25 +10,25 @@ use crate::cache::{
     Configuration, CreateCache, CreateCacheRequest, DecreaseTtl, DecreaseTtlRequest, Delete,
     DeleteCache, DeleteCacheRequest, DeleteRequest, DictionaryFetch, DictionaryFetchRequest,
     DictionaryGetFields, DictionaryGetFieldsRequest, DictionaryLength, DictionaryLengthRequest,
-    DictionaryRemoveFields, DictionaryRemoveFieldsRequest, DictionarySetField,
-    DictionarySetFieldRequest, DictionarySetFields, DictionarySetFieldsRequest, FlushCache,
-    FlushCacheRequest, Get, GetRequest, IncreaseTtl, IncreaseTtlRequest, Increment,
-    IncrementRequest, IntoDictionaryFieldValuePairs, IntoSortedSetElements, ItemGetTtl,
-    ItemGetTtlRequest, ItemGetType, ItemGetTypeRequest, KeyExists, KeyExistsRequest, KeysExist,
-    KeysExistRequest, ListCaches, ListCachesRequest, ListConcatenateBack,
-    ListConcatenateBackRequest, ListConcatenateFront, ListConcatenateFrontRequest, ListFetch,
-    ListFetchRequest, ListLength, ListLengthRequest, ListPopBack, ListPopBackRequest, ListPopFront,
-    ListPopFrontRequest, ListRemoveValue, ListRemoveValueRequest, MomentoRequest, Set,
-    SetAddElements, SetAddElementsRequest, SetFetch, SetFetchRequest, SetIfAbsent,
-    SetIfAbsentOrEqual, SetIfAbsentOrEqualRequest, SetIfAbsentRequest, SetIfEqual,
-    SetIfEqualRequest, SetIfNotEqual, SetIfNotEqualRequest, SetIfPresent, SetIfPresentAndNotEqual,
-    SetIfPresentAndNotEqualRequest, SetIfPresentRequest, SetRemoveElements,
-    SetRemoveElementsRequest, SetRequest, SortedSetFetch, SortedSetFetchByRankRequest,
-    SortedSetFetchByScoreRequest, SortedSetGetRank, SortedSetGetRankRequest, SortedSetGetScore,
-    SortedSetGetScoreRequest, SortedSetLength, SortedSetLengthRequest, SortedSetOrder,
-    SortedSetPutElement, SortedSetPutElementRequest, SortedSetPutElements,
-    SortedSetPutElementsRequest, SortedSetRemoveElements, SortedSetRemoveElementsRequest,
-    UpdateTtl, UpdateTtlRequest,
+    DictionaryRemoveField, DictionaryRemoveFieldRequest, DictionaryRemoveFields,
+    DictionaryRemoveFieldsRequest, DictionarySetField, DictionarySetFieldRequest,
+    DictionarySetFields, DictionarySetFieldsRequest, FlushCache, FlushCacheRequest, Get,
+    GetRequest, IncreaseTtl, IncreaseTtlRequest, Increment, IncrementRequest,
+    IntoDictionaryFieldValuePairs, IntoSortedSetElements, ItemGetTtl, ItemGetTtlRequest,
+    ItemGetType, ItemGetTypeRequest, KeyExists, KeyExistsRequest, KeysExist, KeysExistRequest,
+    ListCaches, ListCachesRequest, ListConcatenateBack, ListConcatenateBackRequest,
+    ListConcatenateFront, ListConcatenateFrontRequest, ListFetch, ListFetchRequest, ListLength,
+    ListLengthRequest, ListPopBack, ListPopBackRequest, ListPopFront, ListPopFrontRequest,
+    ListRemoveValue, ListRemoveValueRequest, MomentoRequest, Set, SetAddElements,
+    SetAddElementsRequest, SetFetch, SetFetchRequest, SetIfAbsent, SetIfAbsentOrEqual,
+    SetIfAbsentOrEqualRequest, SetIfAbsentRequest, SetIfEqual, SetIfEqualRequest, SetIfNotEqual,
+    SetIfNotEqualRequest, SetIfPresent, SetIfPresentAndNotEqual, SetIfPresentAndNotEqualRequest,
+    SetIfPresentRequest, SetRemoveElements, SetRemoveElementsRequest, SetRequest, SortedSetFetch,
+    SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest, SortedSetGetRank,
+    SortedSetGetRankRequest, SortedSetGetScore, SortedSetGetScoreRequest, SortedSetLength,
+    SortedSetLengthRequest, SortedSetOrder, SortedSetPutElement, SortedSetPutElementRequest,
+    SortedSetPutElements, SortedSetPutElementsRequest, SortedSetRemoveElements,
+    SortedSetRemoveElementsRequest, UpdateTtl, UpdateTtlRequest,
 };
 use crate::grpc::header_interceptor::HeaderInterceptor;
 
@@ -438,7 +438,45 @@ impl CacheClient {
         let request = DictionaryLengthRequest::new(cache_name, dictionary_name);
         request.send(self).await
     }
-    // dictionary_remove_field
+
+    /// Removes a field from a dictionary.
+    /// If the dictionary or the field does not exist, a success response is returned.
+    ///
+    /// # Arguments
+    /// * `cache_name` - The name of the cache containing the dictionary.
+    /// * `dictionary_name` - The name of the dictionary to remove the field from.
+    /// * `field` - The field to remove.
+    ///
+    /// # Examples
+    /// Assumes that a CacheClient named `cache_client` has been created and is available.
+    /// ```
+    /// # fn main() -> anyhow::Result<()> {
+    /// # use momento_test_util::create_doctest_cache_client;
+    /// # tokio_test::block_on(async {
+    /// use momento::cache::{DictionaryRemoveField, DictionaryRemoveFieldRequest};
+    /// # let (cache_client, cache_name) = create_doctest_cache_client();
+    /// let dictionary_name = "dictionary";
+    /// let field = "field";
+    ///
+    /// let remove_field_response = cache_client.dictionary_remove_field(cache_name, dictionary_name, field).await;
+    ///
+    /// match remove_field_response {
+    ///   Ok(_) => println!("Field removed from dictionary"),
+    ///   Err(e) => eprintln!("Error removing field from dictionary: {}", e),
+    /// }
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
+    pub async fn dictionary_remove_field(
+        &self,
+        cache_name: impl Into<String>,
+        dictionary_name: impl IntoBytes,
+        field: impl IntoBytes,
+    ) -> MomentoResult<DictionaryRemoveField> {
+        let request = DictionaryRemoveFieldRequest::new(cache_name, dictionary_name, field);
+        request.send(self).await
+    }
 
     /// Removes fields from a dictionary.
     /// If the dictionary or any field does not exist, a success response is returned.

--- a/tests/cache/dictionary.rs
+++ b/tests/cache/dictionary.rs
@@ -1,6 +1,6 @@
 use momento::cache::{
-    DictionaryFetch, DictionaryGetFields, DictionaryLength, DictionaryRemoveFields,
-    DictionarySetField, DictionarySetFields,
+    DictionaryFetch, DictionaryGetFields, DictionaryLength, DictionaryRemoveField,
+    DictionaryRemoveFields, DictionarySetField, DictionarySetFields,
 };
 use momento::{MomentoError, MomentoErrorCode, MomentoResult};
 use momento_test_util::{
@@ -132,7 +132,65 @@ mod dictionary_get_fields {
 
 mod dictionary_increment {}
 
-mod dictionary_remove_field {}
+mod dictionary_remove_field {
+    use super::*;
+
+    #[tokio::test]
+    async fn happy_path() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+
+        let pair = (unique_key(), unique_value());
+        let item = TestDictionary {
+            name: unique_key(),
+            value: HashMap::from([pair.clone()]),
+        };
+
+        let response = client
+            .dictionary_set_fields(cache_name, item.name(), item.value().clone())
+            .await?;
+        assert_eq!(response, DictionarySetFields {});
+
+        let item2 = TestDictionary::new();
+        let response = client
+            .dictionary_set_fields(cache_name, item.name(), item2.value().clone())
+            .await?;
+        assert_eq!(response, DictionarySetFields {});
+
+        let response = client
+            .dictionary_remove_field(cache_name, item.name(), pair.0.clone())
+            .await?;
+        assert_eq!(response, DictionaryRemoveField {});
+
+        let result = client.dictionary_fetch(cache_name, item.name()).await?;
+        assert_fetched_dictionary_equals_test_data(result, &item2)?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn invalid_cache_name() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let result = client
+            .dictionary_remove_field("   ", "my-dictionary", "my-field")
+            .await
+            .unwrap_err();
+        assert_eq!(result.error_code, MomentoErrorCode::InvalidArgumentError);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn nonexistent_cache() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.client;
+        let cache_name = unique_cache_name();
+        let result = client
+            .dictionary_remove_field(cache_name, "my-dictionary", "my-field")
+            .await
+            .unwrap_err();
+
+        assert_eq!(result.error_code, MomentoErrorCode::NotFoundError);
+        Ok(())
+    }
+}
 
 mod dictionary_remove_fields {
     use super::*;


### PR DESCRIPTION
Add cache client command for `dictionary_remove_field`, request and
response types, integration tests, and docs.
