### PR TITLE
chore: flush_cache test should create own cache

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,8 +94,6 @@ To run only the integration tests:
 MOMENTO_API_KEY=<api key> make test-integration
 ```
 
-Note: the flush_cache test runs separately from the other tests as all the integration tests share the same cache and flushing the cache when other tests are running concurrently creates a race condition and nondeterministic behavior.
-
 To run a single file of integration tests:
 
 ```

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,6 @@ test-doctests:
 .PHONY: test-integration
 ## Run integration tests
 test-integration:
-	# Reason for "--ignored":
-	# The flush_cache test first so as not to introduce a race condition that
-	# might cause the other tests to fail since they all use the same test cache.
-	cargo test --tests -- --ignored
 	cargo test --tests
 
 .PHONY: test

--- a/tests/cache/control.rs
+++ b/tests/cache/control.rs
@@ -63,7 +63,6 @@ mod flush_cache {
     // tests that all share the same cache. Flushing the cache when other tests are running concurrently creates
     // a race condition and nondeterministic behavior.
     #[tokio::test]
-    #[ignore]
     async fn flush_existing_cache_returns_success() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = &unique_cache_name();


### PR DESCRIPTION
Addresses #271 

Creating a separate cache for the flush_cache test so that we reserve the `--ignored` flag for test we may actually want to ignore down the road