### PR TITLE
chore: port example to new sdk

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -8,8 +8,7 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-#momento = "0.15.0"
-momento = { path = "../" }
-tokio = { version = "1.18.2", features = ["full"] }
-uuid = { version = "1.2.2", features = ["v4"] }
 futures = "0.3.30"
+momento = { path = "../" }
+tokio = { version = "1.37.0", features = ["full"] }
+uuid = { version = "1.8.0", features = ["v4"] }

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 
 [dependencies]
 futures = "0.3.30"
-momento = { path = "../" }
+momento = "0.35.0"
 tokio = { version = "1.37.0", features = ["full"] }
 uuid = { version = "1.8.0", features = ["v4"] }


### PR DESCRIPTION
As part of the cutover to the new SDK, we port the example from using the old client to the new one.