### PR TITLE
feat: update the topic client for consistency with cache client

### DIFF
--- a/src/topics/config/configuration.rs
+++ b/src/topics/config/configuration.rs
@@ -1,0 +1,81 @@
+use std::time::Duration;
+
+use crate::config::transport_strategy::TransportStrategy;
+
+/// Configuration for a Momento Topics client.
+///
+/// Static, versioned configurations are provided for different environments:
+/// ```
+/// use momento::topics::configurations;
+///
+/// /// Use laptop for local development
+/// let developer_config = configurations::laptop::latest();
+///
+/// /// Use in_region for a typical server environment
+/// let server_config = configurations::in_region::latest();
+/// ```
+/// If you have specific requirements, configurations can also be constructed manually:
+/// ```
+/// use std::time::Duration;
+/// use momento::topics::Configuration;
+/// use momento::config::grpc_configuration::{GrpcConfiguration, GrpcConfigurationBuilder};
+/// use momento::config::transport_strategy::TransportStrategy;
+///
+/// let config = Configuration::builder()
+///     .transport_strategy(
+///         TransportStrategy::builder()
+///             .grpc_configuration(
+///                 GrpcConfiguration::builder()
+///                     .deadline(Duration::from_millis(1000))
+///             )
+///     );
+
+#[derive(Clone, Debug)]
+pub struct Configuration {
+    /// Low-level options for network interactions with Momento.
+    pub(crate) transport_strategy: TransportStrategy,
+}
+
+impl Configuration {
+    pub fn builder() -> ConfigurationBuilder<NeedsTransportStrategy> {
+        ConfigurationBuilder(NeedsTransportStrategy(()))
+    }
+
+    /// Returns the duration the client will wait before terminating an RPC with a DeadlineExceeded error.
+    pub fn deadline_millis(&self) -> Duration {
+        self.transport_strategy.grpc_configuration.deadline
+    }
+}
+
+pub struct ConfigurationBuilder<State>(State);
+
+pub struct NeedsTransportStrategy(());
+
+pub struct ReadyToBuild {
+    transport_strategy: TransportStrategy,
+}
+
+impl ConfigurationBuilder<NeedsTransportStrategy> {
+    pub fn transport_strategy(
+        self,
+        transport_strategy: impl Into<TransportStrategy>,
+    ) -> ConfigurationBuilder<ReadyToBuild> {
+        ConfigurationBuilder(ReadyToBuild {
+            transport_strategy: transport_strategy.into(),
+        })
+    }
+}
+
+impl ConfigurationBuilder<ReadyToBuild> {
+    pub fn build(self) -> Configuration {
+        Configuration {
+            transport_strategy: self.0.transport_strategy,
+        }
+    }
+}
+
+impl From<ConfigurationBuilder<ReadyToBuild>> for Configuration {
+    fn from(builder: ConfigurationBuilder<ReadyToBuild>) -> Configuration {
+        builder.build()
+    }
+}

