### PR TITLE
feat: add response suffix to dictionary response types

### DIFF
--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -10,7 +10,7 @@ use crate::cache::{
     Configuration, CreateCache, CreateCacheRequest, DecreaseTtl, DecreaseTtlRequest, Delete,
     DeleteCache, DeleteCacheRequest, DeleteRequest, DictionaryFetchRequest,
     DictionaryFetchResponse, DictionaryGetFieldRequest, DictionaryGetFieldResponse,
-    DictionaryGetFields, DictionaryGetFieldsRequest, DictionaryIncrement,
+    DictionaryGetFieldsRequest, DictionaryGetFieldsResponse, DictionaryIncrement,
     DictionaryIncrementRequest, DictionaryLength, DictionaryLengthRequest, DictionaryRemoveField,
     DictionaryRemoveFieldRequest, DictionaryRemoveFields, DictionaryRemoveFieldsRequest,
     DictionarySetField, DictionarySetFieldRequest, DictionarySetFields, DictionarySetFieldsRequest,
@@ -421,7 +421,7 @@ impl CacheClient {
     /// # use std::convert::TryInto;
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::{DictionaryGetFields, DictionaryGetFieldsRequest};
+    /// use momento::cache::{DictionaryGetFieldsResponse, DictionaryGetFieldsRequest};
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let dictionary_name = "dictionary";
     /// let fields = vec!["field1", "field2"];
@@ -435,11 +435,11 @@ impl CacheClient {
     /// let response = cache_client.dictionary_get_fields(cache_name, dictionary_name, fields).await?;
     ///
     /// match response {
-    ///    DictionaryGetFields::Hit { .. } => {
+    ///    DictionaryGetFieldsResponse::Hit { .. } => {
     ///      let dictionary: HashMap<String, String> = response.try_into().expect("I stored a dictionary of strings!");
     ///      println!("Fetched dictionary: {:?}", dictionary);
     ///    }
-    ///    DictionaryGetFields::Miss => println!("Cache miss"),
+    ///    DictionaryGetFieldsResponse::Miss => println!("Cache miss"),
     /// }
     /// # Ok(())
     /// # })
@@ -450,7 +450,7 @@ impl CacheClient {
         cache_name: impl Into<String>,
         dictionary_name: impl IntoBytes,
         fields: F,
-    ) -> MomentoResult<DictionaryGetFields<F>> {
+    ) -> MomentoResult<DictionaryGetFieldsResponse<F>> {
         let request = DictionaryGetFieldsRequest::new(cache_name, dictionary_name, fields);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -9,12 +9,12 @@ use tonic::transport::Channel;
 use crate::cache::{
     Configuration, CreateCache, CreateCacheRequest, DecreaseTtl, DecreaseTtlRequest, Delete,
     DeleteCache, DeleteCacheRequest, DeleteRequest, DictionaryFetchRequest,
-    DictionaryFetchResponse, DictionaryGetField, DictionaryGetFieldRequest, DictionaryGetFields,
-    DictionaryGetFieldsRequest, DictionaryIncrement, DictionaryIncrementRequest, DictionaryLength,
-    DictionaryLengthRequest, DictionaryRemoveField, DictionaryRemoveFieldRequest,
-    DictionaryRemoveFields, DictionaryRemoveFieldsRequest, DictionarySetField,
-    DictionarySetFieldRequest, DictionarySetFields, DictionarySetFieldsRequest, FlushCache,
-    FlushCacheRequest, Get, GetRequest, IncreaseTtl, IncreaseTtlRequest, Increment,
+    DictionaryFetchResponse, DictionaryGetFieldRequest, DictionaryGetFieldResponse,
+    DictionaryGetFields, DictionaryGetFieldsRequest, DictionaryIncrement,
+    DictionaryIncrementRequest, DictionaryLength, DictionaryLengthRequest, DictionaryRemoveField,
+    DictionaryRemoveFieldRequest, DictionaryRemoveFields, DictionaryRemoveFieldsRequest,
+    DictionarySetField, DictionarySetFieldRequest, DictionarySetFields, DictionarySetFieldsRequest,
+    FlushCache, FlushCacheRequest, Get, GetRequest, IncreaseTtl, IncreaseTtlRequest, Increment,
     IncrementRequest, IntoDictionaryFieldValuePairs, IntoSortedSetElements, ItemGetTtl,
     ItemGetTtlRequest, ItemGetType, ItemGetTypeRequest, KeyExists, KeyExistsRequest, KeysExist,
     KeysExistRequest, ListCaches, ListCachesRequest, ListConcatenateBack,
@@ -368,7 +368,7 @@ impl CacheClient {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # use std::convert::TryInto;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::DictionaryGetField;
+    /// use momento::cache::DictionaryGetFieldResponse;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let dictionary_name = "dictionary";
     /// let field = "field";
@@ -383,11 +383,11 @@ impl CacheClient {
     /// let response = cache_client.dictionary_get_field(cache_name, dictionary_name, field).await?;
     ///
     /// match response {
-    ///   DictionaryGetField::Hit { value } => {
+    ///   DictionaryGetFieldResponse::Hit { value } => {
     ///     let value: String = value.try_into().expect("I stored a string!");
     ///     println!("Fetched value: {}", value);
     ///   }
-    ///   DictionaryGetField::Miss => println!("Cache miss"),
+    ///   DictionaryGetFieldResponse::Miss => println!("Cache miss"),
     /// }
     /// # Ok(())
     /// # })
@@ -398,7 +398,7 @@ impl CacheClient {
         cache_name: impl Into<String>,
         dictionary_name: impl IntoBytes,
         field: impl IntoBytes,
-    ) -> MomentoResult<DictionaryGetField> {
+    ) -> MomentoResult<DictionaryGetFieldResponse> {
         let request = DictionaryGetFieldRequest::new(cache_name, dictionary_name, field);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -8,28 +8,29 @@ use tonic::transport::Channel;
 
 use crate::cache::{
     Configuration, CreateCache, CreateCacheRequest, DecreaseTtl, DecreaseTtlRequest, Delete,
-    DeleteCache, DeleteCacheRequest, DeleteRequest, DictionaryFetch, DictionaryFetchRequest,
-    DictionaryGetField, DictionaryGetFieldRequest, DictionaryGetFields, DictionaryGetFieldsRequest,
-    DictionaryIncrement, DictionaryIncrementRequest, DictionaryLength, DictionaryLengthRequest,
-    DictionaryRemoveField, DictionaryRemoveFieldRequest, DictionaryRemoveFields,
-    DictionaryRemoveFieldsRequest, DictionarySetField, DictionarySetFieldRequest,
-    DictionarySetFields, DictionarySetFieldsRequest, FlushCache, FlushCacheRequest, Get,
-    GetRequest, IncreaseTtl, IncreaseTtlRequest, Increment, IncrementRequest,
-    IntoDictionaryFieldValuePairs, IntoSortedSetElements, ItemGetTtl, ItemGetTtlRequest,
-    ItemGetType, ItemGetTypeRequest, KeyExists, KeyExistsRequest, KeysExist, KeysExistRequest,
-    ListCaches, ListCachesRequest, ListConcatenateBack, ListConcatenateBackRequest,
-    ListConcatenateFront, ListConcatenateFrontRequest, ListFetch, ListFetchRequest, ListLength,
-    ListLengthRequest, ListPopBack, ListPopBackRequest, ListPopFront, ListPopFrontRequest,
-    ListRemoveValue, ListRemoveValueRequest, MomentoRequest, Set, SetAddElements,
-    SetAddElementsRequest, SetFetch, SetFetchRequest, SetIfAbsent, SetIfAbsentOrEqual,
-    SetIfAbsentOrEqualRequest, SetIfAbsentRequest, SetIfEqual, SetIfEqualRequest, SetIfNotEqual,
-    SetIfNotEqualRequest, SetIfPresent, SetIfPresentAndNotEqual, SetIfPresentAndNotEqualRequest,
-    SetIfPresentRequest, SetRemoveElements, SetRemoveElementsRequest, SetRequest, SortedSetFetch,
-    SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest, SortedSetGetRank,
-    SortedSetGetRankRequest, SortedSetGetScore, SortedSetGetScoreRequest, SortedSetLength,
-    SortedSetLengthRequest, SortedSetOrder, SortedSetPutElement, SortedSetPutElementRequest,
-    SortedSetPutElements, SortedSetPutElementsRequest, SortedSetRemoveElements,
-    SortedSetRemoveElementsRequest, UpdateTtl, UpdateTtlRequest,
+    DeleteCache, DeleteCacheRequest, DeleteRequest, DictionaryFetchRequest,
+    DictionaryFetchResponse, DictionaryGetField, DictionaryGetFieldRequest, DictionaryGetFields,
+    DictionaryGetFieldsRequest, DictionaryIncrement, DictionaryIncrementRequest, DictionaryLength,
+    DictionaryLengthRequest, DictionaryRemoveField, DictionaryRemoveFieldRequest,
+    DictionaryRemoveFields, DictionaryRemoveFieldsRequest, DictionarySetField,
+    DictionarySetFieldRequest, DictionarySetFields, DictionarySetFieldsRequest, FlushCache,
+    FlushCacheRequest, Get, GetRequest, IncreaseTtl, IncreaseTtlRequest, Increment,
+    IncrementRequest, IntoDictionaryFieldValuePairs, IntoSortedSetElements, ItemGetTtl,
+    ItemGetTtlRequest, ItemGetType, ItemGetTypeRequest, KeyExists, KeyExistsRequest, KeysExist,
+    KeysExistRequest, ListCaches, ListCachesRequest, ListConcatenateBack,
+    ListConcatenateBackRequest, ListConcatenateFront, ListConcatenateFrontRequest, ListFetch,
+    ListFetchRequest, ListLength, ListLengthRequest, ListPopBack, ListPopBackRequest, ListPopFront,
+    ListPopFrontRequest, ListRemoveValue, ListRemoveValueRequest, MomentoRequest, Set,
+    SetAddElements, SetAddElementsRequest, SetFetch, SetFetchRequest, SetIfAbsent,
+    SetIfAbsentOrEqual, SetIfAbsentOrEqualRequest, SetIfAbsentRequest, SetIfEqual,
+    SetIfEqualRequest, SetIfNotEqual, SetIfNotEqualRequest, SetIfPresent, SetIfPresentAndNotEqual,
+    SetIfPresentAndNotEqualRequest, SetIfPresentRequest, SetRemoveElements,
+    SetRemoveElementsRequest, SetRequest, SortedSetFetch, SortedSetFetchByRankRequest,
+    SortedSetFetchByScoreRequest, SortedSetGetRank, SortedSetGetRankRequest, SortedSetGetScore,
+    SortedSetGetScoreRequest, SortedSetLength, SortedSetLengthRequest, SortedSetOrder,
+    SortedSetPutElement, SortedSetPutElementRequest, SortedSetPutElements,
+    SortedSetPutElementsRequest, SortedSetRemoveElements, SortedSetRemoveElementsRequest,
+    UpdateTtl, UpdateTtlRequest,
 };
 use crate::grpc::header_interceptor::HeaderInterceptor;
 
@@ -317,7 +318,7 @@ impl CacheClient {
     /// # use std::convert::TryInto;
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::{DictionaryFetchRequest, DictionaryFetch};
+    /// use momento::cache::{DictionaryFetchRequest, DictionaryFetchResponse};
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let dictionary_name = "dictionary";
     ///
@@ -331,11 +332,11 @@ impl CacheClient {
     /// let fetch_response = cache_client.dictionary_fetch(cache_name, dictionary_name).await?;
     ///
     /// match fetch_response {
-    ///    DictionaryFetch::Hit{ value } => {
+    ///    DictionaryFetchResponse::Hit{ value } => {
     ///       let dictionary: HashMap<String, String> = value.try_into().expect("I stored a dictionary!");
     ///       println!("Fetched dictionary: {:?}", dictionary);
     ///    }
-    ///    DictionaryFetch::Miss => println!("Cache miss"),
+    ///    DictionaryFetchResponse::Miss => println!("Cache miss"),
     /// }
     /// # Ok(())
     /// # })
@@ -346,7 +347,7 @@ impl CacheClient {
         &self,
         cache_name: impl Into<String>,
         dictionary_name: impl IntoBytes,
-    ) -> MomentoResult<DictionaryFetch> {
+    ) -> MomentoResult<DictionaryFetchResponse> {
         let request = DictionaryFetchRequest::new(cache_name, dictionary_name);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -12,8 +12,8 @@ use crate::cache::{
     DictionaryFetchResponse, DictionaryGetFieldRequest, DictionaryGetFieldResponse,
     DictionaryGetFieldsRequest, DictionaryGetFieldsResponse, DictionaryIncrementRequest,
     DictionaryIncrementResponse, DictionaryLengthRequest, DictionaryLengthResponse,
-    DictionaryRemoveFieldRequest, DictionaryRemoveFieldResponse, DictionaryRemoveFields,
-    DictionaryRemoveFieldsRequest, DictionarySetField, DictionarySetFieldRequest,
+    DictionaryRemoveFieldRequest, DictionaryRemoveFieldResponse, DictionaryRemoveFieldsRequest,
+    DictionaryRemoveFieldsResponse, DictionarySetField, DictionarySetFieldRequest,
     DictionarySetFields, DictionarySetFieldsRequest, FlushCache, FlushCacheRequest, Get,
     GetRequest, IncreaseTtl, IncreaseTtlRequest, Increment, IncrementRequest,
     IntoDictionaryFieldValuePairs, IntoSortedSetElements, ItemGetTtl, ItemGetTtlRequest,
@@ -587,7 +587,7 @@ impl CacheClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::{DictionaryRemoveFields, DictionaryRemoveFieldsRequest};
+    /// use momento::cache::{DictionaryRemoveFieldsResponse, DictionaryRemoveFieldsRequest};
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let dictionary_name = "dictionary";
     /// let fields = vec!["field1", "field2"];
@@ -613,7 +613,7 @@ impl CacheClient {
         cache_name: impl Into<String>,
         dictionary_name: impl IntoBytes,
         fields: F,
-    ) -> MomentoResult<DictionaryRemoveFields> {
+    ) -> MomentoResult<DictionaryRemoveFieldsResponse> {
         let request = DictionaryRemoveFieldsRequest::new(cache_name, dictionary_name, fields);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -11,26 +11,26 @@ use crate::cache::{
     DeleteCache, DeleteCacheRequest, DeleteRequest, DictionaryFetchRequest,
     DictionaryFetchResponse, DictionaryGetFieldRequest, DictionaryGetFieldResponse,
     DictionaryGetFieldsRequest, DictionaryGetFieldsResponse, DictionaryIncrementRequest,
-    DictionaryIncrementResponse, DictionaryLength, DictionaryLengthRequest, DictionaryRemoveField,
-    DictionaryRemoveFieldRequest, DictionaryRemoveFields, DictionaryRemoveFieldsRequest,
-    DictionarySetField, DictionarySetFieldRequest, DictionarySetFields, DictionarySetFieldsRequest,
-    FlushCache, FlushCacheRequest, Get, GetRequest, IncreaseTtl, IncreaseTtlRequest, Increment,
-    IncrementRequest, IntoDictionaryFieldValuePairs, IntoSortedSetElements, ItemGetTtl,
-    ItemGetTtlRequest, ItemGetType, ItemGetTypeRequest, KeyExists, KeyExistsRequest, KeysExist,
-    KeysExistRequest, ListCaches, ListCachesRequest, ListConcatenateBack,
-    ListConcatenateBackRequest, ListConcatenateFront, ListConcatenateFrontRequest, ListFetch,
-    ListFetchRequest, ListLength, ListLengthRequest, ListPopBack, ListPopBackRequest, ListPopFront,
-    ListPopFrontRequest, ListRemoveValue, ListRemoveValueRequest, MomentoRequest, Set,
-    SetAddElements, SetAddElementsRequest, SetFetch, SetFetchRequest, SetIfAbsent,
-    SetIfAbsentOrEqual, SetIfAbsentOrEqualRequest, SetIfAbsentRequest, SetIfEqual,
-    SetIfEqualRequest, SetIfNotEqual, SetIfNotEqualRequest, SetIfPresent, SetIfPresentAndNotEqual,
-    SetIfPresentAndNotEqualRequest, SetIfPresentRequest, SetRemoveElements,
-    SetRemoveElementsRequest, SetRequest, SortedSetFetch, SortedSetFetchByRankRequest,
-    SortedSetFetchByScoreRequest, SortedSetGetRank, SortedSetGetRankRequest, SortedSetGetScore,
-    SortedSetGetScoreRequest, SortedSetLength, SortedSetLengthRequest, SortedSetOrder,
-    SortedSetPutElement, SortedSetPutElementRequest, SortedSetPutElements,
-    SortedSetPutElementsRequest, SortedSetRemoveElements, SortedSetRemoveElementsRequest,
-    UpdateTtl, UpdateTtlRequest,
+    DictionaryIncrementResponse, DictionaryLengthRequest, DictionaryLengthResponse,
+    DictionaryRemoveField, DictionaryRemoveFieldRequest, DictionaryRemoveFields,
+    DictionaryRemoveFieldsRequest, DictionarySetField, DictionarySetFieldRequest,
+    DictionarySetFields, DictionarySetFieldsRequest, FlushCache, FlushCacheRequest, Get,
+    GetRequest, IncreaseTtl, IncreaseTtlRequest, Increment, IncrementRequest,
+    IntoDictionaryFieldValuePairs, IntoSortedSetElements, ItemGetTtl, ItemGetTtlRequest,
+    ItemGetType, ItemGetTypeRequest, KeyExists, KeyExistsRequest, KeysExist, KeysExistRequest,
+    ListCaches, ListCachesRequest, ListConcatenateBack, ListConcatenateBackRequest,
+    ListConcatenateFront, ListConcatenateFrontRequest, ListFetch, ListFetchRequest, ListLength,
+    ListLengthRequest, ListPopBack, ListPopBackRequest, ListPopFront, ListPopFrontRequest,
+    ListRemoveValue, ListRemoveValueRequest, MomentoRequest, Set, SetAddElements,
+    SetAddElementsRequest, SetFetch, SetFetchRequest, SetIfAbsent, SetIfAbsentOrEqual,
+    SetIfAbsentOrEqualRequest, SetIfAbsentRequest, SetIfEqual, SetIfEqualRequest, SetIfNotEqual,
+    SetIfNotEqualRequest, SetIfPresent, SetIfPresentAndNotEqual, SetIfPresentAndNotEqualRequest,
+    SetIfPresentRequest, SetRemoveElements, SetRemoveElementsRequest, SetRequest, SortedSetFetch,
+    SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest, SortedSetGetRank,
+    SortedSetGetRankRequest, SortedSetGetScore, SortedSetGetScoreRequest, SortedSetLength,
+    SortedSetLengthRequest, SortedSetOrder, SortedSetPutElement, SortedSetPutElementRequest,
+    SortedSetPutElements, SortedSetPutElementsRequest, SortedSetRemoveElements,
+    SortedSetRemoveElementsRequest, UpdateTtl, UpdateTtlRequest,
 };
 use crate::grpc::header_interceptor::HeaderInterceptor;
 
@@ -514,7 +514,7 @@ impl CacheClient {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # use std::convert::TryInto;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::{DictionaryLength, DictionaryLengthRequest};
+    /// use momento::cache::{DictionaryLengthResponse, DictionaryLengthRequest};
     /// use momento::MomentoErrorCode;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let dictionary_name = "dictionary-name";
@@ -529,7 +529,7 @@ impl CacheClient {
         &self,
         cache_name: impl Into<String>,
         dictionary_name: impl IntoBytes,
-    ) -> MomentoResult<DictionaryLength> {
+    ) -> MomentoResult<DictionaryLengthResponse> {
         let request = DictionaryLengthRequest::new(cache_name, dictionary_name);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -14,7 +14,7 @@ use crate::cache::{
     DictionaryIncrementResponse, DictionaryLengthRequest, DictionaryLengthResponse,
     DictionaryRemoveFieldRequest, DictionaryRemoveFieldResponse, DictionaryRemoveFieldsRequest,
     DictionaryRemoveFieldsResponse, DictionarySetFieldRequest, DictionarySetFieldResponse,
-    DictionarySetFields, DictionarySetFieldsRequest, FlushCache, FlushCacheRequest, Get,
+    DictionarySetFieldsRequest, DictionarySetFieldsResponse, FlushCache, FlushCacheRequest, Get,
     GetRequest, IncreaseTtl, IncreaseTtlRequest, Increment, IncrementRequest,
     IntoDictionaryFieldValuePairs, IntoSortedSetElements, ItemGetTtl, ItemGetTtlRequest,
     ItemGetType, ItemGetTypeRequest, KeyExists, KeyExistsRequest, KeysExist, KeysExistRequest,
@@ -691,7 +691,7 @@ impl CacheClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::{CollectionTtl, DictionarySetFields, DictionarySetFieldsRequest};
+    /// use momento::cache::{CollectionTtl, DictionarySetFieldsResponse, DictionarySetFieldsRequest};
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let dictionary_name = "dictionary";
     ///
@@ -714,7 +714,7 @@ impl CacheClient {
         cache_name: impl Into<String>,
         dictionary_name: impl IntoBytes,
         elements: impl IntoDictionaryFieldValuePairs<F, V>,
-    ) -> MomentoResult<DictionarySetFields> {
+    ) -> MomentoResult<DictionarySetFieldsResponse> {
         let request = DictionarySetFieldsRequest::new(cache_name, dictionary_name, elements);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -10,8 +10,8 @@ use crate::cache::{
     Configuration, CreateCache, CreateCacheRequest, DecreaseTtl, DecreaseTtlRequest, Delete,
     DeleteCache, DeleteCacheRequest, DeleteRequest, DictionaryFetchRequest,
     DictionaryFetchResponse, DictionaryGetFieldRequest, DictionaryGetFieldResponse,
-    DictionaryGetFieldsRequest, DictionaryGetFieldsResponse, DictionaryIncrement,
-    DictionaryIncrementRequest, DictionaryLength, DictionaryLengthRequest, DictionaryRemoveField,
+    DictionaryGetFieldsRequest, DictionaryGetFieldsResponse, DictionaryIncrementRequest,
+    DictionaryIncrementResponse, DictionaryLength, DictionaryLengthRequest, DictionaryRemoveField,
     DictionaryRemoveFieldRequest, DictionaryRemoveFields, DictionaryRemoveFieldsRequest,
     DictionarySetField, DictionarySetFieldRequest, DictionarySetFields, DictionarySetFieldsRequest,
     FlushCache, FlushCacheRequest, Get, GetRequest, IncreaseTtl, IncreaseTtlRequest, Increment,
@@ -472,7 +472,7 @@ impl CacheClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::DictionaryIncrement;
+    /// use momento::cache::DictionaryIncrementResponse;
     /// use momento::MomentoErrorCode;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let dictionary_name = "dictionary";
@@ -482,7 +482,7 @@ impl CacheClient {
     /// let response = cache_client.dictionary_increment(&cache_name, dictionary_name, field, amount).await;
     ///
     /// match response {
-    ///   Ok(DictionaryIncrement { value }) => println!("Incremented value: {}", value),
+    ///   Ok(DictionaryIncrementResponse { value }) => println!("Incremented value: {}", value),
     ///   Err(e) => println!("Error incrementing value: {}", e),
     /// }
     /// # Ok(())
@@ -495,7 +495,7 @@ impl CacheClient {
         dictionary_name: impl IntoBytes,
         field: impl IntoBytes,
         amount: i64,
-    ) -> MomentoResult<DictionaryIncrement> {
+    ) -> MomentoResult<DictionaryIncrementResponse> {
         let request = DictionaryIncrementRequest::new(cache_name, dictionary_name, field, amount);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -12,7 +12,7 @@ use crate::cache::{
     DictionaryFetchResponse, DictionaryGetFieldRequest, DictionaryGetFieldResponse,
     DictionaryGetFieldsRequest, DictionaryGetFieldsResponse, DictionaryIncrementRequest,
     DictionaryIncrementResponse, DictionaryLengthRequest, DictionaryLengthResponse,
-    DictionaryRemoveField, DictionaryRemoveFieldRequest, DictionaryRemoveFields,
+    DictionaryRemoveFieldRequest, DictionaryRemoveFieldResponse, DictionaryRemoveFields,
     DictionaryRemoveFieldsRequest, DictionarySetField, DictionarySetFieldRequest,
     DictionarySetFields, DictionarySetFieldsRequest, FlushCache, FlushCacheRequest, Get,
     GetRequest, IncreaseTtl, IncreaseTtlRequest, Increment, IncrementRequest,
@@ -548,7 +548,7 @@ impl CacheClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::{DictionaryRemoveField, DictionaryRemoveFieldRequest};
+    /// use momento::cache::{DictionaryRemoveFieldResponse, DictionaryRemoveFieldRequest};
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let dictionary_name = "dictionary";
     /// let field = "field";
@@ -568,7 +568,7 @@ impl CacheClient {
         cache_name: impl Into<String>,
         dictionary_name: impl IntoBytes,
         field: impl IntoBytes,
-    ) -> MomentoResult<DictionaryRemoveField> {
+    ) -> MomentoResult<DictionaryRemoveFieldResponse> {
         let request = DictionaryRemoveFieldRequest::new(cache_name, dictionary_name, field);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -13,7 +13,7 @@ use crate::cache::{
     DictionaryGetFieldsRequest, DictionaryGetFieldsResponse, DictionaryIncrementRequest,
     DictionaryIncrementResponse, DictionaryLengthRequest, DictionaryLengthResponse,
     DictionaryRemoveFieldRequest, DictionaryRemoveFieldResponse, DictionaryRemoveFieldsRequest,
-    DictionaryRemoveFieldsResponse, DictionarySetField, DictionarySetFieldRequest,
+    DictionaryRemoveFieldsResponse, DictionarySetFieldRequest, DictionarySetFieldResponse,
     DictionarySetFields, DictionarySetFieldsRequest, FlushCache, FlushCacheRequest, Get,
     GetRequest, IncreaseTtl, IncreaseTtlRequest, Increment, IncrementRequest,
     IntoDictionaryFieldValuePairs, IntoSortedSetElements, ItemGetTtl, ItemGetTtlRequest,
@@ -639,7 +639,7 @@ impl CacheClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::{CollectionTtl, DictionarySetField, DictionarySetFieldRequest};
+    /// use momento::cache::{CollectionTtl, DictionarySetFieldResponse, DictionarySetFieldRequest};
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let dictionary_name = "dictionary";
     ///
@@ -666,7 +666,7 @@ impl CacheClient {
         dictionary_name: impl IntoBytes,
         field: impl IntoBytes,
         value: impl IntoBytes,
-    ) -> MomentoResult<DictionarySetField> {
+    ) -> MomentoResult<DictionarySetFieldResponse> {
         let request = DictionarySetFieldRequest::new(cache_name, dictionary_name, field, value);
         request.send(self).await
     }

--- a/src/cache/messages/dictionary/dictionary_get_field.rs
+++ b/src/cache/messages/dictionary/dictionary_get_field.rs
@@ -24,7 +24,7 @@ use std::convert::{TryFrom, TryInto};
 /// # use std::convert::TryInto;
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
-/// use momento::cache::{DictionaryGetField, DictionaryGetFieldRequest};
+/// use momento::cache::{DictionaryGetFieldResponse, DictionaryGetFieldRequest};
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 /// let dictionary_name = "dictionary";
 /// let field = "field1";
@@ -68,7 +68,7 @@ impl<D: IntoBytes, F: IntoBytes> DictionaryGetFieldRequest<D, F> {
 }
 
 impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryGetFieldRequest<D, F> {
-    type Response = DictionaryGetField;
+    type Response = DictionaryGetFieldResponse;
 
     async fn send(self, cache_client: &CacheClient) -> MomentoResult<Self::Response> {
         let request = prep_request_with_timeout(
@@ -88,17 +88,17 @@ impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryGetFieldRequest<D,
             .into_inner();
 
         match response.dictionary {
-            Some(DictionaryProto::Missing(_)) => Ok(DictionaryGetField::Miss),
+            Some(DictionaryProto::Missing(_)) => Ok(DictionaryGetFieldResponse::Miss),
             Some(DictionaryProto::Found(elements)) => {
                 let mut responses: Vec<DictionaryGetResponsePart> =
                     elements.items.into_iter().collect();
 
                 match responses.pop() {
                     Some(value) => match value.result() {
-                        ECacheResult::Hit => Ok(DictionaryGetField::Hit {
+                        ECacheResult::Hit => Ok(DictionaryGetFieldResponse::Hit {
                             value: DictionaryGetFieldValue::new(value.cache_body),
                         }),
-                        ECacheResult::Miss => Ok(DictionaryGetField::Miss),
+                        ECacheResult::Miss => Ok(DictionaryGetFieldResponse::Miss),
                         _ => Err(MomentoError::unknown_error(
                             "DictionaryGetField",
                             Some(format!("{:#?}", value)),
@@ -120,13 +120,13 @@ impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryGetFieldRequest<D,
 /// If you'd like to handle misses you can simply match and handle your response:
 /// ```
 /// fn main() -> anyhow::Result<()> {
-/// # use momento::cache::DictionaryGetField;
+/// # use momento::cache::DictionaryGetFieldResponse;
 /// # use momento::MomentoResult;
-/// # let fetch_response: DictionaryGetField = DictionaryGetField::default();
+/// # let fetch_response: DictionaryGetFieldResponse = DictionaryGetFieldResponse::default();
 /// use std::convert::TryInto;
 /// let item: String = match fetch_response {
-///    DictionaryGetField::Hit { value } => value.try_into().expect("I stored a string!"),
-///    DictionaryGetField::Miss => panic!("I expected a hit!"),
+///    DictionaryGetFieldResponse::Hit { value } => value.try_into().expect("I stored a string!"),
+///    DictionaryGetFieldResponse::Miss => panic!("I expected a hit!"),
 /// };
 /// # Ok(())
 /// }
@@ -134,13 +134,13 @@ impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryGetFieldRequest<D,
 ///
 /// Or if you're storing raw bytes you can get at them simply:
 /// ```
-/// # use momento::cache::DictionaryGetField;
+/// # use momento::cache::DictionaryGetFieldResponse;
 /// # use momento::MomentoResult;
-/// # let fetch_response: DictionaryGetField = DictionaryGetField::default();
+/// # let fetch_response: DictionaryGetFieldResponse = DictionaryGetFieldResponse::default();
 /// use std::convert::TryInto;
 /// let item: Vec<u8> = match fetch_response {
-///   DictionaryGetField::Hit { value } => value.into(),
-///   DictionaryGetField::Miss => panic!("I expected a hit!"),
+///   DictionaryGetFieldResponse::Hit { value } => value.into(),
+///   DictionaryGetFieldResponse::Miss => panic!("I expected a hit!"),
 /// };
 /// ```
 ///
@@ -150,53 +150,53 @@ impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryGetFieldRequest<D,
 /// Of course, a Miss in this case will be turned into an Error. If that's what you want, then
 /// this is what you're after:
 /// ```
-/// # use momento::cache::DictionaryGetField;
+/// # use momento::cache::DictionaryGetFieldResponse;
 /// # use momento::MomentoResult;
-/// # let fetch_response = DictionaryGetField::default();
+/// # let fetch_response = DictionaryGetFieldResponse::default();
 /// use std::convert::TryInto;
 /// let item: MomentoResult<String> = fetch_response.try_into();
 /// ```
 ///
 /// You can also go straight into a `Vec<u8>` if you prefer:
 /// ```
-/// # use momento::cache::DictionaryGetField;
+/// # use momento::cache::DictionaryGetFieldResponse;
 /// # use momento::MomentoResult;
-/// # let fetch_response: DictionaryGetField = DictionaryGetField::default();
+/// # let fetch_response: DictionaryGetFieldResponse = DictionaryGetFieldResponse::default();
 /// use std::convert::TryInto;
 /// let item: MomentoResult<Vec<u8>> = fetch_response.try_into();
 /// ```
 #[derive(Debug, PartialEq, Eq)]
-pub enum DictionaryGetField {
+pub enum DictionaryGetFieldResponse {
     Hit { value: DictionaryGetFieldValue },
     Miss,
 }
 
-impl Default for DictionaryGetField {
+impl Default for DictionaryGetFieldResponse {
     fn default() -> Self {
-        DictionaryGetField::Hit {
+        DictionaryGetFieldResponse::Hit {
             value: DictionaryGetFieldValue::new(Vec::new()),
         }
     }
 }
 
-impl TryFrom<DictionaryGetField> for String {
+impl TryFrom<DictionaryGetFieldResponse> for String {
     type Error = MomentoError;
 
-    fn try_from(value: DictionaryGetField) -> Result<Self, Self::Error> {
+    fn try_from(value: DictionaryGetFieldResponse) -> Result<Self, Self::Error> {
         match value {
-            DictionaryGetField::Hit { value } => value.try_into(),
-            DictionaryGetField::Miss => Err(MomentoError::miss("DictionaryGetField")),
+            DictionaryGetFieldResponse::Hit { value } => value.try_into(),
+            DictionaryGetFieldResponse::Miss => Err(MomentoError::miss("DictionaryGetField")),
         }
     }
 }
 
-impl TryFrom<DictionaryGetField> for Vec<u8> {
+impl TryFrom<DictionaryGetFieldResponse> for Vec<u8> {
     type Error = MomentoError;
 
-    fn try_from(value: DictionaryGetField) -> Result<Self, Self::Error> {
+    fn try_from(value: DictionaryGetFieldResponse) -> Result<Self, Self::Error> {
         match value {
-            DictionaryGetField::Hit { value } => Ok(value.into()),
-            DictionaryGetField::Miss => Err(MomentoError::miss("DictionaryGetField")),
+            DictionaryGetFieldResponse::Hit { value } => Ok(value.into()),
+            DictionaryGetFieldResponse::Miss => Err(MomentoError::miss("DictionaryGetField")),
         }
     }
 }

--- a/src/cache/messages/dictionary/dictionary_get_field.rs
+++ b/src/cache/messages/dictionary/dictionary_get_field.rs
@@ -115,7 +115,7 @@ impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryGetFieldRequest<D,
     }
 }
 
-/// Response object for a [DictionaryGetField](crate::cache::DictionaryGetField).
+/// Response object for a [DictionaryGetFieldRequest](crate::cache::DictionaryGetFieldRequest).
 ///
 /// If you'd like to handle misses you can simply match and handle your response:
 /// ```

--- a/src/cache/messages/dictionary/dictionary_get_fields.rs
+++ b/src/cache/messages/dictionary/dictionary_get_fields.rs
@@ -27,7 +27,7 @@ use std::convert::{TryFrom, TryInto};
 /// # use std::convert::TryInto;
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
-/// use momento::cache::{DictionaryGetFields, DictionaryGetFieldsRequest};
+/// use momento::cache::{DictionaryGetFieldsResponse, DictionaryGetFieldsRequest};
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 /// let dictionary_name = "dictionary";
 /// let fields = vec!["field1", "field2"];
@@ -73,7 +73,7 @@ impl<D: IntoBytes, F: IntoBytesIterable + Clone> DictionaryGetFieldsRequest<D, F
 impl<D: IntoBytes, F: IntoBytesIterable + Clone> MomentoRequest
     for DictionaryGetFieldsRequest<D, F>
 {
-    type Response = DictionaryGetFields<F>;
+    type Response = DictionaryGetFieldsResponse<F>;
 
     async fn send(self, cache_client: &CacheClient) -> MomentoResult<Self::Response> {
         let request = prep_request_with_timeout(
@@ -93,7 +93,7 @@ impl<D: IntoBytes, F: IntoBytesIterable + Clone> MomentoRequest
             .into_inner();
 
         match response.dictionary {
-            Some(DictionaryProto::Missing(_)) => Ok(DictionaryGetFields::Miss),
+            Some(DictionaryProto::Missing(_)) => Ok(DictionaryGetFieldsResponse::Miss),
             Some(DictionaryProto::Found(elements)) => {
                 let responses: Result<Vec<DictionaryGetFieldResponse>, MomentoError> = elements
                     .items
@@ -111,7 +111,7 @@ impl<D: IntoBytes, F: IntoBytesIterable + Clone> MomentoRequest
                     .collect();
 
                 match responses {
-                    Ok(responses) => Ok(DictionaryGetFields::Hit {
+                    Ok(responses) => Ok(DictionaryGetFieldsResponse::Hit {
                         fields: self.fields,
                         responses,
                     }),
@@ -126,19 +126,19 @@ impl<D: IntoBytes, F: IntoBytesIterable + Clone> MomentoRequest
     }
 }
 
-/// Response object for a [DictionaryGetFields](crate::cache::DictionaryGetFields).
+/// Response object for a [DictionaryGetFieldsRequest](crate::cache::DictionaryGetFieldsRequest).
 ///
 /// If you'd like to handle misses you can simply match and handle your response:
 /// ```
 /// fn main() -> anyhow::Result<()> {
 /// # use std::collections::HashMap;
-/// # use momento::cache::DictionaryGetFields;
+/// # use momento::cache::DictionaryGetFieldsResponse;
 /// # use momento::MomentoResult;
-/// # let fetch_response: DictionaryGetFields<Vec<String>> = DictionaryGetFields::default();
+/// # let fetch_response: DictionaryGetFieldsResponse<Vec<String>> = DictionaryGetFieldsResponse::default();
 /// use std::convert::TryInto;
 /// let item: HashMap<String, String> = match fetch_response {
-///   DictionaryGetFields::Hit { .. } => fetch_response.try_into().expect("I stored strings!"),
-///   DictionaryGetFields::Miss => panic!("I expected a hit!"),
+///   DictionaryGetFieldsResponse::Hit { .. } => fetch_response.try_into().expect("I stored strings!"),
+///   DictionaryGetFieldsResponse::Miss => panic!("I expected a hit!"),
 /// };
 /// # Ok(())
 /// }
@@ -147,13 +147,13 @@ impl<D: IntoBytes, F: IntoBytesIterable + Clone> MomentoRequest
 /// Or if you're storing raw bytes you can get at them simply:
 /// ```
 /// # use std::collections::HashMap;
-/// # use momento::cache::DictionaryGetFields;
+/// # use momento::cache::DictionaryGetFieldsResponse;
 /// # use momento::MomentoResult;
-/// # let fetch_response: DictionaryGetFields<Vec<String>> = DictionaryGetFields::default();
+/// # let fetch_response: DictionaryGetFieldsResponse<Vec<String>> = DictionaryGetFieldsResponse::default();
 /// use std::convert::TryInto;
 /// let item: HashMap<Vec<u8>, Vec<u8>> = match fetch_response {
-///  DictionaryGetFields::Hit { .. } => fetch_response.try_into().expect("I stored raw bytes!"),
-/// DictionaryGetFields::Miss => panic!("I expected a hit!"),
+///  DictionaryGetFieldsResponse::Hit { .. } => fetch_response.try_into().expect("I stored raw bytes!"),
+/// DictionaryGetFieldsResponse::Miss => panic!("I expected a hit!"),
 /// };
 /// ```
 ///
@@ -164,9 +164,9 @@ impl<D: IntoBytes, F: IntoBytesIterable + Clone> MomentoRequest
 /// this is what you're after:
 /// ```
 /// # use std::collections::HashMap;
-/// # use momento::cache::DictionaryGetFields;
+/// # use momento::cache::DictionaryGetFieldsResponse;
 /// # use momento::MomentoResult;
-/// # let fetch_response: DictionaryGetFields<Vec<String>> = DictionaryGetFields::default();
+/// # let fetch_response: DictionaryGetFieldsResponse<Vec<String>> = DictionaryGetFieldsResponse::default();
 /// use std::convert::TryInto;
 /// let item: MomentoResult<HashMap<String, String>> = fetch_response.try_into();
 /// ```
@@ -174,14 +174,14 @@ impl<D: IntoBytes, F: IntoBytesIterable + Clone> MomentoRequest
 /// You can also go straight into a `HashMap<Vec<u8>, Vec<u8>>` if you prefer:
 /// ```
 /// # use std::collections::HashMap;
-/// # use momento::cache::DictionaryGetFields;
+/// # use momento::cache::DictionaryGetFieldsResponse;
 /// # use momento::MomentoResult;
-/// # let fetch_response: DictionaryGetFields<Vec<String>> = DictionaryGetFields::default();
+/// # let fetch_response: DictionaryGetFieldsResponse<Vec<String>> = DictionaryGetFieldsResponse::default();
 /// use std::convert::TryInto;
 /// let item: MomentoResult<HashMap<Vec<u8>, Vec<u8>>> = fetch_response.try_into();
 /// ```
 #[derive(Debug, PartialEq, Eq)]
-pub enum DictionaryGetFields<F: IntoBytesIterable> {
+pub enum DictionaryGetFieldsResponse<F: IntoBytesIterable> {
     Hit {
         fields: F,
         responses: Vec<DictionaryGetFieldResponse>,
@@ -189,21 +189,21 @@ pub enum DictionaryGetFields<F: IntoBytesIterable> {
     Miss,
 }
 
-impl<F: IntoBytes> Default for DictionaryGetFields<Vec<F>> {
+impl<F: IntoBytes> Default for DictionaryGetFieldsResponse<Vec<F>> {
     fn default() -> Self {
-        DictionaryGetFields::Hit {
+        DictionaryGetFieldsResponse::Hit {
             fields: vec![],
             responses: vec![],
         }
     }
 }
 
-impl<F: IntoBytesIterable> TryFrom<DictionaryGetFields<F>> for HashMap<String, String> {
+impl<F: IntoBytesIterable> TryFrom<DictionaryGetFieldsResponse<F>> for HashMap<String, String> {
     type Error = MomentoError;
 
-    fn try_from(value: DictionaryGetFields<F>) -> Result<Self, Self::Error> {
+    fn try_from(value: DictionaryGetFieldsResponse<F>) -> Result<Self, Self::Error> {
         match value {
-            DictionaryGetFields::Hit {
+            DictionaryGetFieldsResponse::Hit {
                 fields, responses, ..
             } => {
                 let mut result = HashMap::new();
@@ -221,17 +221,17 @@ impl<F: IntoBytesIterable> TryFrom<DictionaryGetFields<F>> for HashMap<String, S
                 Ok(result)
             }
             // In other SDKs we do not convert a `Miss` into an empty HashMap
-            DictionaryGetFields::Miss => Err(MomentoError::miss("DictionaryGetFields")),
+            DictionaryGetFieldsResponse::Miss => Err(MomentoError::miss("DictionaryGetFields")),
         }
     }
 }
 
-impl<F: IntoBytesIterable> TryFrom<DictionaryGetFields<F>> for HashMap<Vec<u8>, Vec<u8>> {
+impl<F: IntoBytesIterable> TryFrom<DictionaryGetFieldsResponse<F>> for HashMap<Vec<u8>, Vec<u8>> {
     type Error = MomentoError;
 
-    fn try_from(value: DictionaryGetFields<F>) -> Result<Self, Self::Error> {
+    fn try_from(value: DictionaryGetFieldsResponse<F>) -> Result<Self, Self::Error> {
         match value {
-            DictionaryGetFields::Hit {
+            DictionaryGetFieldsResponse::Hit {
                 fields, responses, ..
             } => {
                 let mut result = HashMap::new();
@@ -247,7 +247,7 @@ impl<F: IntoBytesIterable> TryFrom<DictionaryGetFields<F>> for HashMap<Vec<u8>, 
                 Ok(result)
             }
             // In other SDKs we do not convert a `Miss` into an empty HashMap
-            DictionaryGetFields::Miss => Err(MomentoError {
+            DictionaryGetFieldsResponse::Miss => Err(MomentoError {
                 message: "dictionary get fields response was a miss".into(),
                 error_code: MomentoErrorCode::Miss,
                 inner_error: None,

--- a/src/cache/messages/dictionary/dictionary_increment.rs
+++ b/src/cache/messages/dictionary/dictionary_increment.rs
@@ -22,7 +22,7 @@ use crate::{
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
-/// use momento::cache::{CollectionTtl, DictionaryIncrement, DictionaryIncrementRequest};
+/// use momento::cache::{CollectionTtl, DictionaryIncrementResponse, DictionaryIncrementRequest};
 /// use momento::MomentoErrorCode;
 ///
 /// let dictionary_name = "dictionary";
@@ -73,9 +73,9 @@ impl<D: IntoBytes, F: IntoBytes> DictionaryIncrementRequest<D, F> {
 }
 
 impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryIncrementRequest<D, F> {
-    type Response = DictionaryIncrement;
+    type Response = DictionaryIncrementResponse;
 
-    async fn send(self, cache_client: &CacheClient) -> MomentoResult<DictionaryIncrement> {
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<DictionaryIncrementResponse> {
         let collection_ttl = self.collection_ttl.unwrap_or_default();
         let request = prep_request_with_timeout(
             &self.cache_name,
@@ -95,18 +95,18 @@ impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryIncrementRequest<D
             .dictionary_increment(request)
             .await?
             .into_inner();
-        Ok(DictionaryIncrement {
+        Ok(DictionaryIncrementResponse {
             value: response.value,
         })
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct DictionaryIncrement {
+pub struct DictionaryIncrementResponse {
     pub value: i64,
 }
 
-impl DictionaryIncrement {
+impl DictionaryIncrementResponse {
     pub fn value(self) -> i64 {
         self.value
     }

--- a/src/cache/messages/dictionary/dictionary_remove_field.rs
+++ b/src/cache/messages/dictionary/dictionary_remove_field.rs
@@ -19,7 +19,7 @@ use momento_protos::cache_client::{
 /// # fn main() -> anyhow::Result<()> {
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
-/// use momento::cache::{DictionaryRemoveField, DictionaryRemoveFieldRequest};
+/// use momento::cache::{DictionaryRemoveFieldResponse, DictionaryRemoveFieldRequest};
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 /// let dictionary_name = "dictionary";
 /// let field = "field";
@@ -31,7 +31,7 @@ use momento_protos::cache_client::{
 /// );
 ///
 /// match cache_client.send_request(remove_field_request).await {
-///   Ok(DictionaryRemoveField {}) => println!("Field removed from dictionary"),
+///   Ok(DictionaryRemoveFieldResponse {}) => println!("Field removed from dictionary"),
 ///   Err(e) => eprintln!("Error removing field from dictionary: {}", e),
 /// }
 /// # Ok(())
@@ -55,7 +55,7 @@ impl<D: IntoBytes, F: IntoBytes> DictionaryRemoveFieldRequest<D, F> {
 }
 
 impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryRemoveFieldRequest<D, F> {
-    type Response = DictionaryRemoveField;
+    type Response = DictionaryRemoveFieldResponse;
 
     async fn send(self, cache_client: &CacheClient) -> Result<Self::Response, MomentoError> {
         let fields_to_delete = DictionaryFieldSelector::Some {
@@ -77,9 +77,9 @@ impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryRemoveFieldRequest
             .await?
             .into_inner();
 
-        Ok(DictionaryRemoveField {})
+        Ok(DictionaryRemoveFieldResponse {})
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct DictionaryRemoveField {}
+pub struct DictionaryRemoveFieldResponse {}

--- a/src/cache/messages/dictionary/dictionary_remove_fields.rs
+++ b/src/cache/messages/dictionary/dictionary_remove_fields.rs
@@ -20,7 +20,7 @@ use momento_protos::cache_client::{
 /// # fn main() -> anyhow::Result<()> {
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
-/// use momento::cache::{DictionaryRemoveFields, DictionaryRemoveFieldsRequest};
+/// use momento::cache::{DictionaryRemoveFieldsResponse, DictionaryRemoveFieldsRequest};
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 /// let dictionary_name = "dictionary";
 /// let fields = vec!["field1", "field2"];
@@ -32,7 +32,7 @@ use momento_protos::cache_client::{
 /// );
 ///
 /// match cache_client.send_request(remove_fields_request).await {
-///   Ok(DictionaryRemoveFields {}) => println!("Fields removed from dictionary"),
+///   Ok(DictionaryRemoveFieldsResponse {}) => println!("Fields removed from dictionary"),
 ///   Err(e) => eprintln!("Error removing fields from dictionary: {}", e),
 /// }
 /// # Ok(())
@@ -56,7 +56,7 @@ impl<D: IntoBytes, F: IntoBytesIterable> DictionaryRemoveFieldsRequest<D, F> {
 }
 
 impl<D: IntoBytes, F: IntoBytesIterable> MomentoRequest for DictionaryRemoveFieldsRequest<D, F> {
-    type Response = DictionaryRemoveFields;
+    type Response = DictionaryRemoveFieldsResponse;
 
     async fn send(self, cache_client: &CacheClient) -> Result<Self::Response, MomentoError> {
         let fields_to_delete = DictionaryFieldSelector::Some {
@@ -78,9 +78,9 @@ impl<D: IntoBytes, F: IntoBytesIterable> MomentoRequest for DictionaryRemoveFiel
             .await?
             .into_inner();
 
-        Ok(DictionaryRemoveFields {})
+        Ok(DictionaryRemoveFieldsResponse {})
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct DictionaryRemoveFields {}
+pub struct DictionaryRemoveFieldsResponse {}

--- a/src/cache/messages/dictionary/dictionary_set_field.rs
+++ b/src/cache/messages/dictionary/dictionary_set_field.rs
@@ -26,7 +26,7 @@ use momento_protos::cache_client::{
 /// # fn main() -> anyhow::Result<()> {
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
-/// use momento::cache::{CollectionTtl, DictionarySetField, DictionarySetFieldRequest};
+/// use momento::cache::{CollectionTtl, DictionarySetFieldResponse, DictionarySetFieldRequest};
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 /// let dictionary_name = "dictionary";
 ///
@@ -87,7 +87,7 @@ where
     F: IntoBytes,
     V: IntoBytes,
 {
-    type Response = DictionarySetField;
+    type Response = DictionarySetFieldResponse;
 
     async fn send(self, cache_client: &CacheClient) -> MomentoResult<Self::Response> {
         let collection_ttl = self.collection_ttl.unwrap_or_default();
@@ -111,9 +111,9 @@ where
             .dictionary_set(request)
             .await?;
 
-        Ok(DictionarySetField {})
+        Ok(DictionarySetFieldResponse {})
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct DictionarySetField {}
+pub struct DictionarySetFieldResponse {}

--- a/src/cache/messages/dictionary/dictionary_set_fields.rs
+++ b/src/cache/messages/dictionary/dictionary_set_fields.rs
@@ -66,7 +66,7 @@ impl<F: IntoBytes, V: IntoBytes> IntoDictionaryFieldValuePairs<F, V> for HashMap
 /// # fn main() -> anyhow::Result<()> {
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
-/// use momento::cache::{CollectionTtl, DictionarySetFields, DictionarySetFieldsRequest};
+/// use momento::cache::{CollectionTtl, DictionarySetFieldsResponse, DictionarySetFieldsRequest};
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 /// let dictionary_name = "dictionary";
 ///
@@ -133,7 +133,7 @@ where
     V: IntoBytes,
     E: IntoDictionaryFieldValuePairs<F, V>,
 {
-    type Response = DictionarySetFields;
+    type Response = DictionarySetFieldsResponse;
 
     async fn send(self, cache_client: &CacheClient) -> MomentoResult<Self::Response> {
         let collection_ttl = self.collection_ttl.unwrap_or_default();
@@ -162,9 +162,9 @@ where
             .dictionary_set(request)
             .await?;
 
-        Ok(DictionarySetFields {})
+        Ok(DictionarySetFieldsResponse {})
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct DictionarySetFields {}
+pub struct DictionarySetFieldsResponse {}

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -28,7 +28,7 @@ pub use messages::dictionary::dictionary_remove_field::{
     DictionaryRemoveFieldRequest, DictionaryRemoveFieldResponse,
 };
 pub use messages::dictionary::dictionary_remove_fields::{
-    DictionaryRemoveFields, DictionaryRemoveFieldsRequest,
+    DictionaryRemoveFieldsRequest, DictionaryRemoveFieldsResponse,
 };
 pub use messages::dictionary::dictionary_set_field::{
     DictionarySetField, DictionarySetFieldRequest,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -16,7 +16,7 @@ pub use messages::dictionary::dictionary_get_field::{
     DictionaryGetFieldRequest, DictionaryGetFieldResponse,
 };
 pub use messages::dictionary::dictionary_get_fields::{
-    DictionaryGetFields, DictionaryGetFieldsRequest,
+    DictionaryGetFieldsRequest, DictionaryGetFieldsResponse,
 };
 pub use messages::dictionary::dictionary_increment::{
     DictionaryIncrement, DictionaryIncrementRequest,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -19,7 +19,7 @@ pub use messages::dictionary::dictionary_get_fields::{
     DictionaryGetFieldsRequest, DictionaryGetFieldsResponse,
 };
 pub use messages::dictionary::dictionary_increment::{
-    DictionaryIncrement, DictionaryIncrementRequest,
+    DictionaryIncrementRequest, DictionaryIncrementResponse,
 };
 pub use messages::dictionary::dictionary_length::{DictionaryLength, DictionaryLengthRequest};
 pub use messages::dictionary::dictionary_remove_field::{

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -21,7 +21,9 @@ pub use messages::dictionary::dictionary_get_fields::{
 pub use messages::dictionary::dictionary_increment::{
     DictionaryIncrementRequest, DictionaryIncrementResponse,
 };
-pub use messages::dictionary::dictionary_length::{DictionaryLength, DictionaryLengthRequest};
+pub use messages::dictionary::dictionary_length::{
+    DictionaryLengthRequest, DictionaryLengthResponse,
+};
 pub use messages::dictionary::dictionary_remove_field::{
     DictionaryRemoveField, DictionaryRemoveFieldRequest,
 };

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -13,7 +13,7 @@ pub use messages::dictionary::dictionary_fetch::{
     DictionaryFetchRequest, DictionaryFetchResponse, DictionaryFetchValue,
 };
 pub use messages::dictionary::dictionary_get_field::{
-    DictionaryGetField, DictionaryGetFieldRequest,
+    DictionaryGetFieldRequest, DictionaryGetFieldResponse,
 };
 pub use messages::dictionary::dictionary_get_fields::{
     DictionaryGetFields, DictionaryGetFieldsRequest,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -25,7 +25,7 @@ pub use messages::dictionary::dictionary_length::{
     DictionaryLengthRequest, DictionaryLengthResponse,
 };
 pub use messages::dictionary::dictionary_remove_field::{
-    DictionaryRemoveField, DictionaryRemoveFieldRequest,
+    DictionaryRemoveFieldRequest, DictionaryRemoveFieldResponse,
 };
 pub use messages::dictionary::dictionary_remove_fields::{
     DictionaryRemoveFields, DictionaryRemoveFieldsRequest,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -31,7 +31,7 @@ pub use messages::dictionary::dictionary_remove_fields::{
     DictionaryRemoveFieldsRequest, DictionaryRemoveFieldsResponse,
 };
 pub use messages::dictionary::dictionary_set_field::{
-    DictionarySetField, DictionarySetFieldRequest,
+    DictionarySetFieldRequest, DictionarySetFieldResponse,
 };
 pub use messages::dictionary::dictionary_set_fields::{
     DictionaryFieldValuePair, DictionarySetFields, DictionarySetFieldsRequest,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -34,7 +34,7 @@ pub use messages::dictionary::dictionary_set_field::{
     DictionarySetFieldRequest, DictionarySetFieldResponse,
 };
 pub use messages::dictionary::dictionary_set_fields::{
-    DictionaryFieldValuePair, DictionarySetFields, DictionarySetFieldsRequest,
+    DictionaryFieldValuePair, DictionarySetFieldsRequest, DictionarySetFieldsResponse,
     IntoDictionaryFieldValuePairs,
 };
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -10,7 +10,7 @@ pub use messages::list_caches::{
 };
 
 pub use messages::dictionary::dictionary_fetch::{
-    DictionaryFetch, DictionaryFetchRequest, DictionaryFetchValue,
+    DictionaryFetchRequest, DictionaryFetchResponse, DictionaryFetchValue,
 };
 pub use messages::dictionary::dictionary_get_field::{
     DictionaryGetField, DictionaryGetFieldRequest,

--- a/tests/cache/dictionary.rs
+++ b/tests/cache/dictionary.rs
@@ -1,6 +1,6 @@
 use momento::cache::{
     DictionaryFetchResponse, DictionaryGetFieldResponse, DictionaryGetFieldsResponse,
-    DictionaryIncrementResponse, DictionaryLengthResponse, DictionaryRemoveField,
+    DictionaryIncrementResponse, DictionaryLengthResponse, DictionaryRemoveFieldResponse,
     DictionaryRemoveFields, DictionarySetField, DictionarySetFields,
 };
 use momento::{MomentoError, MomentoErrorCode, MomentoResult};
@@ -275,7 +275,7 @@ mod dictionary_remove_field {
         let response = client
             .dictionary_remove_field(cache_name, item.name(), pair.0.clone())
             .await?;
-        assert_eq!(response, DictionaryRemoveField {});
+        assert_eq!(response, DictionaryRemoveFieldResponse {});
 
         let result = client.dictionary_fetch(cache_name, item.name()).await?;
         assert_fetched_dictionary_equals_test_data(result, &item2)?;

--- a/tests/cache/dictionary.rs
+++ b/tests/cache/dictionary.rs
@@ -1,5 +1,5 @@
 use momento::cache::{
-    DictionaryFetchResponse, DictionaryGetField, DictionaryGetFields, DictionaryIncrement,
+    DictionaryFetchResponse, DictionaryGetFieldResponse, DictionaryGetFields, DictionaryIncrement,
     DictionaryLength, DictionaryRemoveField, DictionaryRemoveFields, DictionarySetField,
     DictionarySetFields,
 };
@@ -87,13 +87,13 @@ mod dictionary_get_field {
             .dictionary_get_field(cache_name, item.name(), field.clone())
             .await?;
         match result {
-            DictionaryGetField::Hit { .. } => {
+            DictionaryGetFieldResponse::Hit { .. } => {
                 let actual: String = result
                     .try_into()
                     .expect("Stored string but could not convert into String");
                 assert_eq!(actual, *value);
             }
-            DictionaryGetField::Miss => panic!("I expected a hit!"),
+            DictionaryGetFieldResponse::Miss => panic!("I expected a hit!"),
         }
         Ok(())
     }

--- a/tests/cache/dictionary.rs
+++ b/tests/cache/dictionary.rs
@@ -1,7 +1,7 @@
 use momento::cache::{
     DictionaryFetchResponse, DictionaryGetFieldResponse, DictionaryGetFieldsResponse,
     DictionaryIncrementResponse, DictionaryLengthResponse, DictionaryRemoveFieldResponse,
-    DictionaryRemoveFields, DictionarySetField, DictionarySetFields,
+    DictionaryRemoveFieldsResponse, DictionarySetField, DictionarySetFields,
 };
 use momento::{MomentoError, MomentoErrorCode, MomentoResult};
 use momento_test_util::{
@@ -334,7 +334,7 @@ mod dictionary_remove_fields {
                 item.value().keys().cloned().collect::<Vec<String>>(),
             )
             .await?;
-        assert_eq!(response, DictionaryRemoveFields {});
+        assert_eq!(response, DictionaryRemoveFieldsResponse {});
 
         let result = client.dictionary_fetch(cache_name, item.name()).await?;
         assert_fetched_dictionary_equals_test_data(result, &item2)?;
@@ -504,7 +504,7 @@ mod dictionary_length {
                 item1.value().keys().cloned().collect::<Vec<String>>(),
             )
             .await?;
-        assert_eq!(response, DictionaryRemoveFields {});
+        assert_eq!(response, DictionaryRemoveFieldsResponse {});
 
         let result = client.dictionary_length(cache_name, item1.name()).await?;
         assert_eq!(

--- a/tests/cache/dictionary.rs
+++ b/tests/cache/dictionary.rs
@@ -1,5 +1,5 @@
 use momento::cache::{
-    DictionaryFetch, DictionaryGetField, DictionaryGetFields, DictionaryIncrement,
+    DictionaryFetchResponse, DictionaryGetField, DictionaryGetFields, DictionaryIncrement,
     DictionaryLength, DictionaryRemoveField, DictionaryRemoveFields, DictionarySetField,
     DictionarySetFields,
 };
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 
 fn assert_fetched_dictionary_equals_test_data(
-    dictionary_fetch_result: DictionaryFetch,
+    dictionary_fetch_result: DictionaryFetchResponse,
     expected: &TestDictionary,
 ) -> Result<(), MomentoError> {
     let actual: HashMap<String, String> = dictionary_fetch_result.try_into()?;
@@ -30,7 +30,7 @@ mod dictionary_fetch {
         // Test a miss
         let dictionary_name = unique_key();
         let result = client.dictionary_fetch(cache_name, dictionary_name).await?;
-        assert_eq!(result, DictionaryFetch::Miss);
+        assert_eq!(result, DictionaryFetchResponse::Miss);
 
         // Test a hit
         let item = TestDictionary::new();

--- a/tests/cache/dictionary.rs
+++ b/tests/cache/dictionary.rs
@@ -1,7 +1,7 @@
 use momento::cache::{
-    DictionaryFetchResponse, DictionaryGetFieldResponse, DictionaryGetFields, DictionaryIncrement,
-    DictionaryLength, DictionaryRemoveField, DictionaryRemoveFields, DictionarySetField,
-    DictionarySetFields,
+    DictionaryFetchResponse, DictionaryGetFieldResponse, DictionaryGetFieldsResponse,
+    DictionaryIncrement, DictionaryLength, DictionaryRemoveField, DictionaryRemoveFields,
+    DictionarySetField, DictionarySetFields,
 };
 use momento::{MomentoError, MomentoErrorCode, MomentoResult};
 use momento_test_util::{
@@ -153,11 +153,11 @@ mod dictionary_get_fields {
             )
             .await?;
         match result {
-            DictionaryGetFields::Hit { .. } => {
+            DictionaryGetFieldsResponse::Hit { .. } => {
                 let actual: HashMap<String, String> = result.try_into().expect("Stored string-string field-value pairs but could not convert into HashMap<String, String>");
                 assert_eq!(actual, *item.value());
             }
-            DictionaryGetFields::Miss => panic!("I expected a hit!"),
+            DictionaryGetFieldsResponse::Miss => panic!("I expected a hit!"),
         }
         Ok(())
     }

--- a/tests/cache/dictionary.rs
+++ b/tests/cache/dictionary.rs
@@ -1,7 +1,7 @@
 use momento::cache::{
     DictionaryFetchResponse, DictionaryGetFieldResponse, DictionaryGetFieldsResponse,
-    DictionaryIncrementResponse, DictionaryLength, DictionaryRemoveField, DictionaryRemoveFields,
-    DictionarySetField, DictionarySetFields,
+    DictionaryIncrementResponse, DictionaryLengthResponse, DictionaryRemoveField,
+    DictionaryRemoveFields, DictionarySetField, DictionarySetFields,
 };
 use momento::{MomentoError, MomentoErrorCode, MomentoResult};
 use momento_test_util::{
@@ -477,7 +477,7 @@ mod dictionary_length {
 
         // Length of a missing dictionary is not defined; it's a miss
         let result = client.dictionary_length(cache_name, unique_key()).await?;
-        assert_eq!(result, DictionaryLength::Miss);
+        assert_eq!(result, DictionaryLengthResponse::Miss);
 
         // Length of a stored dictionary should work
         // Add 4 items to the dictionary
@@ -494,7 +494,7 @@ mod dictionary_length {
         assert_eq!(response, DictionarySetFields {});
 
         let result = client.dictionary_length(cache_name, item1.name()).await?;
-        assert_eq!(result, DictionaryLength::Hit { length: 4 });
+        assert_eq!(result, DictionaryLengthResponse::Hit { length: 4 });
 
         // And after removing some fields we should have fewer
         let response = client
@@ -509,7 +509,7 @@ mod dictionary_length {
         let result = client.dictionary_length(cache_name, item1.name()).await?;
         assert_eq!(
             result,
-            DictionaryLength::Hit {
+            DictionaryLengthResponse::Hit {
                 length: item2.value().len() as u32
             }
         );

--- a/tests/cache/dictionary.rs
+++ b/tests/cache/dictionary.rs
@@ -1,6 +1,6 @@
 use momento::cache::{
     DictionaryFetchResponse, DictionaryGetFieldResponse, DictionaryGetFieldsResponse,
-    DictionaryIncrement, DictionaryLength, DictionaryRemoveField, DictionaryRemoveFields,
+    DictionaryIncrementResponse, DictionaryLength, DictionaryRemoveField, DictionaryRemoveFields,
     DictionarySetField, DictionarySetFields,
 };
 use momento::{MomentoError, MomentoErrorCode, MomentoResult};
@@ -205,7 +205,7 @@ mod dictionary_increment {
         let response = client
             .dictionary_increment(cache_name, item.name(), "number", 1)
             .await?;
-        assert_eq!(response, DictionaryIncrement { value: 1 });
+        assert_eq!(response, DictionaryIncrementResponse { value: 1 });
 
         let (field, _) = item.value().iter().next().unwrap();
 

--- a/tests/cache/dictionary.rs
+++ b/tests/cache/dictionary.rs
@@ -1,7 +1,7 @@
 use momento::cache::{
     DictionaryFetchResponse, DictionaryGetFieldResponse, DictionaryGetFieldsResponse,
     DictionaryIncrementResponse, DictionaryLengthResponse, DictionaryRemoveFieldResponse,
-    DictionaryRemoveFieldsResponse, DictionarySetFieldResponse, DictionarySetFields,
+    DictionaryRemoveFieldsResponse, DictionarySetFieldResponse, DictionarySetFieldsResponse,
 };
 use momento::{MomentoError, MomentoErrorCode, MomentoResult};
 use momento_test_util::{
@@ -37,7 +37,7 @@ mod dictionary_fetch {
         let dictionary_set_response = client
             .dictionary_set_fields(cache_name, item.name(), item.value().clone())
             .await?;
-        assert_eq!(dictionary_set_response, DictionarySetFields {});
+        assert_eq!(dictionary_set_response, DictionarySetFieldsResponse {});
         let result = client.dictionary_fetch(cache_name, item.name()).await?;
         assert_fetched_dictionary_equals_test_data(result, &item)?;
         Ok(())
@@ -78,7 +78,7 @@ mod dictionary_get_field {
         let response = client
             .dictionary_set_fields(cache_name, item.name(), item.value().clone())
             .await?;
-        assert_eq!(response, DictionarySetFields {});
+        assert_eq!(response, DictionarySetFieldsResponse {});
 
         let (field, value) = item.value().iter().next().unwrap();
 
@@ -136,13 +136,13 @@ mod dictionary_get_fields {
         let response = client
             .dictionary_set_fields(cache_name, item.name(), item.value().clone())
             .await?;
-        assert_eq!(response, DictionarySetFields {});
+        assert_eq!(response, DictionarySetFieldsResponse {});
 
         let item2 = TestDictionary::new();
         let response = client
             .dictionary_set_fields(cache_name, item2.name(), item2.value().clone())
             .await?;
-        assert_eq!(response, DictionarySetFields {});
+        assert_eq!(response, DictionarySetFieldsResponse {});
 
         // Now get the values relevant to the first dictionary
         let result = client
@@ -200,7 +200,7 @@ mod dictionary_increment {
         let response = client
             .dictionary_set_fields(cache_name, item.name(), item.value().clone())
             .await?;
-        assert_eq!(response, DictionarySetFields {});
+        assert_eq!(response, DictionarySetFieldsResponse {});
 
         let response = client
             .dictionary_increment(cache_name, item.name(), "number", 1)
@@ -264,13 +264,13 @@ mod dictionary_remove_field {
         let response = client
             .dictionary_set_fields(cache_name, item.name(), item.value().clone())
             .await?;
-        assert_eq!(response, DictionarySetFields {});
+        assert_eq!(response, DictionarySetFieldsResponse {});
 
         let item2 = TestDictionary::new();
         let response = client
             .dictionary_set_fields(cache_name, item.name(), item2.value().clone())
             .await?;
-        assert_eq!(response, DictionarySetFields {});
+        assert_eq!(response, DictionarySetFieldsResponse {});
 
         let response = client
             .dictionary_remove_field(cache_name, item.name(), pair.0.clone())
@@ -319,13 +319,13 @@ mod dictionary_remove_fields {
         let response = client
             .dictionary_set_fields(cache_name, item.name(), item.value().clone())
             .await?;
-        assert_eq!(response, DictionarySetFields {});
+        assert_eq!(response, DictionarySetFieldsResponse {});
 
         let item2 = TestDictionary::new();
         let response = client
             .dictionary_set_fields(cache_name, item.name(), item2.value().clone())
             .await?;
-        assert_eq!(response, DictionarySetFields {});
+        assert_eq!(response, DictionarySetFieldsResponse {});
 
         let response = client
             .dictionary_remove_fields(
@@ -427,7 +427,7 @@ mod dictionary_set_fields {
         let response = client
             .dictionary_set_fields(cache_name, item.name(), item.value().clone())
             .await?;
-        assert_eq!(response, DictionarySetFields {});
+        assert_eq!(response, DictionarySetFieldsResponse {});
 
         let result = client.dictionary_fetch(cache_name, item.name()).await?;
         assert_fetched_dictionary_equals_test_data(result, &item)?;
@@ -485,13 +485,13 @@ mod dictionary_length {
         let response = client
             .dictionary_set_fields(cache_name, item1.name(), item1.value().clone())
             .await?;
-        assert_eq!(response, DictionarySetFields {});
+        assert_eq!(response, DictionarySetFieldsResponse {});
 
         let item2 = TestDictionary::new();
         let response = client
             .dictionary_set_fields(cache_name, item1.name(), item2.value().clone())
             .await?;
-        assert_eq!(response, DictionarySetFields {});
+        assert_eq!(response, DictionarySetFieldsResponse {});
 
         let result = client.dictionary_length(cache_name, item1.name()).await?;
         assert_eq!(result, DictionaryLengthResponse::Hit { length: 4 });

--- a/tests/cache/dictionary.rs
+++ b/tests/cache/dictionary.rs
@@ -1,7 +1,7 @@
 use momento::cache::{
     DictionaryFetchResponse, DictionaryGetFieldResponse, DictionaryGetFieldsResponse,
     DictionaryIncrementResponse, DictionaryLengthResponse, DictionaryRemoveFieldResponse,
-    DictionaryRemoveFieldsResponse, DictionarySetField, DictionarySetFields,
+    DictionaryRemoveFieldsResponse, DictionarySetFieldResponse, DictionarySetFields,
 };
 use momento::{MomentoError, MomentoErrorCode, MomentoResult};
 use momento_test_util::{
@@ -383,7 +383,7 @@ mod dictionary_set_field {
         let response = client
             .dictionary_set_field(cache_name, item.name(), pair.0, pair.1)
             .await?;
-        assert_eq!(response, DictionarySetField {});
+        assert_eq!(response, DictionarySetFieldResponse {});
 
         let result = client.dictionary_fetch(cache_name, item.name()).await?;
         assert_fetched_dictionary_equals_test_data(result, &item)?;


### PR DESCRIPTION
Adds the suffix `Response` to all dictionary response types to code and docstrings.

Work towards #285 