### PR TITLE
feat: TopicClient follow-up revisions"

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -6,7 +6,7 @@ The Momento Rust SDK package is available on `crates.io`: [momento](https://crat
 
 You will need to install additional dependencies to make full use of our SDK:
 
-```
+```bash
 cargo add momento
 cargo add tokio --features full
 cargo add futures

--- a/README.template.md
+++ b/README.template.md
@@ -8,7 +8,7 @@ You will need to install additional dependencies to make full use of our SDK:
 
 ```
 cargo add momento
-cargo add tokio
+cargo add tokio --features full
 cargo add futures
 ```
 

--- a/README.template.md
+++ b/README.template.md
@@ -4,6 +4,16 @@
 
 The Momento Rust SDK package is available on `crates.io`: [momento](https://crates.io/crates/momento).
 
+You will need to install additional dependencies to make full use of our SDK:
+
+```
+cargo add momento
+cargo add tokio
+cargo add futures
+```
+
+Note: you will only need to install `futures` if you use Momento Topics.
+
 ## Usage
 
 Here is a quickstart you can use in your own project:

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 
 [dependencies]
 futures = "0.3.30"
-momento = "0.35.0"
+momento = "0.37.0"
 tokio = { version = "1.37.0", features = ["full"] }
 uuid = { version = "1.8.0", features = ["v4"] }

--- a/example/src/bin/docs_examples.rs
+++ b/example/src/bin/docs_examples.rs
@@ -721,11 +721,10 @@ pub async fn example_API_KeysExist(
 
 #[allow(non_snake_case)]
 pub fn example_API_InstantiateTopicClient() -> Result<(), MomentoError> {
-    let _topic_client = TopicClient::connect(
-        CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())?,
-        None,
-    )
-    .expect("could not connect");
+    let _topic_client = TopicClient::builder()
+        .configuration(momento::topics::configurations::laptop::latest())
+        .credential_provider(CredentialProvider::from_env_var("MOMENTO_API_KEY")?)
+        .build()?;
     Ok(())
 }
 
@@ -750,7 +749,7 @@ pub async fn example_API_TopicSubscribe(
 ) -> Result<(), MomentoError> {
     // Make a subscription
     let mut subscription = topic_client
-        .subscribe(cache_name, topic_name, None)
+        .subscribe(cache_name, topic_name)
         .await
         .expect("subscribe rpc failed");
 
@@ -836,11 +835,10 @@ pub async fn main() -> Result<(), MomentoError> {
 
     example_API_InstantiateTopicClient()?;
 
-    let topic_client = TopicClient::connect(
-        CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())?,
-        None,
-    )
-    .expect("TopicClient could not connect");
+    let topic_client = TopicClient::builder()
+        .configuration(momento::topics::configurations::laptop::latest())
+        .credential_provider(CredentialProvider::from_env_var("MOMENTO_API_KEY")?)
+        .build()?;
     let topic_name = format!("{}-{}", "docs-examples-topic", Uuid::new_v4());
 
     example_API_TopicPublish(&topic_client, &cache_name, &topic_name).await?;

--- a/example/src/bin/topics.rs
+++ b/example/src/bin/topics.rs
@@ -1,0 +1,44 @@
+use futures::StreamExt;
+use momento::topics::{configurations, TopicPublish};
+use momento::{CredentialProvider, MomentoError, MomentoErrorCode, MomentoResult, TopicClient};
+use tokio::task::JoinHandle;
+use tokio::time::sleep;
+
+#[tokio::main]
+async fn main() -> MomentoResult<()> {
+    let topic_client = TopicClient::builder()
+        .configuration(configurations::laptop::latest())
+        .credential_provider(CredentialProvider::from_env_var("MOMENTO_API_KEY")?)
+        .build()?;
+
+    let mut subscription = topic_client.subscribe("cache", "my-topic").await?;
+    let mut subscriber_handle: JoinHandle<MomentoResult<()>> = tokio::spawn(async move {
+        println!("Subscriber should do some work with the subscription!");
+        while let Some(message) = subscription.next().await {
+            println!("Received message: {:?}", message);
+        }
+        Ok(())
+    });
+
+    let publish_result = topic_client
+        .publish("cache", "my-topic", "Hello, World!")
+        .await?;
+    match publish_result {
+        TopicPublish {} => {
+            println!("Publish result is a TopicPublish!");
+        }
+    }
+    sleep(std::time::Duration::from_secs(5)).await;
+
+    // subscription.close().await?;
+    println!("Joining subscriber handle");
+    subscriber_handle.await.or(Err(MomentoError {
+        message: "Subscriber handle failed".to_string(),
+        error_code: MomentoErrorCode::UnknownError,
+        details: None,
+        inner_error: None,
+    }))??;
+    println!("Joined subscriber handle");
+
+    Ok(())
+}

--- a/src/topics/messages/publish.rs
+++ b/src/topics/messages/publish.rs
@@ -22,7 +22,6 @@ use crate::{
 /// # tokio_test::block_on(async {
 /// use momento::{CredentialProvider, TopicClient};
 /// use momento::topics::{TopicPublish, PublishRequest};
-/// use futures::StreamExt;
 ///
 /// let topic_client = TopicClient::builder()
 ///     .configuration(momento::topics::configurations::laptop::latest())

--- a/src/topics/messages/publish.rs
+++ b/src/topics/messages/publish.rs
@@ -28,7 +28,7 @@ use crate::{
 ///     .configuration(momento::topics::configurations::laptop::latest())
 ///     .credential_provider(
 ///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
-///             .expect("auth token should be valid"),
+///             .expect("API key should be valid"),
 ///     )
 ///     .build()?;
 ///

--- a/src/topics/messages/publish.rs
+++ b/src/topics/messages/publish.rs
@@ -17,7 +17,30 @@ use crate::{
 ///
 /// # Example
 ///
-/// See [TopicClient] for an example.
+/// ```
+/// # fn main() -> anyhow::Result<()> {
+/// # tokio_test::block_on(async {
+/// use momento::{CredentialProvider, TopicClient};
+/// use momento::topics::{TopicPublish, PublishRequest};
+/// use futures::StreamExt;
+///
+/// let topic_client = TopicClient::builder()
+///     .configuration(momento::topics::configurations::laptop::latest())
+///     .credential_provider(
+///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
+///             .expect("auth token should be valid"),
+///     )
+///     .build()?;
+///
+/// // Publish to a topic
+/// let request = PublishRequest::new("cache", "topic", "value");
+/// match topic_client.send_request(request).await? {
+///     TopicPublish {} => println!("Published message!"),
+/// }
+/// # Ok(())
+/// # })
+/// # }
+/// ```
 pub struct PublishRequest<V: IntoTopicValue> {
     cache_name: String,
     topic: String,

--- a/src/topics/messages/subscribe.rs
+++ b/src/topics/messages/subscribe.rs
@@ -48,6 +48,8 @@ use crate::{
 /// # })
 /// # }
 /// ```
+/// 
+/// Learn more about how to use a Momento Topics [Subscription].
 pub struct SubscribeRequest {
     cache_name: String,
     topic: String,

--- a/src/topics/messages/subscribe.rs
+++ b/src/topics/messages/subscribe.rs
@@ -48,7 +48,7 @@ use crate::{
 /// # })
 /// # }
 /// ```
-/// 
+///
 /// Learn more about how to use a Momento Topics [Subscription].
 pub struct SubscribeRequest {
     cache_name: String,

--- a/src/topics/messages/subscribe.rs
+++ b/src/topics/messages/subscribe.rs
@@ -19,7 +19,35 @@ use crate::{
 ///
 /// # Example
 ///
-/// See [TopicClient] for an example.
+/// ```no_run
+/// # fn main() -> anyhow::Result<()> {
+/// # tokio_test::block_on(async {
+/// use momento::{CredentialProvider, TopicClient};
+/// use futures::StreamExt;
+/// use momento::topics::{SubscribeRequest};
+///
+/// let topic_client = TopicClient::builder()
+///     .configuration(momento::topics::configurations::laptop::latest())
+///     .credential_provider(
+///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
+///             .expect("auth token should be valid"),
+///     )
+///     .build()?;
+///
+/// // Subscribe to a topic and resume from sequence number 10
+/// let request = SubscribeRequest::new("cache", "topic", Some(10));
+///
+/// // Note: your subscription must be declared as `mut`!
+/// let mut subscription = topic_client.send_request(request).await?;
+///
+/// // Consume messages from the subscription using `next()`
+/// while let Some(message) = subscription.next().await {
+///    println!("Received message: {:?}", message);
+/// }
+/// # Ok(())
+/// # })
+/// # }
+/// ```
 pub struct SubscribeRequest {
     cache_name: String,
     topic: String,

--- a/src/topics/messages/subscribe.rs
+++ b/src/topics/messages/subscribe.rs
@@ -20,13 +20,13 @@ use crate::{
 /// # Example
 ///
 /// See [TopicClient] for an example.
-pub struct SubscriptionRequest {
+pub struct SubscribeRequest {
     cache_name: String,
     topic: String,
     resume_at_topic_sequence_number: Option<u64>,
 }
 
-impl SubscriptionRequest {
+impl SubscribeRequest {
     pub fn new(
         cache_name: impl Into<String>,
         topic: impl Into<String>,
@@ -40,7 +40,7 @@ impl SubscriptionRequest {
     }
 }
 
-impl MomentoRequest for SubscriptionRequest {
+impl MomentoRequest for SubscribeRequest {
     type Response = Subscription;
 
     async fn send(self, topic_client: &TopicClient) -> MomentoResult<Subscription> {

--- a/src/topics/messages/subscribe.rs
+++ b/src/topics/messages/subscribe.rs
@@ -24,13 +24,13 @@ use crate::{
 /// # tokio_test::block_on(async {
 /// use momento::{CredentialProvider, TopicClient};
 /// use futures::StreamExt;
-/// use momento::topics::{SubscribeRequest};
+/// use momento::topics::SubscribeRequest;
 ///
 /// let topic_client = TopicClient::builder()
 ///     .configuration(momento::topics::configurations::laptop::latest())
 ///     .credential_provider(
 ///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
-///             .expect("auth token should be valid"),
+///             .expect("API key should be valid"),
 ///     )
 ///     .build()?;
 ///

--- a/src/topics/messages/subscription.rs
+++ b/src/topics/messages/subscription.rs
@@ -25,7 +25,7 @@ type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
 /// # tokio_test::block_on(async {
 /// use momento::{CredentialProvider, TopicClient};
 /// use futures::StreamExt;
-/// 
+///
 /// let topic_client = TopicClient::builder()
 ///     .configuration(momento::topics::configurations::laptop::latest())
 ///     .credential_provider(
@@ -33,7 +33,7 @@ type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
 ///             .expect("auth token should be valid"),
 ///     )
 ///     .build()?;
-/// 
+///
 /// let mut subscription = topic_client.subscribe("cache", "my-topic").await?;
 /// let subscriber_handle = tokio::spawn(async move {
 ///     println!("Subscriber should keep receiving until thread is killed");
@@ -44,7 +44,7 @@ type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
 ///
 /// tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 /// subscriber_handle.abort();
-/// 
+///
 /// # Ok(())
 /// # })
 /// # }
@@ -56,7 +56,7 @@ type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
 /// # tokio_test::block_on(async {
 /// use momento::{CredentialProvider, TopicClient};
 /// use futures::StreamExt;
-/// 
+///
 /// let topic_client = TopicClient::builder()
 ///     .configuration(momento::topics::configurations::laptop::latest())
 ///     .credential_provider(
@@ -64,7 +64,7 @@ type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
 ///             .expect("auth token should be valid"),
 ///     )
 ///     .build()?;
-/// 
+///
 /// let mut subscription = topic_client.subscribe("cache", "my-topic").await?;
 /// tokio::spawn(async move {
 ///     println!("Subscriber should receive 10 messages then exist");

--- a/src/topics/messages/subscription.rs
+++ b/src/topics/messages/subscription.rs
@@ -30,7 +30,7 @@ type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
 ///     .configuration(momento::topics::configurations::laptop::latest())
 ///     .credential_provider(
 ///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
-///             .expect("auth token should be valid"),
+///             .expect("API key should be valid"),
 ///     )
 ///     .build()?;
 ///
@@ -61,7 +61,7 @@ type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
 ///     .configuration(momento::topics::configurations::laptop::latest())
 ///     .credential_provider(
 ///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
-///             .expect("auth token should be valid"),
+///             .expect("API key should be valid"),
 ///     )
 ///     .build()?;
 ///

--- a/src/topics/mod.rs
+++ b/src/topics/mod.rs
@@ -1,7 +1,7 @@
 mod messages;
 pub use messages::publish::{PublishRequest, TopicPublish};
 pub use messages::subscribe::SubscribeRequest;
-pub use messages::subscription::{IntoTopicValue, Subscription, SubscriptionState};
+pub use messages::subscription::*;
 pub use messages::MomentoRequest;
 
 mod config;

--- a/src/topics/mod.rs
+++ b/src/topics/mod.rs
@@ -1,6 +1,6 @@
 mod messages;
 pub use messages::publish::{PublishRequest, TopicPublish};
-pub use messages::subscribe::SubscriptionRequest;
+pub use messages::subscribe::SubscribeRequest;
 pub use messages::subscription::{IntoTopicValue, Subscription, SubscriptionState};
 pub use messages::MomentoRequest;
 

--- a/src/topics/topic_client.rs
+++ b/src/topics/topic_client.rs
@@ -8,7 +8,7 @@ use crate::topics::{Configuration, IntoTopicValue, PublishRequest, Subscription}
 use crate::{MomentoError, MomentoResult};
 
 use crate::topics::messages::publish::TopicPublish;
-use crate::topics::messages::subscribe::SubscriptionRequest;
+use crate::topics::messages::subscribe::SubscribeRequest;
 
 type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
 
@@ -101,7 +101,7 @@ impl TopicClient {
         cache_name: impl Into<String> + Clone,
         topic: impl Into<String> + Clone,
     ) -> Result<Subscription, MomentoError> {
-        let request = SubscriptionRequest::new(cache_name, topic, None);
+        let request = SubscribeRequest::new(cache_name, topic, None);
         request.send(self).await
     }
 
@@ -109,7 +109,7 @@ impl TopicClient {
     /// you want to set optional fields on a request that are not supported by the short-hand API for
     /// that request type.
     ///
-    /// See [SubscriptionRequest] for an example of creating a request with optional fields.
+    /// See [SubscribeRequest] for an example of creating a request with optional fields.
     pub async fn send_request<R: MomentoRequest>(&self, request: R) -> MomentoResult<R::Response> {
         request.send(self).await
     }

--- a/src/topics/topic_client.rs
+++ b/src/topics/topic_client.rs
@@ -26,7 +26,7 @@ type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
 ///     .configuration(momento::topics::configurations::laptop::latest())
 ///     .credential_provider(
 ///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
-///             .expect("auth token should be valid"),
+///             .expect("API key should be valid"),
 ///     )
 ///     .build()
 /// {
@@ -64,14 +64,14 @@ impl TopicClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # tokio_test::block_on(async {
     /// use momento::{CredentialProvider, TopicClient};
-    /// use momento::topics::{TopicPublish};
+    /// use momento::topics::TopicPublish;
     /// use futures::StreamExt;
     ///
     /// let topic_client = TopicClient::builder()
     ///     .configuration(momento::topics::configurations::laptop::latest())
     ///     .credential_provider(
     ///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
-    ///             .expect("auth token should be valid"),
+    ///             .expect("API key should be valid"),
     ///     )
     ///     .build()?;
     ///
@@ -114,7 +114,7 @@ impl TopicClient {
     ///     .configuration(momento::topics::configurations::laptop::latest())
     ///     .credential_provider(
     ///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
-    ///             .expect("auth token should be valid"),
+    ///             .expect("API key should be valid"),
     ///     )
     ///     .build()?;
     ///

--- a/src/topics/topic_client.rs
+++ b/src/topics/topic_client.rs
@@ -20,7 +20,6 @@ type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
 /// # fn main() -> anyhow::Result<()> {
 /// # tokio_test::block_on(async {
 /// use momento::{CredentialProvider, TopicClient};
-/// use futures::StreamExt;
 ///
 /// let topic_client = match TopicClient::builder()
 ///     .configuration(momento::topics::configurations::laptop::latest())
@@ -65,7 +64,6 @@ impl TopicClient {
     /// # tokio_test::block_on(async {
     /// use momento::{CredentialProvider, TopicClient};
     /// use momento::topics::TopicPublish;
-    /// use futures::StreamExt;
     ///
     /// let topic_client = TopicClient::builder()
     ///     .configuration(momento::topics::configurations::laptop::latest())

--- a/src/topics/topic_client.rs
+++ b/src/topics/topic_client.rs
@@ -12,11 +12,6 @@ use crate::topics::messages::subscribe::SubscribeRequest;
 
 type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
 
-pub struct TopicClient {
-    pub(crate) client: pubsub::pubsub_client::PubsubClient<ChannelType>,
-    pub(crate) configuration: Configuration,
-}
-
 /// Client to work with Momento Topics, the pub/sub service.
 ///
 /// # Example
@@ -42,6 +37,11 @@ pub struct TopicClient {
 /// # })
 /// # }
 /// ```
+pub struct TopicClient {
+    pub(crate) client: pubsub::pubsub_client::PubsubClient<ChannelType>,
+    pub(crate) configuration: Configuration,
+}
+
 impl TopicClient {
     /* constructor */
     pub fn builder() -> TopicClientBuilder<NeedsConfiguration> {

--- a/src/topics/topic_client.rs
+++ b/src/topics/topic_client.rs
@@ -129,6 +129,8 @@ impl TopicClient {
     /// # })
     /// # }
     /// ```
+    ///
+    /// Learn more about how to use a Momento Topics [Subscription].
     pub async fn subscribe(
         &self,
         cache_name: impl Into<String> + Clone,

--- a/src/topics/topic_client.rs
+++ b/src/topics/topic_client.rs
@@ -20,7 +20,8 @@ pub struct TopicClient {
 /// Client to work with Momento Topics, the pub/sub service.
 ///
 /// # Example
-/// ```no_run
+///
+/// ```
 /// # fn main() -> anyhow::Result<()> {
 /// # tokio_test::block_on(async {
 /// use momento::{CredentialProvider, TopicClient};
@@ -37,16 +38,6 @@ pub struct TopicClient {
 ///     Ok(client) => client,
 ///     Err(err) => panic!("{err}"),
 /// };
-///
-/// // Publish to a topic
-/// topic_client.publish("cache", "topic", "value").await?;
-///
-/// // Subscribe to a topic and print received messages
-/// let mut subscription = topic_client.subscribe("cache", "topic").await?;
-/// while let Some(message) = subscription.next().await {
-///    println!("Received message: {:?}", message);
-/// }
-///
 /// # Ok(())
 /// # })
 /// # }
@@ -69,7 +60,29 @@ impl TopicClient {
     ///
     /// # Example
     ///
-    /// See [TopicClient] for an example.
+    /// ```
+    /// # fn main() -> anyhow::Result<()> {
+    /// # tokio_test::block_on(async {
+    /// use momento::{CredentialProvider, TopicClient};
+    /// use momento::topics::{TopicPublish};
+    /// use futures::StreamExt;
+    ///
+    /// let topic_client = TopicClient::builder()
+    ///     .configuration(momento::topics::configurations::laptop::latest())
+    ///     .credential_provider(
+    ///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
+    ///             .expect("auth token should be valid"),
+    ///     )
+    ///     .build()?;
+    ///
+    /// // Publish to a topic
+    /// match topic_client.publish("cache", "topic", "value").await? {
+    ///     TopicPublish {} => println!("Published message!"),
+    /// }
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
     pub async fn publish(
         &self,
         cache_name: impl Into<String>,
@@ -89,13 +102,33 @@ impl TopicClient {
     /// * `cache_name` - The name of the cache to use as a namespace for the topic.
     /// * `topic` - The name of the topic to publish to.
     ///
-    /// # Optional Arguments
-    ///
-    /// * `resume_at_topic_sequence_number` - The sequence number to resume from. If not provided, the subscription will start from the latest message or from zero if starting a new subscription.
-    ///
     /// # Example
     ///
-    /// See [TopicClient] for an example.
+    /// ```no_run
+    /// # fn main() -> anyhow::Result<()> {
+    /// # tokio_test::block_on(async {
+    /// use momento::{CredentialProvider, TopicClient};
+    /// use futures::StreamExt;
+    ///
+    /// let topic_client = TopicClient::builder()
+    ///     .configuration(momento::topics::configurations::laptop::latest())
+    ///     .credential_provider(
+    ///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
+    ///             .expect("auth token should be valid"),
+    ///     )
+    ///     .build()?;
+    ///
+    /// // Subscribe to a topic. Note: your subscription must be declared as `mut`!
+    /// let mut subscription = topic_client.subscribe("cache", "topic").await?;
+    ///
+    /// // Consume messages from the subscription using `next()`
+    /// while let Some(message) = subscription.next().await {
+    ///    println!("Received message: {:?}", message);
+    /// }
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
     pub async fn subscribe(
         &self,
         cache_name: impl Into<String> + Clone,


### PR DESCRIPTION
Addresses https://github.com/momentohq/client-sdk-rust/issues/275

- rename SubscriptionRequest -> SubscribeRequest for consistency
- update readme template to include installing tokio and futures
- make sure all Subscription-related objects are exported
- add more examples in docstrings
- update dev docs examples
- add topics example file