--- a/src/topics/config/configurations.rs
+++ b/src/topics/config/configurations.rs
@@ -1,0 +1,94 @@
+/// Provides defaults suitable for a medium-to-high-latency dev environment. Permissive timeouts
+/// and relaxed latency and throughput targets.
+pub mod laptop {
+    use std::time::Duration;
+
+    use crate::config::grpc_configuration::GrpcConfiguration;
+    use crate::config::transport_strategy::TransportStrategy;
+    use crate::topics::Configuration;
+
+    /// Latest recommended config for a laptop development environment.
+    ///
+    /// NOTE: this config may change in future releases to take advantage of improvements
+    /// we identify for default configurations.
+    pub fn latest() -> impl Into<Configuration> {
+        Configuration::builder().transport_strategy(
+            TransportStrategy::builder().grpc_configuration(
+                GrpcConfiguration::builder()
+                    .deadline(Duration::from_millis(15000))
+                    .enable_keep_alives_with_defaults(),
+            ),
+        )
+    }
+}
+
+/// Provides defaults suitable for an environment where your client is running in the same
+/// region as the Momento service. It has more aggressive timeouts than the laptop config.
+pub mod in_region {
+    use std::time::Duration;
+
+    use crate::config::grpc_configuration::GrpcConfiguration;
+    use crate::config::transport_strategy::TransportStrategy;
+    use crate::topics::Configuration;
+
+    /// Latest recommended config for a typical in-region environment.
+    ///
+    /// NOTE: this config may change in future releases to take advantage of improvements
+    /// we identify for default configurations.
+    pub fn latest() -> impl Into<Configuration> {
+        Configuration::builder().transport_strategy(
+            TransportStrategy::builder().grpc_configuration(
+                GrpcConfiguration::builder()
+                    .deadline(Duration::from_millis(1100))
+                    .enable_keep_alives_with_defaults(),
+            ),
+        )
+    }
+}
+
+/// This config prioritizes keeping p99.9 latencies as low as possible, potentially sacrificing
+/// some throughput to achieve this. Use this config if low latency is more important in
+/// your application than topics availability.
+pub mod low_latency {
+    use std::time::Duration;
+
+    use crate::config::grpc_configuration::GrpcConfiguration;
+    use crate::config::transport_strategy::TransportStrategy;
+    use crate::topics::Configuration;
+
+    /// Latest recommended config for a low-latency environment.
+    ///
+    /// NOTE: this config may change in future releases to take advantage of improvements
+    /// we identify for default configurations.
+    pub fn latest() -> impl Into<Configuration> {
+        Configuration::builder().transport_strategy(
+            TransportStrategy::builder().grpc_configuration(
+                GrpcConfiguration::builder()
+                    .deadline(Duration::from_millis(500))
+                    .enable_keep_alives_with_defaults(),
+            ),
+        )
+    }
+}
+
+/// Provides defaults suitable for a typical lambda environment. It has more aggressive timeouts
+/// than the laptop config and does not check connection health with a keep-alive.
+pub mod lambda {
+    use std::time::Duration;
+
+    use crate::config::grpc_configuration::GrpcConfiguration;
+    use crate::config::transport_strategy::TransportStrategy;
+    use crate::topics::Configuration;
+
+    /// Latest recommended config for a typical lambda environment.
+    ///
+    /// NOTE: this config may change in future releases to take advantage of improvements
+    /// we identify for default configurations.
+    pub fn latest() -> impl Into<Configuration> {
+        Configuration::builder().transport_strategy(
+            TransportStrategy::builder().grpc_configuration(
+                GrpcConfiguration::builder().deadline(Duration::from_millis(1100)),
+            ),
+        )
+    }
+}

--- a/src/topics/config/mod.rs
+++ b/src/topics/config/mod.rs
@@ -1,0 +1,4 @@
+/// Configuration for the Momento Topics client.
+pub mod configuration;
+/// Pre-built configurations for the Momento Topics client.
+pub mod configurations;

--- a/src/topics/messages/mod.rs
+++ b/src/topics/messages/mod.rs
@@ -1,1 +1,7 @@
+pub mod publish;
+pub mod subscribe;
 pub mod subscription;
+
+mod momento_request;
+
+pub use momento_request::MomentoRequest;

--- a/src/topics/messages/momento_request.rs
+++ b/src/topics/messages/momento_request.rs
@@ -1,0 +1,16 @@
+use crate::MomentoResult;
+use crate::TopicClient;
+
+pub trait MomentoRequest {
+    type Response;
+
+    /// An internal fn that allows Momento request types to define their interaction with
+    /// the gRPC client. You can impl this fn for your own types if you'd like to hand them
+    /// to the Momento client directly, but that is not an explicitly supported scenario and
+    /// this signature may change a little over time. If that's okay with you, impl away!
+    #[doc(hidden)]
+    fn send(
+        self,
+        topic_client: &TopicClient,
+    ) -> impl std::future::Future<Output = MomentoResult<Self::Response>> + Send;
+}

--- a/src/topics/messages/publish.rs
+++ b/src/topics/messages/publish.rs
@@ -5,7 +5,19 @@ use crate::{
     MomentoResult, TopicClient,
 };
 
