### PR TITLE
fix: impl Display for CredentialProvider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ build-examples:
 .PHONY: run-examples
 ## Run example code
 run-examples:
-	cd example && make lint && cargo run --bin=rust && cargo run --bin=readme && cargo run --bin=docs_examples
+	cd example && make lint && cargo run --bin=basic && cargo run --bin=readme && cargo run --bin=docs_examples
 
 # See <https://gist.github.com/klmr/575726c7e05d8780505a> for explanation.
 .PHONY: help

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 
 [dependencies]
 futures = "0.3.30"
-momento = "0.37.0"
+momento = { version = "0.38.0" }
 tokio = { version = "1.37.0", features = ["full"] }
 uuid = { version = "1.8.0", features = ["v4"] }

--- a/example/src/bin/basic.rs
+++ b/example/src/bin/basic.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<(), MomentoError> {
     // Initializing Momento
     let cache_client = match CacheClient::builder()
         .default_ttl(Duration::from_secs(60))
-        .configuration(configurations::laptop::latest())
+        .configuration(configurations::Laptop::latest())
         .credential_provider(
             CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
                 .expect("auth token should be valid"),

--- a/example/src/bin/docs_examples.rs
+++ b/example/src/bin/docs_examples.rs
@@ -1,5 +1,5 @@
 use futures::StreamExt;
-use momento::cache::configurations::laptop;
+use momento::cache::configurations::Laptop;
 use momento::cache::{
     CreateCache, DecreaseTtl, DictionaryFetch, DictionaryGetField, DictionaryGetFields,
     IncreaseTtl, ItemType, SetIfAbsent, SetIfAbsentOrEqual, SetIfEqual, SetIfNotEqual,
@@ -19,29 +19,29 @@ pub fn example_API_CredentialProviderFromString() {
 
 #[allow(non_snake_case)]
 pub fn example_API_ConfigurationLaptop() {
-    let _config = momento::cache::configurations::laptop::latest();
+    let _config = momento::cache::configurations::Laptop::latest();
 }
 
 #[allow(non_snake_case)]
 pub fn example_API_ConfigurationInRegionDefaultLatest() {
-    let _config = momento::cache::configurations::in_region::latest();
+    let _config = momento::cache::configurations::InRegion::latest();
 }
 
 #[allow(non_snake_case)]
 pub fn example_API_ConfigurationInRegionLowLatency() {
-    let _config = momento::cache::configurations::low_latency::latest();
+    let _config = momento::cache::configurations::LowLatency::latest();
 }
 
 #[allow(non_snake_case)]
 pub fn example_API_ConfigurationLambdaLatest() {
-    let _config = momento::cache::configurations::lambda::latest();
+    let _config = momento::cache::configurations::Lambda::latest();
 }
 
 #[allow(non_snake_case)]
 pub fn example_API_InstantiateCacheClient() -> Result<(), MomentoError> {
     let _cache_client = CacheClient::builder()
         .default_ttl(Duration::from_secs(60))
-        .configuration(laptop::latest())
+        .configuration(Laptop::latest())
         .credential_provider(CredentialProvider::from_env_var(
             "MOMENTO_API_KEY".to_string(),
         )?)
@@ -722,7 +722,7 @@ pub async fn example_API_KeysExist(
 #[allow(non_snake_case)]
 pub fn example_API_InstantiateTopicClient() -> Result<(), MomentoError> {
     let _topic_client = TopicClient::builder()
-        .configuration(momento::topics::configurations::laptop::latest())
+        .configuration(momento::topics::configurations::Laptop::latest())
         .credential_provider(CredentialProvider::from_env_var("MOMENTO_API_KEY")?)
         .build()?;
     Ok(())
@@ -772,7 +772,7 @@ pub async fn main() -> Result<(), MomentoError> {
 
     let cache_client = CacheClient::builder()
         .default_ttl(Duration::from_secs(60))
-        .configuration(laptop::latest())
+        .configuration(Laptop::latest())
         .credential_provider(CredentialProvider::from_env_var(
             "MOMENTO_API_KEY".to_string(),
         )?)
@@ -836,7 +836,7 @@ pub async fn main() -> Result<(), MomentoError> {
     example_API_InstantiateTopicClient()?;
 
     let topic_client = TopicClient::builder()
-        .configuration(momento::topics::configurations::laptop::latest())
+        .configuration(momento::topics::configurations::Laptop::latest())
         .credential_provider(CredentialProvider::from_env_var("MOMENTO_API_KEY")?)
         .build()?;
     let topic_name = format!("{}-{}", "docs-examples-topic", Uuid::new_v4());

--- a/example/src/bin/readme.rs
+++ b/example/src/bin/readme.rs
@@ -1,4 +1,4 @@
-use momento::cache::configurations::laptop;
+use momento::cache::configurations::Laptop;
 use momento::cache::Get;
 use momento::{CacheClient, CredentialProvider, MomentoError};
 use std::time::Duration;
@@ -9,7 +9,7 @@ const CACHE_NAME: &str = "cache";
 pub async fn main() -> Result<(), MomentoError> {
     let cache_client = CacheClient::builder()
         .default_ttl(Duration::from_secs(60))
-        .configuration(laptop::latest())
+        .configuration(Laptop::latest())
         .credential_provider(CredentialProvider::from_env_var(
             "MOMENTO_API_KEY".to_string(),
         )?)

--- a/example/src/bin/topics.rs
+++ b/example/src/bin/topics.rs
@@ -6,7 +6,7 @@ use tokio::time::sleep;
 #[tokio::main]
 async fn main() -> MomentoResult<()> {
     let topic_client = TopicClient::builder()
-        .configuration(configurations::laptop::latest())
+        .configuration(configurations::Laptop::latest())
         .credential_provider(CredentialProvider::from_env_var("MOMENTO_API_KEY")?)
         .build()?;
 

--- a/src/credential_provider.rs
+++ b/src/credential_provider.rs
@@ -4,7 +4,7 @@ use base64::Engine;
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde::{Deserialize, Serialize};
 use std::env;
-use std::fmt::{Debug, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 
 #[derive(Debug, Serialize, Deserialize)]
 struct JwtClaims {
@@ -30,6 +30,27 @@ pub struct CredentialProvider {
     pub(crate) control_endpoint: String,
     pub(crate) cache_endpoint: String,
     pub(crate) token_endpoint: String,
+}
+
+impl Display for CredentialProvider {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "CredentialProvider {{ auth_token: <redacted>, cache_endpoint: {}, control_endpoint: {}, token_endpoint: {} }}",
+            self.cache_endpoint, self.control_endpoint, self.token_endpoint
+        )
+    }
+}
+
+impl Debug for CredentialProvider {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CredentialProvider")
+            .field("auth_token", &"<redacted>")
+            .field("cache_endpoint", &self.cache_endpoint)
+            .field("control_endpoint", &self.control_endpoint)
+            .field("token_endpoint", &self.token_endpoint)
+            .finish()
+    }
 }
 
 impl CredentialProvider {
@@ -114,16 +135,6 @@ impl CredentialProvider {
         self.cache_endpoint = https_endpoint(get_cache_endpoint(endpoint));
         self.token_endpoint = https_endpoint(get_token_endpoint(endpoint));
         self
-    }
-}
-
-impl Debug for CredentialProvider {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CredentialProvider")
-            .field("auth_token", &"<redacted>")
-            .field("cache_endpoint", &self.cache_endpoint)
-            .field("control_endpoint", &self.control_endpoint)
-            .finish()
     }
 }
 


### PR DESCRIPTION
Implements Display for CredentialProvider to ensure that we redact
the auth token.

Also updates the examples to the new struct names for the
cred providers.
