### PR TITLE
chore: create examples for topics client

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 
 [dependencies]
 futures = "0.3.30"
-momento = "0.35.0"
+momento = "0.36.0"
 tokio = { version = "1.37.0", features = ["full"] }
 uuid = { version = "1.8.0", features = ["v4"] }

--- a/example/src/bin/topics_publisher.rs
+++ b/example/src/bin/topics_publisher.rs
@@ -1,0 +1,22 @@
+use momento::{CredentialProvider, MomentoError, TopicClient};
+
+#[tokio::main]
+async fn main() -> Result<(), MomentoError> {
+    let topic_client = TopicClient::connect(
+        CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())?,
+        None,
+    )
+    .expect("could not connect");
+
+    // publish 10 messages 1 second apart
+    for i in 0..10 {
+        let message = format!("Hello, Momento! {}", i);
+        topic_client
+            .publish("cache", "topic_name", &*message)
+            .await?;
+        println!("Published message: {}", message);
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    }
+
+    Ok(())
+}

--- a/example/src/bin/topics_subscriber.rs
+++ b/example/src/bin/topics_subscriber.rs
@@ -1,5 +1,5 @@
-use momento::{CredentialProvider, MomentoError, TopicClient};
 use futures::StreamExt;
+use momento::{CredentialProvider, MomentoError, TopicClient};
 
 #[tokio::main]
 async fn main() -> Result<(), MomentoError> {

--- a/example/src/bin/topics_subscriber.rs
+++ b/example/src/bin/topics_subscriber.rs
@@ -1,0 +1,24 @@
+use momento::{CredentialProvider, MomentoError, TopicClient};
+use futures::StreamExt;
+
+#[tokio::main]
+async fn main() -> Result<(), MomentoError> {
+    let topic_client = TopicClient::connect(
+        CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())?,
+        None,
+    )
+    .expect("could not connect");
+
+    // Make a subscription
+    let mut subscription = topic_client
+        .subscribe("cache", "topic_name", None)
+        .await
+        .expect("subscribe rpc failed");
+
+    // Consume the subscription
+    while let Some(item) = subscription.next().await {
+        println!("Received subscription item: {item:?}")
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
@malandis just putting this PR up to show the current state of the topics client. 

I think we'll probably want to:
- create basic config objects for the TopicClient
- replace `connect` with a `builder` method instead and remove the `user_application_name` parameter
- maybe remove the `resume_at_topic_sequence_number` from the `subscribe` method and create another function that accepts that argument? (sequence number is used only be the resubscribe method, not sure if an end user would ever need to provide that argument)

Thoughts? Anything else that might need to be updated?