### PR TITLE
chore: add lint rule to check usage of expect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,12 @@
 all: precommit
 
 .PHONY: lint
+## Check the formatting of all files, run clippy on the source code, then run
+## clippy on the tests (but allow expect to be used in tests)
 lint:
 	cargo fmt -- --check
-	cargo clippy --all-targets --all-features -- -D warnings -W clippy::unwrap_used
+	cargo clippy --all-features -- -D warnings -W clippy::unwrap_used -W clippy::expect_used
+	cargo clippy --tests -- -D warnings -W clippy::unwrap_used
 
 .PHONY: build
 ## Build project

--- a/scripts/test-teardown.rs
+++ b/scripts/test-teardown.rs
@@ -5,6 +5,7 @@ use momento::CacheClient;
 use momento_test_util::{get_test_cache_name, get_test_credential_provider};
 
 #[tokio::main]
+#[allow(clippy::expect_used)] // we want to panic if teardown cannot complete
 async fn main() {
     let cache_name = get_test_cache_name();
     let credential_provider = get_test_credential_provider();

--- a/src/cache/messages/data/dictionary/dictionary_get_field.rs
+++ b/src/cache/messages/data/dictionary/dictionary_get_field.rs
@@ -104,7 +104,10 @@ impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryGetFieldRequest<D,
                             Some(format!("{:#?}", value)),
                         )),
                     },
-                    None => Err(MomentoError::unknown_error("DictionaryGetField", None)),
+                    None => Err(MomentoError::unknown_error(
+                        "DictionaryGetField",
+                        Some("Expected to receive one element".to_string()),
+                    )),
                 }
             }
             _ => Err(MomentoError::unknown_error(

--- a/src/cache/messages/data/list/list_fetch.rs
+++ b/src/cache/messages/data/list/list_fetch.rs
@@ -177,11 +177,7 @@ impl TryFrom<ListFetchValue> for Vec<String> {
     type Error = MomentoError;
 
     fn try_from(value: ListFetchValue) -> Result<Self, Self::Error> {
-        Ok(value
-            .raw_item
-            .into_iter()
-            .map(|v| parse_string(v).expect("expected a valid UTF-8 string"))
-            .collect())
+        value.raw_item.into_iter().map(parse_string).collect()
     }
 }
 

--- a/src/cache/messages/data/list/list_pop_back.rs
+++ b/src/cache/messages/data/list/list_pop_back.rs
@@ -136,7 +136,7 @@ impl TryFrom<ListPopBackValue> for String {
     type Error = MomentoError;
 
     fn try_from(value: ListPopBackValue) -> Result<Self, Self::Error> {
-        Ok(parse_string(value.raw_item).expect("expected a valid UTF-8 string"))
+        parse_string(value.raw_item)
     }
 }
 

--- a/src/cache/messages/data/list/list_pop_front.rs
+++ b/src/cache/messages/data/list/list_pop_front.rs
@@ -136,7 +136,7 @@ impl TryFrom<ListPopFrontValue> for String {
     type Error = MomentoError;
 
     fn try_from(value: ListPopFrontValue) -> Result<Self, Self::Error> {
-        Ok(parse_string(value.raw_item).expect("expected a valid UTF-8 string"))
+        parse_string(value.raw_item)
     }
 }
 

--- a/src/cache/messages/data/set/set_fetch.rs
+++ b/src/cache/messages/data/set/set_fetch.rs
@@ -141,11 +141,7 @@ impl TryFrom<SetFetchValue> for Vec<String> {
     type Error = MomentoError;
 
     fn try_from(value: SetFetchValue) -> Result<Self, Self::Error> {
-        Ok(value
-            .raw_item
-            .into_iter()
-            .map(|v| parse_string(v).expect("expected a valid UTF-8 string"))
-            .collect())
+        value.raw_item.into_iter().map(parse_string).collect()
     }
 }
 

--- a/test-util/src/cache_test_state.rs
+++ b/test-util/src/cache_test_state.rs
@@ -20,6 +20,7 @@ pub struct CacheTestState {
     runtime: tokio::runtime::Runtime,
 }
 
+#[allow(clippy::expect_used)] // we want to panic if clients can't be built
 impl CacheTestState {
     fn new() -> Self {
         let cache_name = get_test_cache_name();

--- a/test-util/src/test_utils.rs
+++ b/test-util/src/test_utils.rs
@@ -62,6 +62,7 @@ pub fn get_test_cache_name() -> String {
     env::var("TEST_CACHE_NAME").unwrap_or("rust-sdk-test-cache".to_string())
 }
 
+#[allow(clippy::expect_used)] // we want to panic if the env var is not set
 pub fn get_test_credential_provider() -> CredentialProvider {
     CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
         .expect("auth token should be valid")


### PR DESCRIPTION
Addresses https://github.com/momentohq/client-sdk-rust/issues/279

Added the clippy rule Dylan recommended and refactored as needed. Had to revise the `lint` Makefile and add `#[allow(clippy::expect_used)]` in several places to omit test-related files from the rule as we _do_ want the tests to panic if something goes wrong.

Current implementations of `From` and `TryFrom` are fine upon inspection.