### PR TITLE
refactor: declare structs for pre-built configurations

### DIFF
--- a/scripts/test-setup.rs
+++ b/scripts/test-setup.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use momento::cache::configurations;
+use momento::cache::configurations::{self, PrebuiltConfiguration};
 use momento::{CacheClient, MomentoResult};
 use momento_test_util::{get_test_cache_name, get_test_credential_provider};
 
@@ -12,7 +12,7 @@ async fn main() -> MomentoResult<()> {
 
     let cache_client = CacheClient::builder()
         .default_ttl(Duration::from_secs(5))
-        .configuration(configurations::laptop::latest())
+        .configuration(configurations::Laptop::latest())
         .credential_provider(credential_provider)
         .build()?;
 

--- a/scripts/test-setup.rs
+++ b/scripts/test-setup.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use momento::cache::configurations::{self, PrebuiltConfiguration};
+use momento::cache::configurations;
 use momento::{CacheClient, MomentoResult};
 use momento_test_util::{get_test_cache_name, get_test_credential_provider};
 

--- a/scripts/test-teardown.rs
+++ b/scripts/test-teardown.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use momento::cache::configurations;
+use momento::cache::configurations::{self, PrebuiltConfiguration};
 use momento::CacheClient;
 use momento_test_util::{get_test_cache_name, get_test_credential_provider};
 
@@ -11,7 +11,7 @@ async fn main() {
 
     let cache_client = CacheClient::builder()
         .default_ttl(Duration::from_secs(5))
-        .configuration(configurations::laptop::latest())
+        .configuration(configurations::Laptop::latest())
         .credential_provider(credential_provider)
         .build()
         .expect("cache client cannot be created");

--- a/scripts/test-teardown.rs
+++ b/scripts/test-teardown.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use momento::cache::configurations::{self, PrebuiltConfiguration};
+use momento::cache::configurations;
 use momento::CacheClient;
 use momento_test_util::{get_test_cache_name, get_test_credential_provider};
 

--- a/src/cache/config/configuration.rs
+++ b/src/cache/config/configuration.rs
@@ -9,10 +9,10 @@ use crate::config::transport_strategy::TransportStrategy;
 /// use momento::cache::configurations;
 ///
 /// /// Use laptop for local development
-/// let developer_config = configurations::laptop::latest();
+/// let developer_config = configurations::Laptop::latest();
 ///
 /// /// Use in_region for a typical server environment
-/// let server_config = configurations::in_region::latest();
+/// let server_config = configurations::InRegion::latest();
 /// ```
 /// If you have specific requirements, configurations can also be constructed manually:
 /// ```

--- a/src/cache/config/configurations.rs
+++ b/src/cache/config/configurations.rs
@@ -4,33 +4,27 @@ use crate::cache::Configuration;
 use crate::config::grpc_configuration::GrpcConfiguration;
 use crate::config::transport_strategy::TransportStrategy;
 
-/// A trait representing prebuilt configurations.
-pub trait PrebuiltConfiguration {
+/// Provides defaults suitable for a medium-to-high-latency dev environment. Permissive timeouts
+/// and relaxed latency and throughput targets.
+pub struct Laptop {}
+
+impl Laptop {
     /// Returns the latest prebuilt configuration.
     /// This is the recommended configuration for most users.
     ///
     /// NOTE: this config may change in future releases to take advantage of improvements
     /// we identify for default configurations.
-    fn latest() -> impl Into<Configuration>;
+    #[allow(dead_code)]
+    pub fn latest() -> impl Into<Configuration> {
+        Laptop::v1()
+    }
 
     /// Returns the v1 prebuilt configuration.
     ///
     /// Versioning the prebuilt configurations allows users to opt-in to changes in the default
     /// configurations. This is useful for users who want to ensure that their application's
     /// behavior does not change unexpectedly.
-    fn v1() -> impl Into<Configuration>;
-}
-
-/// Provides defaults suitable for a medium-to-high-latency dev environment. Permissive timeouts
-/// and relaxed latency and throughput targets.
-pub struct Laptop {}
-
-impl PrebuiltConfiguration for Laptop {
-    fn latest() -> impl Into<Configuration> {
-        Laptop::v1()
-    }
-
-    fn v1() -> impl Into<Configuration> {
+    pub fn v1() -> impl Into<Configuration> {
         Configuration::builder().transport_strategy(
             TransportStrategy::builder().grpc_configuration(
                 GrpcConfiguration::builder()
@@ -45,12 +39,24 @@ impl PrebuiltConfiguration for Laptop {
 /// region as the Momento service. It has more aggressive timeouts than the laptop config.
 pub struct InRegion {}
 
-impl PrebuiltConfiguration for InRegion {
-    fn latest() -> impl Into<Configuration> {
+impl InRegion {
+    /// Returns the latest prebuilt configuration.
+    /// This is the recommended configuration for most users.
+    ///
+    /// NOTE: this config may change in future releases to take advantage of improvements
+    /// we identify for default configurations.
+    #[allow(dead_code)]
+    pub fn latest() -> impl Into<Configuration> {
         InRegion::v1()
     }
 
-    fn v1() -> impl Into<Configuration> {
+    /// Returns the v1 prebuilt configuration.
+    ///
+    /// Versioning the prebuilt configurations allows users to opt-in to changes in the default
+    /// configurations. This is useful for users who want to ensure that their application's
+    /// behavior does not change unexpectedly.
+    #[allow(dead_code)]
+    pub fn v1() -> impl Into<Configuration> {
         Configuration::builder().transport_strategy(
             TransportStrategy::builder().grpc_configuration(
                 GrpcConfiguration::builder()
@@ -66,12 +72,23 @@ impl PrebuiltConfiguration for InRegion {
 /// your application than cache availability.
 pub struct LowLatency {}
 
-impl PrebuiltConfiguration for LowLatency {
-    fn latest() -> impl Into<Configuration> {
+impl LowLatency {
+    /// Returns the latest prebuilt configuration.
+    /// This is the recommended configuration for most users.
+    ///
+    /// NOTE: this config may change in future releases to take advantage of improvements
+    /// we identify for default configurations.
+    #[allow(dead_code)]
+    pub fn latest() -> impl Into<Configuration> {
         LowLatency::v1()
     }
 
-    fn v1() -> impl Into<Configuration> {
+    /// Returns the v1 prebuilt configuration.
+    ///
+    /// Versioning the prebuilt configurations allows users to opt-in to changes in the default
+    /// configurations. This is useful for users who want to ensure that their application's
+    /// behavior does not change unexpectedly.
+    pub fn v1() -> impl Into<Configuration> {
         Configuration::builder().transport_strategy(
             TransportStrategy::builder().grpc_configuration(
                 GrpcConfiguration::builder()
@@ -94,16 +111,22 @@ impl PrebuiltConfiguration for LowLatency {
 /// Therefore, keep-alives should be disabled in lambda and similar environments.
 pub struct Lambda {}
 
-impl PrebuiltConfiguration for Lambda {
+impl Lambda {
     /// Latest recommended config for a typical lambda environment.
     ///
     /// NOTE: this config may change in future releases to take advantage of improvements
     /// we identify for default configurations.
-    fn latest() -> impl Into<Configuration> {
+    #[allow(dead_code)]
+    pub fn latest() -> impl Into<Configuration> {
         Lambda::v1()
     }
 
-    fn v1() -> impl Into<Configuration> {
+    /// Returns the v1 prebuilt configuration.
+    ///
+    /// Versioning the prebuilt configurations allows users to opt-in to changes in the default
+    /// configurations. This is useful for users who want to ensure that their application's
+    /// behavior does not change unexpectedly.
+    pub fn v1() -> impl Into<Configuration> {
         Configuration::builder().transport_strategy(
             TransportStrategy::builder().grpc_configuration(
                 GrpcConfiguration::builder().deadline(Duration::from_millis(1100)),

--- a/src/cache/config/configurations.rs
+++ b/src/cache/config/configurations.rs
@@ -1,17 +1,36 @@
-/// Provides defaults suitable for a medium-to-high-latency dev environment. Permissive timeouts
-/// and relaxed latency and throughput targets.
-pub mod laptop {
-    use std::time::Duration;
+use std::time::Duration;
 
-    use crate::cache::Configuration;
-    use crate::config::grpc_configuration::GrpcConfiguration;
-    use crate::config::transport_strategy::TransportStrategy;
+use crate::cache::Configuration;
+use crate::config::grpc_configuration::GrpcConfiguration;
+use crate::config::transport_strategy::TransportStrategy;
 
-    /// Latest recommended config for a laptop development environment.
+/// A trait representing prebuilt configurations.
+pub trait PrebuiltConfiguration {
+    /// Returns the latest prebuilt configuration.
+    /// This is the recommended configuration for most users.
     ///
     /// NOTE: this config may change in future releases to take advantage of improvements
     /// we identify for default configurations.
-    pub fn latest() -> impl Into<Configuration> {
+    fn latest() -> impl Into<Configuration>;
+
+    /// Returns the v1 prebuilt configuration.
+    ///
+    /// Versioning the prebuilt configurations allows users to opt-in to changes in the default
+    /// configurations. This is useful for users who want to ensure that their application's
+    /// behavior does not change unexpectedly.
+    fn v1() -> impl Into<Configuration>;
+}
+
+/// Provides defaults suitable for a medium-to-high-latency dev environment. Permissive timeouts
+/// and relaxed latency and throughput targets.
+pub struct Laptop {}
+
+impl PrebuiltConfiguration for Laptop {
+    fn latest() -> impl Into<Configuration> {
+        Laptop::v1()
+    }
+
+    fn v1() -> impl Into<Configuration> {
         Configuration::builder().transport_strategy(
             TransportStrategy::builder().grpc_configuration(
                 GrpcConfiguration::builder()
@@ -24,18 +43,14 @@ pub mod laptop {
 
 /// Provides defaults suitable for an environment where your client is running in the same
 /// region as the Momento service. It has more aggressive timeouts than the laptop config.
-pub mod in_region {
-    use std::time::Duration;
+pub struct InRegion {}
 
-    use crate::cache::Configuration;
-    use crate::config::grpc_configuration::GrpcConfiguration;
-    use crate::config::transport_strategy::TransportStrategy;
+impl PrebuiltConfiguration for InRegion {
+    fn latest() -> impl Into<Configuration> {
+        InRegion::v1()
+    }
 
-    /// Latest recommended config for a typical in-region environment.
-    ///
-    /// NOTE: this config may change in future releases to take advantage of improvements
-    /// we identify for default configurations.
-    pub fn latest() -> impl Into<Configuration> {
+    fn v1() -> impl Into<Configuration> {
         Configuration::builder().transport_strategy(
             TransportStrategy::builder().grpc_configuration(
                 GrpcConfiguration::builder()
@@ -49,18 +64,14 @@ pub mod in_region {
 /// This config prioritizes keeping p99.9 latencies as low as possible, potentially sacrificing
 /// some throughput to achieve this. Use this config if low latency is more important in
 /// your application than cache availability.
-pub mod low_latency {
-    use std::time::Duration;
+pub struct LowLatency {}
 
-    use crate::cache::Configuration;
-    use crate::config::grpc_configuration::GrpcConfiguration;
-    use crate::config::transport_strategy::TransportStrategy;
+impl PrebuiltConfiguration for LowLatency {
+    fn latest() -> impl Into<Configuration> {
+        LowLatency::v1()
+    }
 
-    /// Latest recommended config for a low-latency environment.
-    ///
-    /// NOTE: this config may change in future releases to take advantage of improvements
-    /// we identify for default configurations.
-    pub fn latest() -> impl Into<Configuration> {
+    fn v1() -> impl Into<Configuration> {
         Configuration::builder().transport_strategy(
             TransportStrategy::builder().grpc_configuration(
                 GrpcConfiguration::builder()
@@ -71,20 +82,28 @@ pub mod low_latency {
     }
 }
 
-/// Provides defaults suitable for a typical lambda environment. It has more aggressive timeouts
-/// than the laptop config and does not check connection health with a keep-alive.
-pub mod lambda {
-    use std::time::Duration;
+/// This config optimizes for lambda environments.
+///
+/// In addition to the in region settings of [InRegion], this
+/// disables keep-alives.
+///
+/// NOTE: keep-alives are very important for long-lived server environments where there may be periods of time
+/// when the connection is idle. However, they are very problematic for lambda environments where the lambda
+/// runtime is continuously frozen and unfrozen, because the lambda may be frozen before the "ACK" is received
+/// from the server. This can cause the keep-alive to timeout even though the connection is completely healthy.
+/// Therefore, keep-alives should be disabled in lambda and similar environments.
+pub struct Lambda {}
 
-    use crate::cache::Configuration;
-    use crate::config::grpc_configuration::GrpcConfiguration;
-    use crate::config::transport_strategy::TransportStrategy;
-
+impl PrebuiltConfiguration for Lambda {
     /// Latest recommended config for a typical lambda environment.
     ///
     /// NOTE: this config may change in future releases to take advantage of improvements
     /// we identify for default configurations.
-    pub fn latest() -> impl Into<Configuration> {
+    fn latest() -> impl Into<Configuration> {
+        Lambda::v1()
+    }
+
+    fn v1() -> impl Into<Configuration> {
         Configuration::builder().transport_strategy(
             TransportStrategy::builder().grpc_configuration(
                 GrpcConfiguration::builder().deadline(Duration::from_millis(1100)),

--- a/src/topics/config/configuration.rs
+++ b/src/topics/config/configuration.rs
@@ -9,10 +9,10 @@ use crate::config::transport_strategy::TransportStrategy;
 /// use momento::topics::configurations;
 ///
 /// /// Use laptop for local development
-/// let developer_config = configurations::laptop::latest();
+/// let developer_config = configurations::Laptop::latest();
 ///
 /// /// Use in_region for a typical server environment
-/// let server_config = configurations::in_region::latest();
+/// let server_config = configurations::Region::latest();
 /// ```
 /// If you have specific requirements, configurations can also be constructed manually:
 /// ```

--- a/src/topics/config/configuration.rs
+++ b/src/topics/config/configuration.rs
@@ -12,7 +12,7 @@ use crate::config::transport_strategy::TransportStrategy;
 /// let developer_config = configurations::Laptop::latest();
 ///
 /// /// Use in_region for a typical server environment
-/// let server_config = configurations::Region::latest();
+/// let server_config = configurations::InRegion::latest();
 /// ```
 /// If you have specific requirements, configurations can also be constructed manually:
 /// ```

--- a/src/topics/config/configurations.rs
+++ b/src/topics/config/configurations.rs
@@ -1,17 +1,28 @@
+use std::time::Duration;
+
+use crate::config::grpc_configuration::GrpcConfiguration;
+use crate::config::transport_strategy::TransportStrategy;
+use crate::topics::Configuration;
+
 /// Provides defaults suitable for a medium-to-high-latency dev environment. Permissive timeouts
 /// and relaxed latency and throughput targets.
-pub mod laptop {
-    use std::time::Duration;
+pub struct Laptop {}
 
-    use crate::config::grpc_configuration::GrpcConfiguration;
-    use crate::config::transport_strategy::TransportStrategy;
-    use crate::topics::Configuration;
-
+impl Laptop {
     /// Latest recommended config for a laptop development environment.
     ///
     /// NOTE: this config may change in future releases to take advantage of improvements
     /// we identify for default configurations.
     pub fn latest() -> impl Into<Configuration> {
+        Laptop::v1()
+    }
+
+    /// Returns the v1 prebuilt configuration.
+    ///
+    /// Versioning the prebuilt configurations allows users to opt-in to changes in the default
+    /// configurations. This is useful for users who want to ensure that their application's
+    /// behavior does not change unexpectedly.
+    pub fn v1() -> impl Into<Configuration> {
         Configuration::builder().transport_strategy(
             TransportStrategy::builder().grpc_configuration(
                 GrpcConfiguration::builder()
@@ -24,18 +35,24 @@ pub mod laptop {
 
 /// Provides defaults suitable for an environment where your client is running in the same
 /// region as the Momento service. It has more aggressive timeouts than the laptop config.
-pub mod in_region {
-    use std::time::Duration;
+pub struct InRegion {}
 
-    use crate::config::grpc_configuration::GrpcConfiguration;
-    use crate::config::transport_strategy::TransportStrategy;
-    use crate::topics::Configuration;
-
+impl InRegion {
     /// Latest recommended config for a typical in-region environment.
     ///
     /// NOTE: this config may change in future releases to take advantage of improvements
     /// we identify for default configurations.
     pub fn latest() -> impl Into<Configuration> {
+        InRegion::v1()
+    }
+
+    /// Returns the v1 prebuilt configuration.
+    ///
+    /// Versioning the prebuilt configurations allows users to opt-in to changes in the default
+    /// configurations. This is useful for users who want to ensure that their application's
+    /// behavior does not change unexpectedly.
+    #[allow(dead_code)]
+    pub fn v1() -> impl Into<Configuration> {
         Configuration::builder().transport_strategy(
             TransportStrategy::builder().grpc_configuration(
                 GrpcConfiguration::builder()
@@ -49,18 +66,23 @@ pub mod in_region {
 /// This config prioritizes keeping p99.9 latencies as low as possible, potentially sacrificing
 /// some throughput to achieve this. Use this config if low latency is more important in
 /// your application than topics availability.
-pub mod low_latency {
-    use std::time::Duration;
+pub struct LowLatency {}
 
-    use crate::config::grpc_configuration::GrpcConfiguration;
-    use crate::config::transport_strategy::TransportStrategy;
-    use crate::topics::Configuration;
-
+impl LowLatency {
     /// Latest recommended config for a low-latency environment.
     ///
     /// NOTE: this config may change in future releases to take advantage of improvements
     /// we identify for default configurations.
     pub fn latest() -> impl Into<Configuration> {
+        LowLatency::v1()
+    }
+
+    /// Returns the v1 prebuilt configuration.
+    ///
+    /// Versioning the prebuilt configurations allows users to opt-in to changes in the default
+    /// configurations. This is useful for users who want to ensure that their application's
+    /// behavior does not change unexpectedly.
+    pub fn v1() -> impl Into<Configuration> {
         Configuration::builder().transport_strategy(
             TransportStrategy::builder().grpc_configuration(
                 GrpcConfiguration::builder()
@@ -73,18 +95,26 @@ pub mod low_latency {
 
 /// Provides defaults suitable for a typical lambda environment. It has more aggressive timeouts
 /// than the laptop config and does not check connection health with a keep-alive.
-pub mod lambda {
-    use std::time::Duration;
+pub struct Lambda {}
 
-    use crate::config::grpc_configuration::GrpcConfiguration;
-    use crate::config::transport_strategy::TransportStrategy;
-    use crate::topics::Configuration;
-
+impl Lambda {
     /// Latest recommended config for a typical lambda environment.
     ///
     /// NOTE: this config may change in future releases to take advantage of improvements
     /// we identify for default configurations.
     pub fn latest() -> impl Into<Configuration> {
+        Lambda::v1()
+    }
+
+    /// Returns the v1 prebuilt configuration.
+    ///
+    /// Versioning the prebuilt configurations allows users to opt-in to changes in the default
+    /// configurations. This is useful for users who want to ensure that their application's
+    /// behavior does not change unexpectedly.
+    /// This is useful for users who want to ensure that their application's behavior does not
+    /// change unexpectedly.
+    #[allow(dead_code)]
+    pub fn v1() -> impl Into<Configuration> {
         Configuration::builder().transport_strategy(
             TransportStrategy::builder().grpc_configuration(
                 GrpcConfiguration::builder().deadline(Duration::from_millis(1100)),

--- a/src/topics/messages/publish.rs
+++ b/src/topics/messages/publish.rs
@@ -21,10 +21,10 @@ use crate::{
 /// # fn main() -> anyhow::Result<()> {
 /// # tokio_test::block_on(async {
 /// use momento::{CredentialProvider, TopicClient};
-/// use momento::topics::{TopicPublish, PublishRequest};
+/// use momento::topics::{configurations, TopicPublish, PublishRequest};
 ///
 /// let topic_client = TopicClient::builder()
-///     .configuration(momento::topics::configurations::laptop::latest())
+///     .configuration(configurations::Laptop::latest())
 ///     .credential_provider(
 ///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
 ///             .expect("API key should be valid"),

--- a/src/topics/messages/subscribe.rs
+++ b/src/topics/messages/subscribe.rs
@@ -24,10 +24,10 @@ use crate::{
 /// # tokio_test::block_on(async {
 /// use momento::{CredentialProvider, TopicClient};
 /// use futures::StreamExt;
-/// use momento::topics::SubscribeRequest;
+/// use momento::topics::{configurations , SubscribeRequest};
 ///
 /// let topic_client = TopicClient::builder()
-///     .configuration(momento::topics::configurations::laptop::latest())
+///     .configuration(configurations::Laptop::latest())
 ///     .credential_provider(
 ///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
 ///             .expect("API key should be valid"),

--- a/src/topics/messages/subscription.rs
+++ b/src/topics/messages/subscription.rs
@@ -23,11 +23,11 @@ type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
 /// ```no_run
 /// # fn main() -> anyhow::Result<()> {
 /// # tokio_test::block_on(async {
-/// use momento::{CredentialProvider, TopicClient};
+/// use momento::{topics::configurations, CredentialProvider, TopicClient};
 /// use futures::StreamExt;
 ///
 /// let topic_client = TopicClient::builder()
-///     .configuration(momento::topics::configurations::laptop::latest())
+///     .configuration(configurations::Laptop::latest())
 ///     .credential_provider(
 ///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
 ///             .expect("API key should be valid"),
@@ -54,11 +54,11 @@ type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
 /// ```no_run
 /// # fn main() -> anyhow::Result<()> {
 /// # tokio_test::block_on(async {
-/// use momento::{CredentialProvider, TopicClient};
+/// use momento::{topics::configurations, CredentialProvider, TopicClient};
 /// use futures::StreamExt;
 ///
 /// let topic_client = TopicClient::builder()
-///     .configuration(momento::topics::configurations::laptop::latest())
+///     .configuration(configurations::Laptop::latest())
 ///     .credential_provider(
 ///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
 ///             .expect("API key should be valid"),

--- a/src/topics/topic_client.rs
+++ b/src/topics/topic_client.rs
@@ -19,10 +19,10 @@ type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
 /// ```
 /// # fn main() -> anyhow::Result<()> {
 /// # tokio_test::block_on(async {
-/// use momento::{CredentialProvider, TopicClient};
+/// use momento::{topics::configurations, CredentialProvider, TopicClient};
 ///
 /// let topic_client = match TopicClient::builder()
-///     .configuration(momento::topics::configurations::Laptop::latest())
+///     .configuration(configurations::Laptop::latest())
 ///     .credential_provider(
 ///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
 ///             .expect("API key should be valid"),
@@ -63,10 +63,10 @@ impl TopicClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # tokio_test::block_on(async {
     /// use momento::{CredentialProvider, TopicClient};
-    /// use momento::topics::TopicPublish;
+    /// use momento::topics::{configurations, TopicPublish};
     ///
     /// let topic_client = TopicClient::builder()
-    ///     .configuration(momento::topics::configurations::laptop::latest())
+    ///     .configuration(configurations::Laptop::latest())
     ///     .credential_provider(
     ///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
     ///             .expect("API key should be valid"),
@@ -105,11 +105,11 @@ impl TopicClient {
     /// ```no_run
     /// # fn main() -> anyhow::Result<()> {
     /// # tokio_test::block_on(async {
-    /// use momento::{CredentialProvider, TopicClient};
+    /// use momento::{topics::configurations, CredentialProvider, TopicClient};
     /// use futures::StreamExt;
     ///
     /// let topic_client = TopicClient::builder()
-    ///     .configuration(momento::topics::configurations::laptop::latest())
+    ///     .configuration(configurations::Laptop::latest())
     ///     .credential_provider(
     ///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
     ///             .expect("API key should be valid"),

--- a/src/topics/topic_client.rs
+++ b/src/topics/topic_client.rs
@@ -27,7 +27,7 @@ pub struct TopicClient {
 /// use futures::StreamExt;
 ///
 /// let topic_client = match TopicClient::builder()
-///     .configuration(momento::topics::configurations::laptop::latest())
+///     .configuration(momento::topics::configurations::Laptop::latest())
 ///     .credential_provider(
 ///         CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
 ///             .expect("auth token should be valid"),

--- a/test-util/src/cache_test_state.rs
+++ b/test-util/src/cache_test_state.rs
@@ -6,7 +6,7 @@ use once_cell::sync::Lazy;
 use tokio::sync::watch::channel;
 
 use crate::{get_test_cache_name, get_test_credential_provider};
-use momento::cache::configurations;
+use momento::cache::configurations::{self, PrebuiltConfiguration};
 use momento::CacheClient;
 
 pub static CACHE_TEST_STATE: Lazy<Arc<CacheTestState>> =
@@ -39,7 +39,7 @@ impl CacheTestState {
         runtime.spawn(async move {
             let cache_client = CacheClient::builder()
                 .default_ttl(Duration::from_secs(5))
-                .configuration(configurations::laptop::latest())
+                .configuration(configurations::Laptop::latest())
                 .credential_provider(credential_provider)
                 .build()
                 .expect("Failed to create cache client");

--- a/test-util/src/cache_test_state.rs
+++ b/test-util/src/cache_test_state.rs
@@ -6,7 +6,7 @@ use once_cell::sync::Lazy;
 use tokio::sync::watch::channel;
 
 use crate::{get_test_cache_name, get_test_credential_provider};
-use momento::cache::configurations::{self, PrebuiltConfiguration};
+use momento::cache::configurations;
 use momento::CacheClient;
 
 pub static CACHE_TEST_STATE: Lazy<Arc<CacheTestState>> =

--- a/test-util/src/test_utils.rs
+++ b/test-util/src/test_utils.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::future::Future;
 use std::time::Duration;
 
-use momento::cache::configurations::{self, PrebuiltConfiguration};
+use momento::cache::configurations;
 use momento::CacheClient;
 use momento::CredentialProvider;
 

--- a/test-util/src/test_utils.rs
+++ b/test-util/src/test_utils.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::future::Future;
 use std::time::Duration;
 
-use momento::cache::configurations;
+use momento::cache::configurations::{self, PrebuiltConfiguration};
 use momento::CacheClient;
 use momento::CredentialProvider;
 
@@ -64,7 +64,7 @@ pub fn build_cache_client_and_credential_provider() -> (CacheClient, CredentialP
     let credential_provider = get_test_credential_provider();
     let cache_client = momento::CacheClient::builder()
         .default_ttl(Duration::from_secs(5))
-        .configuration(configurations::laptop::latest())
+        .configuration(configurations::Laptop::latest())
         .credential_provider(credential_provider.clone())
         .build()
         .expect("cache client should be created");


### PR DESCRIPTION
Groups pre-built configs into structs. Previously they were mods, which, while syntactically legal, differs from the patterns in our SDKs and other types in this one.

In the first iteration, I considered making a trait to capture the various versions we would expose (eg `latest`, `v1`), but found consuming the trait too much friction to just import a single config.