-/// TODO
+/// Publish a value to a topic.
+/// The cache is used as a namespace for your topics, and it needs to exist.
+/// You don't create topics, you just start using them.
+///
+/// # Arguments
+///
+/// * `cache_name` - The name of the cache to use as a namespace for the topic.
+/// * `topic` - The name of the topic to publish to.
+/// * `value` - The value to publish to the topic.
+///
+/// # Example
+///
+/// See [TopicClient] for an example.
 pub struct PublishRequest<V: IntoTopicValue> {
     cache_name: String,
     topic: String,

--- a/src/topics/messages/publish.rs
+++ b/src/topics/messages/publish.rs
@@ -1,0 +1,47 @@
+use momento_protos::cache_client::pubsub::TopicValue;
+
+use crate::{
+    topics::IntoTopicValue, topics::MomentoRequest, utils::prep_request_with_timeout,
+    MomentoResult, TopicClient,
+};
+
+/// TODO
+pub struct PublishRequest<V: IntoTopicValue> {
+    cache_name: String,
+    topic: String,
+    value: V,
+}
+
+impl<V: IntoTopicValue> PublishRequest<V> {
+    pub fn new(cache_name: impl Into<String>, topic: impl Into<String>, value: V) -> Self {
+        Self {
+            cache_name: cache_name.into(),
+            topic: topic.into(),
+            value,
+        }
+    }
+}
+
+impl<V: IntoTopicValue + std::marker::Send> MomentoRequest for PublishRequest<V> {
+    type Response = TopicPublish;
+
+    async fn send(self, topic_client: &TopicClient) -> MomentoResult<TopicPublish> {
+        let request = prep_request_with_timeout(
+            &self.cache_name.to_string(),
+            topic_client.configuration.deadline_millis(),
+            momento_protos::cache_client::pubsub::PublishRequest {
+                cache_name: self.cache_name,
+                topic: self.topic,
+                value: Some(TopicValue {
+                    kind: Some(self.value.into_topic_value()),
+                }),
+            },
+        )?;
+
+        let _ = topic_client.client.clone().publish(request).await?;
+        Ok(TopicPublish {})
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct TopicPublish {}

--- a/src/topics/messages/subscribe.rs
+++ b/src/topics/messages/subscribe.rs
@@ -1,0 +1,58 @@
+use crate::{
+    topics::{MomentoRequest, Subscription, SubscriptionState},
+    utils::prep_request_with_timeout,
+    MomentoResult, TopicClient,
+};
+
+/// TODO
+pub struct SubscriptionRequest {
+    cache_name: String,
+    topic: String,
+    resume_at_topic_sequence_number: Option<u64>,
+}
+
+impl SubscriptionRequest {
+    pub fn new(
+        cache_name: impl Into<String>,
+        topic: impl Into<String>,
+        resume_at_topic_sequence_number: Option<u64>,
+    ) -> Self {
+        Self {
+            cache_name: cache_name.into(),
+            topic: topic.into(),
+            resume_at_topic_sequence_number,
+        }
+    }
+}
+
+impl MomentoRequest for SubscriptionRequest {
+    type Response = Subscription;
+
+    async fn send(self, topic_client: &TopicClient) -> MomentoResult<Subscription> {
+        let request = prep_request_with_timeout(
+            &self.cache_name.to_string(),
+            topic_client.configuration.deadline_millis(),
+            momento_protos::cache_client::pubsub::SubscriptionRequest {
+                cache_name: self.cache_name.to_string(),
+                topic: self.topic.to_string(),
+                resume_at_topic_sequence_number: self
+                    .resume_at_topic_sequence_number
+                    .unwrap_or_default(),
+            },
+        )?;
+
+        let stream = topic_client
+            .client
+            .clone()
+            .subscribe(request)
+            .await?
+            .into_inner();
+        Ok(Subscription::new(
+            topic_client.client.clone(),
+            self.cache_name,
+            self.topic,
+            self.resume_at_topic_sequence_number.unwrap_or_default(),
+            SubscriptionState::Subscribed(stream),
+        ))
+    }
+}

--- a/src/topics/messages/subscribe.rs
+++ b/src/topics/messages/subscribe.rs
@@ -4,7 +4,22 @@ use crate::{
     MomentoResult, TopicClient,
 };
 
-/// TODO
+/// Subscribe to a topic.
+/// The cache is used as a namespace for your topics, and it needs to exist.
+/// You don't create topics, you just start using them.
+///
+/// # Arguments
+///
+/// * `cache_name` - The name of the cache to use as a namespace for the topic.
+/// * `topic` - The name of the topic to publish to.
+///
+/// # Optional Arguments
+///
+/// * `resume_at_topic_sequence_number` - The sequence number to resume from. If not provided, the subscription will start from the latest message or from zero if starting a new subscription.
+///
+/// # Example
+///
+/// See [TopicClient] for an example.
 pub struct SubscriptionRequest {
     cache_name: String,
     topic: String,

--- a/src/topics/messages/subscription.rs
+++ b/src/topics/messages/subscription.rs
@@ -1,8 +1,7 @@
 use futures::future::BoxFuture;
 use futures::{Future, FutureExt};
-use momento_protos::cache_client::pubsub::{
-    self, pubsub_client::PubsubClient, SubscriptionRequest,
-};
+use momento_protos::cache_client::pubsub::SubscriptionRequest;
+use momento_protos::cache_client::pubsub::{self, pubsub_client::PubsubClient};
 use tonic::{codegen::InterceptedService, transport::Channel};
 
 use crate::grpc::header_interceptor::HeaderInterceptor;

--- a/src/topics/mod.rs
+++ b/src/topics/mod.rs
@@ -1,5 +1,14 @@
 mod messages;
+pub use messages::publish::{PublishRequest, TopicPublish};
+pub use messages::subscribe::SubscriptionRequest;
 pub use messages::subscription::{IntoTopicValue, Subscription, SubscriptionState};
+pub use messages::MomentoRequest;
+
+mod config;
+
+pub use config::configuration::Configuration;
+pub use config::configurations;
 
 mod topic_client;
+mod topic_client_builder;
 pub use topic_client::TopicClient;

--- a/src/topics/topic_client.rs
+++ b/src/topics/topic_client.rs
@@ -1,20 +1,20 @@
-use momento_protos::cache_client::pubsub::{
-    self, pubsub_client::PubsubClient, PublishRequest, SubscriptionRequest,
-};
+use momento_protos::cache_client::pubsub;
 use tonic::{codegen::InterceptedService, transport::Channel};
 
-use crate::topics::{IntoTopicValue, Subscription, SubscriptionState};
-use crate::{
-    grpc::header_interceptor::HeaderInterceptor,
-    utils::{connect_channel_lazily, user_agent},
-    MomentoResult,
-};
-use crate::{CredentialProvider, MomentoError};
+use crate::grpc::header_interceptor::HeaderInterceptor;
+use crate::topics::messages::MomentoRequest;
+use crate::topics::topic_client_builder::{NeedsConfiguration, TopicClientBuilder};
+use crate::topics::{Configuration, IntoTopicValue, PublishRequest, Subscription};
+use crate::{MomentoError, MomentoResult};
+
+use crate::topics::messages::publish::TopicPublish;
+use crate::topics::messages::subscribe::SubscriptionRequest;
 
 type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
 
 pub struct TopicClient {
-    client: pubsub::pubsub_client::PubsubClient<ChannelType>,
+    pub(crate) client: pubsub::pubsub_client::PubsubClient<ChannelType>,
+    pub(crate) configuration: Configuration,
 }
 
 /// Work with topics, publishing and subscribing.
@@ -45,21 +45,9 @@ pub struct TopicClient {
 /// };
 /// ```
 impl TopicClient {
-    pub fn connect(
-        credential_provider: CredentialProvider,
-        user_application_name: Option<&str>,
-    ) -> MomentoResult<Self> {
-        let channel = connect_channel_lazily(&credential_provider.cache_endpoint)?;
-        let authorized_channel = InterceptedService::new(
-            channel,
-            HeaderInterceptor::new(
-                &credential_provider.auth_token,
-                &user_agent(user_application_name.unwrap_or("sdk")),
-            ),
-        );
-        Ok(Self {
-            client: pubsub::pubsub_client::PubsubClient::new(authorized_channel),
-        })
+    /* constructor */
+    pub fn builder() -> TopicClientBuilder<NeedsConfiguration> {
+        TopicClientBuilder(NeedsConfiguration(()))
     }
 
     /// Publish a value to a topic.
@@ -69,41 +57,10 @@ impl TopicClient {
         &self,
         cache_name: impl Into<String>,
         topic: impl Into<String>,
-        value: impl IntoTopicValue,
-    ) -> Result<(), MomentoError> {
-        TopicClient::actually_publish(&mut self.client.clone(), cache_name, topic, value).await
-    }
-
-    /// Publish a value to a topic.
-    /// The cache is used as a namespace for your topics, and it needs to exist.
-    /// You don't create topics, you just start using them.
-    ///
-    /// Use this if you have &mut, as it will save you a small amount of overhead for reusing the client.
-    pub async fn publish_mut(
-        &mut self,
-        cache_name: impl Into<String>,
-        topic: impl Into<String>,
-        value: impl IntoTopicValue,
-    ) -> Result<(), MomentoError> {
-        TopicClient::actually_publish(&mut self.client, cache_name, topic, value).await
-    }
-
-    async fn actually_publish(
-        client: &mut PubsubClient<ChannelType>,
-        cache_name: impl Into<String>,
-        topic: impl Into<String>,
-        value: impl IntoTopicValue,
-    ) -> Result<(), MomentoError> {
-        client
-            .publish(PublishRequest {
-                cache_name: cache_name.into(),
-                topic: topic.into(),
-                value: Some(pubsub::TopicValue {
-                    kind: Some(value.into_topic_value()),
-                }),
-            })
-            .await?;
-        Ok(())
+        value: impl IntoTopicValue + std::marker::Send,
+    ) -> MomentoResult<TopicPublish> {
+        let request = PublishRequest::new(cache_name, topic, value);
+        request.send(self).await
     }
 
     /// Subscribe to a topic.
@@ -113,38 +70,17 @@ impl TopicClient {
         &self,
         cache_name: impl Into<String> + Clone,
         topic: impl Into<String> + Clone,
-        resume_at_topic_sequence_number: Option<u64>,
     ) -> Result<Subscription, MomentoError> {
-        TopicClient::actually_subscribe(
-            self.client.clone(),
-            cache_name,
-            topic,
-            resume_at_topic_sequence_number,
-        )
-        .await
+        let request = SubscriptionRequest::new(cache_name, topic, None);
+        request.send(self).await
     }
 
-    async fn actually_subscribe(
-        mut client: PubsubClient<ChannelType>,
-        cache_name: impl Into<String> + Clone,
-        topic: impl Into<String> + Clone,
-        resume_at_topic_sequence_number: Option<u64>,
-    ) -> Result<Subscription, MomentoError> {
-        let tonic_stream = client
-            .subscribe(SubscriptionRequest {
-                cache_name: cache_name.clone().into(),
-                topic: topic.clone().into(),
-                resume_at_topic_sequence_number: resume_at_topic_sequence_number
-                    .unwrap_or_default(),
-            })
-            .await?
-            .into_inner();
-        Ok(Subscription::new(
-            client,
-            cache_name.into(),
-            topic.into(),
-            resume_at_topic_sequence_number.unwrap_or_default(),
-            SubscriptionState::Subscribed(tonic_stream),
-        ))
+    /// Lower-level API to send any type of MomentoRequest to the server. This is used for cases when
+    /// you want to set optional fields on a request that are not supported by the short-hand API for
+    /// that request type.
+    ///
+    /// See [SubscriptionRequest] for an example of creating a request with optional fields.
+    pub async fn send_request<R: MomentoRequest>(&self, request: R) -> MomentoResult<R::Response> {
+        request.send(self).await
     }
 }

--- a/src/topics/topic_client_builder.rs
+++ b/src/topics/topic_client_builder.rs
@@ -1,0 +1,60 @@
+use momento_protos::cache_client::pubsub::pubsub_client::PubsubClient;
+use tonic::service::interceptor::InterceptedService;
+
+use crate::{
+    grpc::header_interceptor::HeaderInterceptor,
+    topics::Configuration,
+    utils::{self, connect_channel_lazily},
+    CredentialProvider, MomentoResult, TopicClient,
+};
+
+pub struct TopicClientBuilder<State>(pub State);
+
+pub struct NeedsConfiguration(pub ());
+
+pub struct NeedsCredentialProvider {
+    configuration: Configuration,
+}
+
+pub struct ReadyToBuild {
+    configuration: Configuration,
+    credential_provider: CredentialProvider,
+}
+
+impl TopicClientBuilder<NeedsConfiguration> {
+    pub fn configuration(
+        self,
+        configuration: impl Into<Configuration>,
+    ) -> TopicClientBuilder<NeedsCredentialProvider> {
+        TopicClientBuilder(NeedsCredentialProvider {
+            configuration: configuration.into(),
+        })
+    }
+}
+
+impl TopicClientBuilder<NeedsCredentialProvider> {
+    pub fn credential_provider(
+        self,
+        credential_provider: CredentialProvider,
+    ) -> TopicClientBuilder<ReadyToBuild> {
+        TopicClientBuilder(ReadyToBuild {
+            configuration: self.0.configuration,
+            credential_provider,
+        })
+    }
+}
+
+impl TopicClientBuilder<ReadyToBuild> {
+    pub fn build(self) -> MomentoResult<TopicClient> {
+        let agent_value = &utils::user_agent("sdk");
+        let channel = connect_channel_lazily(&self.0.credential_provider.cache_endpoint)?;
+        let authorized_channel = InterceptedService::new(
+            channel,
+            HeaderInterceptor::new(&self.0.credential_provider.auth_token, agent_value),
+        );
+        Ok(TopicClient {
+            client: PubsubClient::new(authorized_channel),
+            configuration: self.0.configuration,
+        })
+    }
+}


### PR DESCRIPTION
Made edits based on https://github.com/momentohq/client-sdk-rust/pull/274

Adding integration tests for topics will require setting up a shared topics client, created a separate ticket for that: https://github.com/momentohq/client-sdk-rust/issues/277