### PR TITLE
feat: add response suffix to list types

### DIFF
--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -20,10 +20,10 @@ use crate::cache::{
     ItemGetType, ItemGetTypeRequest, KeyExists, KeyExistsRequest, KeysExist, KeysExistRequest,
     ListCaches, ListCachesRequest, ListConcatenateBackRequest, ListConcatenateBackResponse,
     ListConcatenateFrontRequest, ListConcatenateFrontResponse, ListFetchRequest, ListFetchResponse,
-    ListLengthRequest, ListLengthResponse, ListPopBackRequest, ListPopBackResponse, ListPopFront,
-    ListPopFrontRequest, ListRemoveValue, ListRemoveValueRequest, MomentoRequest, Set,
-    SetAddElements, SetAddElementsRequest, SetFetch, SetFetchRequest, SetIfAbsent,
-    SetIfAbsentOrEqual, SetIfAbsentOrEqualRequest, SetIfAbsentRequest, SetIfEqual,
+    ListLengthRequest, ListLengthResponse, ListPopBackRequest, ListPopBackResponse,
+    ListPopFrontRequest, ListPopFrontResponse, ListRemoveValue, ListRemoveValueRequest,
+    MomentoRequest, Set, SetAddElements, SetAddElementsRequest, SetFetch, SetFetchRequest,
+    SetIfAbsent, SetIfAbsentOrEqual, SetIfAbsentOrEqualRequest, SetIfAbsentRequest, SetIfEqual,
     SetIfEqualRequest, SetIfNotEqual, SetIfNotEqualRequest, SetIfPresent, SetIfPresentAndNotEqual,
     SetIfPresentAndNotEqualRequest, SetIfPresentRequest, SetRemoveElements,
     SetRemoveElementsRequest, SetRequest, SortedSetFetch, SortedSetFetchByRankRequest,
@@ -2087,7 +2087,7 @@ impl CacheClient {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
     /// use std::convert::TryInto;
-    /// use momento::cache::{ListPopFront, ListPopFrontRequest};
+    /// use momento::cache::{ListPopFrontResponse, ListPopFrontRequest};
     /// use momento::MomentoErrorCode;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let list_name = "list-name";
@@ -2103,7 +2103,7 @@ impl CacheClient {
         &self,
         cache_name: impl Into<String>,
         list_name: impl IntoBytes,
-    ) -> MomentoResult<ListPopFront> {
+    ) -> MomentoResult<ListPopFrontResponse> {
         let request = ListPopFrontRequest::new(cache_name, list_name);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -19,18 +19,19 @@ use crate::cache::{
     IntoDictionaryFieldValuePairs, IntoSortedSetElements, ItemGetTtl, ItemGetTtlRequest,
     ItemGetType, ItemGetTypeRequest, KeyExists, KeyExistsRequest, KeysExist, KeysExistRequest,
     ListCaches, ListCachesRequest, ListConcatenateBackRequest, ListConcatenateBackResponse,
-    ListConcatenateFront, ListConcatenateFrontRequest, ListFetch, ListFetchRequest, ListLength,
-    ListLengthRequest, ListPopBack, ListPopBackRequest, ListPopFront, ListPopFrontRequest,
-    ListRemoveValue, ListRemoveValueRequest, MomentoRequest, Set, SetAddElements,
-    SetAddElementsRequest, SetFetch, SetFetchRequest, SetIfAbsent, SetIfAbsentOrEqual,
-    SetIfAbsentOrEqualRequest, SetIfAbsentRequest, SetIfEqual, SetIfEqualRequest, SetIfNotEqual,
-    SetIfNotEqualRequest, SetIfPresent, SetIfPresentAndNotEqual, SetIfPresentAndNotEqualRequest,
-    SetIfPresentRequest, SetRemoveElements, SetRemoveElementsRequest, SetRequest, SortedSetFetch,
-    SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest, SortedSetGetRank,
-    SortedSetGetRankRequest, SortedSetGetScore, SortedSetGetScoreRequest, SortedSetLength,
-    SortedSetLengthRequest, SortedSetOrder, SortedSetPutElement, SortedSetPutElementRequest,
-    SortedSetPutElements, SortedSetPutElementsRequest, SortedSetRemoveElements,
-    SortedSetRemoveElementsRequest, UpdateTtl, UpdateTtlRequest,
+    ListConcatenateFrontRequest, ListConcatenateFrontResponse, ListFetch, ListFetchRequest,
+    ListLength, ListLengthRequest, ListPopBack, ListPopBackRequest, ListPopFront,
+    ListPopFrontRequest, ListRemoveValue, ListRemoveValueRequest, MomentoRequest, Set,
+    SetAddElements, SetAddElementsRequest, SetFetch, SetFetchRequest, SetIfAbsent,
+    SetIfAbsentOrEqual, SetIfAbsentOrEqualRequest, SetIfAbsentRequest, SetIfEqual,
+    SetIfEqualRequest, SetIfNotEqual, SetIfNotEqualRequest, SetIfPresent, SetIfPresentAndNotEqual,
+    SetIfPresentAndNotEqualRequest, SetIfPresentRequest, SetRemoveElements,
+    SetRemoveElementsRequest, SetRequest, SortedSetFetch, SortedSetFetchByRankRequest,
+    SortedSetFetchByScoreRequest, SortedSetGetRank, SortedSetGetRankRequest, SortedSetGetScore,
+    SortedSetGetScoreRequest, SortedSetLength, SortedSetLengthRequest, SortedSetOrder,
+    SortedSetPutElement, SortedSetPutElementRequest, SortedSetPutElements,
+    SortedSetPutElementsRequest, SortedSetRemoveElements, SortedSetRemoveElementsRequest,
+    UpdateTtl, UpdateTtlRequest,
 };
 use crate::grpc::header_interceptor::HeaderInterceptor;
 
@@ -1917,7 +1918,7 @@ impl CacheClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::ListConcatenateFront;
+    /// use momento::cache::ListConcatenateFrontResponse;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let list_name = "list-name";
     ///
@@ -1942,7 +1943,7 @@ impl CacheClient {
         cache_name: impl Into<String>,
         list_name: impl IntoBytes,
         values: impl IntoBytesIterable,
-    ) -> MomentoResult<ListConcatenateFront> {
+    ) -> MomentoResult<ListConcatenateFrontResponse> {
         let request = ListConcatenateFrontRequest::new(cache_name, list_name, values);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -20,7 +20,7 @@ use crate::cache::{
     ItemGetType, ItemGetTypeRequest, KeyExists, KeyExistsRequest, KeysExist, KeysExistRequest,
     ListCaches, ListCachesRequest, ListConcatenateBackRequest, ListConcatenateBackResponse,
     ListConcatenateFrontRequest, ListConcatenateFrontResponse, ListFetchRequest, ListFetchResponse,
-    ListLengthRequest, ListLengthResponse, ListPopBack, ListPopBackRequest, ListPopFront,
+    ListLengthRequest, ListLengthResponse, ListPopBackRequest, ListPopBackResponse, ListPopFront,
     ListPopFrontRequest, ListRemoveValue, ListRemoveValueRequest, MomentoRequest, Set,
     SetAddElements, SetAddElementsRequest, SetFetch, SetFetchRequest, SetIfAbsent,
     SetIfAbsentOrEqual, SetIfAbsentOrEqualRequest, SetIfAbsentRequest, SetIfEqual,
@@ -2053,7 +2053,7 @@ impl CacheClient {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
     /// use std::convert::TryInto;
-    /// use momento::cache::{ListPopBack, ListPopBackRequest};
+    /// use momento::cache::{ListPopBackResponse, ListPopBackRequest};
     /// use momento::MomentoErrorCode;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let list_name = "list-name";
@@ -2069,7 +2069,7 @@ impl CacheClient {
         &self,
         cache_name: impl Into<String>,
         list_name: impl IntoBytes,
-    ) -> MomentoResult<ListPopBack> {
+    ) -> MomentoResult<ListPopBackResponse> {
         let request = ListPopBackRequest::new(cache_name, list_name);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -19,7 +19,7 @@ use crate::cache::{
     IntoDictionaryFieldValuePairs, IntoSortedSetElements, ItemGetTtl, ItemGetTtlRequest,
     ItemGetType, ItemGetTypeRequest, KeyExists, KeyExistsRequest, KeysExist, KeysExistRequest,
     ListCaches, ListCachesRequest, ListConcatenateBackRequest, ListConcatenateBackResponse,
-    ListConcatenateFrontRequest, ListConcatenateFrontResponse, ListFetch, ListFetchRequest,
+    ListConcatenateFrontRequest, ListConcatenateFrontResponse, ListFetchRequest, ListFetchResponse,
     ListLength, ListLengthRequest, ListPopBack, ListPopBackRequest, ListPopFront,
     ListPopFrontRequest, ListRemoveValue, ListRemoveValueRequest, MomentoRequest, Set,
     SetAddElements, SetAddElementsRequest, SetFetch, SetFetchRequest, SetIfAbsent,
@@ -2018,7 +2018,7 @@ impl CacheClient {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
     /// use std::convert::TryInto;
-    /// use momento::cache::ListFetch;
+    /// use momento::cache::ListFetchResponse;
     /// use momento::MomentoErrorCode;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let list_name = "list-name";
@@ -2035,7 +2035,7 @@ impl CacheClient {
         &self,
         cache_name: impl Into<String>,
         list_name: impl IntoBytes,
-    ) -> MomentoResult<ListFetch> {
+    ) -> MomentoResult<ListFetchResponse> {
         let request = ListFetchRequest::new(cache_name, list_name);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -18,7 +18,7 @@ use crate::cache::{
     GetRequest, IncreaseTtl, IncreaseTtlRequest, Increment, IncrementRequest,
     IntoDictionaryFieldValuePairs, IntoSortedSetElements, ItemGetTtl, ItemGetTtlRequest,
     ItemGetType, ItemGetTypeRequest, KeyExists, KeyExistsRequest, KeysExist, KeysExistRequest,
-    ListCaches, ListCachesRequest, ListConcatenateBack, ListConcatenateBackRequest,
+    ListCaches, ListCachesRequest, ListConcatenateBackRequest, ListConcatenateBackResponse,
     ListConcatenateFront, ListConcatenateFrontRequest, ListFetch, ListFetchRequest, ListLength,
     ListLengthRequest, ListPopBack, ListPopBackRequest, ListPopFront, ListPopFrontRequest,
     ListRemoveValue, ListRemoveValueRequest, MomentoRequest, Set, SetAddElements,
@@ -1967,7 +1967,7 @@ impl CacheClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::ListConcatenateBack;
+    /// use momento::cache::ListConcatenateBackResponse;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let list_name = "list-name";
     ///
@@ -1992,7 +1992,7 @@ impl CacheClient {
         cache_name: impl Into<String>,
         list_name: impl IntoBytes,
         values: impl IntoBytesIterable,
-    ) -> MomentoResult<ListConcatenateBack> {
+    ) -> MomentoResult<ListConcatenateBackResponse> {
         let request = ListConcatenateBackRequest::new(cache_name, list_name, values);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -20,7 +20,7 @@ use crate::cache::{
     ItemGetType, ItemGetTypeRequest, KeyExists, KeyExistsRequest, KeysExist, KeysExistRequest,
     ListCaches, ListCachesRequest, ListConcatenateBackRequest, ListConcatenateBackResponse,
     ListConcatenateFrontRequest, ListConcatenateFrontResponse, ListFetchRequest, ListFetchResponse,
-    ListLength, ListLengthRequest, ListPopBack, ListPopBackRequest, ListPopFront,
+    ListLengthRequest, ListLengthResponse, ListPopBack, ListPopBackRequest, ListPopFront,
     ListPopFrontRequest, ListRemoveValue, ListRemoveValueRequest, MomentoRequest, Set,
     SetAddElements, SetAddElementsRequest, SetFetch, SetFetchRequest, SetIfAbsent,
     SetIfAbsentOrEqual, SetIfAbsentOrEqualRequest, SetIfAbsentRequest, SetIfEqual,
@@ -1877,7 +1877,7 @@ impl CacheClient {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
     /// use std::convert::TryInto;
-    /// use momento::cache::ListLength;
+    /// use momento::cache::ListLengthResponse;
     /// use momento::MomentoErrorCode;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let list_name = "list-name";
@@ -1893,7 +1893,7 @@ impl CacheClient {
         &self,
         cache_name: impl Into<String>,
         list_name: impl IntoBytes,
-    ) -> MomentoResult<ListLength> {
+    ) -> MomentoResult<ListLengthResponse> {
         let request = ListLengthRequest::new(cache_name, list_name);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -21,7 +21,7 @@ use crate::cache::{
     ListCaches, ListCachesRequest, ListConcatenateBackRequest, ListConcatenateBackResponse,
     ListConcatenateFrontRequest, ListConcatenateFrontResponse, ListFetchRequest, ListFetchResponse,
     ListLengthRequest, ListLengthResponse, ListPopBackRequest, ListPopBackResponse,
-    ListPopFrontRequest, ListPopFrontResponse, ListRemoveValue, ListRemoveValueRequest,
+    ListPopFrontRequest, ListPopFrontResponse, ListRemoveValueRequest, ListRemoveValueResponse,
     MomentoRequest, Set, SetAddElements, SetAddElementsRequest, SetFetch, SetFetchRequest,
     SetIfAbsent, SetIfAbsentOrEqual, SetIfAbsentOrEqualRequest, SetIfAbsentRequest, SetIfEqual,
     SetIfEqualRequest, SetIfNotEqual, SetIfNotEqualRequest, SetIfPresent, SetIfPresentAndNotEqual,
@@ -2121,14 +2121,14 @@ impl CacheClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::{ListRemoveValue, ListRemoveValueRequest};
+    /// use momento::cache::{ListRemoveValueResponse, ListRemoveValueRequest};
     /// use momento::MomentoErrorCode;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let list_name = "list-name";
     /// # cache_client.list_concatenate_front(&cache_name, list_name, vec!["value1", "value2"]).await;
     ///
     /// match cache_client.list_remove_value(cache_name, list_name, "value1").await {
-    ///     Ok(ListRemoveValue {}) => println!("Successfully removed value"),
+    ///     Ok(ListRemoveValueResponse {}) => println!("Successfully removed value"),
     ///     Err(e) => eprintln!("Error removing value: {:?}", e),
     /// }
     /// # Ok(())
@@ -2141,7 +2141,7 @@ impl CacheClient {
         cache_name: impl Into<String>,
         list_name: impl IntoBytes,
         value: impl IntoBytes,
-    ) -> MomentoResult<ListRemoveValue> {
+    ) -> MomentoResult<ListRemoveValueResponse> {
         let request = ListRemoveValueRequest::new(cache_name, list_name, value);
         request.send(self).await
     }

--- a/src/cache/messages/list/list_concatenate_back.rs
+++ b/src/cache/messages/list/list_concatenate_back.rs
@@ -25,7 +25,7 @@ use crate::{
 /// # fn main() -> anyhow::Result<()> {
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
-/// use momento::cache::{ListConcatenateBack, ListConcatenateBackRequest};
+/// use momento::cache::{ListConcatenateBackResponse, ListConcatenateBackRequest};
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 /// let list_name = "list-name";
 /// let concat_back_request = ListConcatenateBackRequest::new(cache_name, list_name, vec!["value1", "value2"]);
@@ -71,9 +71,9 @@ impl<L: IntoBytes, V: IntoBytesIterable> ListConcatenateBackRequest<L, V> {
 }
 
 impl<L: IntoBytes, V: IntoBytesIterable> MomentoRequest for ListConcatenateBackRequest<L, V> {
-    type Response = ListConcatenateBack;
+    type Response = ListConcatenateBackResponse;
 
-    async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListConcatenateBack> {
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListConcatenateBackResponse> {
         let collection_ttl = self.collection_ttl.unwrap_or_default();
         let values = self.values;
         let list_name = self.list_name.into_bytes();
@@ -95,9 +95,9 @@ impl<L: IntoBytes, V: IntoBytesIterable> MomentoRequest for ListConcatenateBackR
             .clone()
             .list_concatenate_back(request)
             .await?;
-        Ok(ListConcatenateBack {})
+        Ok(ListConcatenateBackResponse {})
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct ListConcatenateBack {}
+pub struct ListConcatenateBackResponse {}

--- a/src/cache/messages/list/list_concatenate_front.rs
+++ b/src/cache/messages/list/list_concatenate_front.rs
@@ -25,7 +25,7 @@ use crate::{
 /// # fn main() -> anyhow::Result<()> {
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
-/// use momento::cache::{ListConcatenateFront, ListConcatenateFrontRequest};
+/// use momento::cache::{ListConcatenateFrontResponse, ListConcatenateFrontRequest};
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 /// let list_name = "list-name";
 /// let concat_front_request = ListConcatenateFrontRequest::new(cache_name, list_name, vec!["value1", "value2"]);
@@ -71,9 +71,9 @@ impl<L: IntoBytes, V: IntoBytesIterable> ListConcatenateFrontRequest<L, V> {
 }
 
 impl<L: IntoBytes, V: IntoBytesIterable> MomentoRequest for ListConcatenateFrontRequest<L, V> {
-    type Response = ListConcatenateFront;
+    type Response = ListConcatenateFrontResponse;
 
-    async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListConcatenateFront> {
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListConcatenateFrontResponse> {
         let collection_ttl = self.collection_ttl.unwrap_or_default();
         let values = self.values;
         let list_name = self.list_name.into_bytes();
@@ -95,9 +95,9 @@ impl<L: IntoBytes, V: IntoBytesIterable> MomentoRequest for ListConcatenateFront
             .clone()
             .list_concatenate_front(request)
             .await?;
-        Ok(ListConcatenateFront {})
+        Ok(ListConcatenateFrontResponse {})
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct ListConcatenateFront {}
+pub struct ListConcatenateFrontResponse {}

--- a/src/cache/messages/list/list_remove_value.rs
+++ b/src/cache/messages/list/list_remove_value.rs
@@ -17,7 +17,7 @@ use crate::{
 /// # fn main() -> anyhow::Result<()> {
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
-/// use momento::cache::{ListRemoveValue, ListRemoveValueRequest};
+/// use momento::cache::{ListRemoveValueResponse, ListRemoveValueRequest};
 /// use momento::MomentoErrorCode;
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 /// let list_name = "list-name";
@@ -25,7 +25,7 @@ use crate::{
 ///
 /// let remove_request = ListRemoveValueRequest::new(cache_name, list_name, "value1");
 /// match cache_client.send_request(remove_request).await {
-///     Ok(ListRemoveValue {}) => println!("Successfully removed value"),
+///     Ok(ListRemoveValueResponse {}) => println!("Successfully removed value"),
 ///     Err(e) => eprintln!("Error removing value: {:?}", e),
 /// }
 /// # Ok(())
@@ -49,9 +49,9 @@ impl<L: IntoBytes, V: IntoBytes> ListRemoveValueRequest<L, V> {
 }
 
 impl<L: IntoBytes, V: IntoBytes> MomentoRequest for ListRemoveValueRequest<L, V> {
-    type Response = ListRemoveValue;
+    type Response = ListRemoveValueResponse;
 
-    async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListRemoveValue> {
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListRemoveValueResponse> {
         let request = prep_request_with_timeout(
             &self.cache_name,
             cache_client.configuration.deadline_millis(),
@@ -67,9 +67,9 @@ impl<L: IntoBytes, V: IntoBytes> MomentoRequest for ListRemoveValueRequest<L, V>
             .list_remove(request)
             .await?
             .into_inner();
-        Ok(ListRemoveValue {})
+        Ok(ListRemoveValueResponse {})
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct ListRemoveValue {}
+pub struct ListRemoveValueResponse {}

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -80,7 +80,9 @@ pub use messages::sorted_set::sorted_set_remove_elements::{
     SortedSetRemoveElements, SortedSetRemoveElementsRequest,
 };
 
-pub use messages::list::list_concatenate_back::{ListConcatenateBack, ListConcatenateBackRequest};
+pub use messages::list::list_concatenate_back::{
+    ListConcatenateBackRequest, ListConcatenateBackResponse,
+};
 pub use messages::list::list_concatenate_front::{
     ListConcatenateFront, ListConcatenateFrontRequest,
 };

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -91,7 +91,9 @@ pub use messages::list::list_length::{ListLengthRequest, ListLengthResponse};
 pub use messages::list::list_pop_back::{
     ListPopBackRequest, ListPopBackResponse, ListPopBackValue,
 };
-pub use messages::list::list_pop_front::{ListPopFront, ListPopFrontRequest, ListPopFrontValue};
+pub use messages::list::list_pop_front::{
+    ListPopFrontRequest, ListPopFrontResponse, ListPopFrontValue,
+};
 pub use messages::list::list_remove_value::{ListRemoveValue, ListRemoveValueRequest};
 
 // Similar re-exporting with config::configuration and config::configurations

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -88,7 +88,9 @@ pub use messages::list::list_concatenate_front::{
 };
 pub use messages::list::list_fetch::{ListFetchRequest, ListFetchResponse, ListFetchValue};
 pub use messages::list::list_length::{ListLengthRequest, ListLengthResponse};
-pub use messages::list::list_pop_back::{ListPopBack, ListPopBackRequest, ListPopBackValue};
+pub use messages::list::list_pop_back::{
+    ListPopBackRequest, ListPopBackResponse, ListPopBackValue,
+};
 pub use messages::list::list_pop_front::{ListPopFront, ListPopFrontRequest, ListPopFrontValue};
 pub use messages::list::list_remove_value::{ListRemoveValue, ListRemoveValueRequest};
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -87,7 +87,7 @@ pub use messages::list::list_concatenate_front::{
     ListConcatenateFrontRequest, ListConcatenateFrontResponse,
 };
 pub use messages::list::list_fetch::{ListFetchRequest, ListFetchResponse, ListFetchValue};
-pub use messages::list::list_length::{ListLength, ListLengthRequest};
+pub use messages::list::list_length::{ListLengthRequest, ListLengthResponse};
 pub use messages::list::list_pop_back::{ListPopBack, ListPopBackRequest, ListPopBackValue};
 pub use messages::list::list_pop_front::{ListPopFront, ListPopFrontRequest, ListPopFrontValue};
 pub use messages::list::list_remove_value::{ListRemoveValue, ListRemoveValueRequest};

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -94,7 +94,7 @@ pub use messages::list::list_pop_back::{
 pub use messages::list::list_pop_front::{
     ListPopFrontRequest, ListPopFrontResponse, ListPopFrontValue,
 };
-pub use messages::list::list_remove_value::{ListRemoveValue, ListRemoveValueRequest};
+pub use messages::list::list_remove_value::{ListRemoveValueRequest, ListRemoveValueResponse};
 
 // Similar re-exporting with config::configuration and config::configurations
 // so import paths can be simpmlified to "momento::cache::Configuration" and

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -86,7 +86,7 @@ pub use messages::list::list_concatenate_back::{
 pub use messages::list::list_concatenate_front::{
     ListConcatenateFrontRequest, ListConcatenateFrontResponse,
 };
-pub use messages::list::list_fetch::{ListFetch, ListFetchRequest, ListFetchValue};
+pub use messages::list::list_fetch::{ListFetchRequest, ListFetchResponse, ListFetchValue};
 pub use messages::list::list_length::{ListLength, ListLengthRequest};
 pub use messages::list::list_pop_back::{ListPopBack, ListPopBackRequest, ListPopBackValue};
 pub use messages::list::list_pop_front::{ListPopFront, ListPopFrontRequest, ListPopFrontValue};

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -84,7 +84,7 @@ pub use messages::list::list_concatenate_back::{
     ListConcatenateBackRequest, ListConcatenateBackResponse,
 };
 pub use messages::list::list_concatenate_front::{
-    ListConcatenateFront, ListConcatenateFrontRequest,
+    ListConcatenateFrontRequest, ListConcatenateFrontResponse,
 };
 pub use messages::list::list_fetch::{ListFetch, ListFetchRequest, ListFetchValue};
 pub use messages::list::list_length::{ListLength, ListLengthRequest};

--- a/test-util/src/test_data.rs
+++ b/test-util/src/test_data.rs
@@ -1,5 +1,5 @@
 use momento::{
-    cache::{Get, GetValue, ListFetch, ListFetchValue, SortedSetElements, SortedSetFetch},
+    cache::{Get, GetValue, ListFetchResponse, ListFetchValue, SortedSetElements, SortedSetFetch},
     IntoBytes,
 };
 use std::collections::HashMap;
@@ -197,9 +197,9 @@ impl Default for TestList {
     }
 }
 
-impl From<&TestList> for ListFetch {
+impl From<&TestList> for ListFetchResponse {
     fn from(test_list: &TestList) -> Self {
-        ListFetch::Hit {
+        ListFetchResponse::Hit {
             values: ListFetchValue::new(
                 test_list
                     .values()

--- a/tests/cache/list.rs
+++ b/tests/cache/list.rs
@@ -1,7 +1,7 @@
 use momento::cache::{
     CollectionTtl, ListConcatenateBackRequest, ListConcatenateBackResponse,
     ListConcatenateFrontRequest, ListConcatenateFrontResponse, ListFetchResponse,
-    ListLengthResponse, ListPopBack, ListPopFront, ListRemoveValue,
+    ListLengthResponse, ListPopBackResponse, ListPopFront, ListRemoveValue,
 };
 use momento::{MomentoErrorCode, MomentoResult};
 
@@ -300,7 +300,7 @@ mod list_pop_back {
 
         let result = client.list_pop_back(cache_name, list_name).await?;
 
-        assert_eq!(result, ListPopBack::Miss {});
+        assert_eq!(result, ListPopBackResponse::Miss {});
 
         Ok(())
     }

--- a/tests/cache/list.rs
+++ b/tests/cache/list.rs
@@ -1,7 +1,7 @@
 use momento::cache::{
     CollectionTtl, ListConcatenateBackRequest, ListConcatenateBackResponse,
     ListConcatenateFrontRequest, ListConcatenateFrontResponse, ListFetchResponse,
-    ListLengthResponse, ListPopBackResponse, ListPopFrontResponse, ListRemoveValue,
+    ListLengthResponse, ListPopBackResponse, ListPopFrontResponse, ListRemoveValueResponse,
 };
 use momento::{MomentoErrorCode, MomentoResult};
 
@@ -434,7 +434,7 @@ mod list_remove {
             .list_remove_value(cache_name, list_name, "value")
             .await?;
 
-        assert_eq!(result, ListRemoveValue {});
+        assert_eq!(result, ListRemoveValueResponse {});
 
         Ok(())
     }
@@ -466,7 +466,7 @@ mod list_remove {
         let result = client
             .list_remove_value(cache_name, test_list.name(), first_value)
             .await?;
-        assert_eq!(result, ListRemoveValue {});
+        assert_eq!(result, ListRemoveValueResponse {});
         assert_list_eq(
             client.list_fetch(cache_name, test_list.name()).await?,
             vec![second_value],

--- a/tests/cache/list.rs
+++ b/tests/cache/list.rs
@@ -1,7 +1,7 @@
 use momento::cache::{
     CollectionTtl, ListConcatenateBackRequest, ListConcatenateBackResponse,
-    ListConcatenateFrontRequest, ListConcatenateFrontResponse, ListFetch, ListLength, ListPopBack,
-    ListPopFront, ListRemoveValue,
+    ListConcatenateFrontRequest, ListConcatenateFrontResponse, ListFetchResponse, ListLength,
+    ListPopBack, ListPopFront, ListRemoveValue,
 };
 use momento::{MomentoErrorCode, MomentoResult};
 
@@ -10,8 +10,11 @@ use momento_test_util::{unique_cache_name, TestList, CACHE_TEST_STATE};
 use std::convert::TryInto;
 use std::time::Duration;
 
-fn assert_list_eq(list_fetch_result: ListFetch, expected: Vec<String>) -> MomentoResult<()> {
-    let expected: ListFetch = expected.into();
+fn assert_list_eq(
+    list_fetch_result: ListFetchResponse,
+    expected: Vec<String>,
+) -> MomentoResult<()> {
+    let expected: ListFetchResponse = expected.into();
     assert_eq!(
         list_fetch_result, expected,
         "Expected ListFetch::Hit to be equal to {:?}, but got {:?}",
@@ -83,7 +86,7 @@ mod list_concatenate_back {
 
         // Expect a miss after collection ttl expires
         let result = client.list_fetch(cache_name, test_list.name()).await?;
-        assert_eq!(result, ListFetch::Miss);
+        assert_eq!(result, ListFetchResponse::Miss);
 
         Ok(())
     }
@@ -153,7 +156,7 @@ mod list_concatenate_front {
 
         // Expect a miss after collection ttl expires
         let result = client.list_fetch(cache_name, test_list.name()).await?;
-        assert_eq!(result, ListFetch::Miss);
+        assert_eq!(result, ListFetchResponse::Miss);
 
         Ok(())
     }
@@ -232,7 +235,7 @@ mod list_fetch {
 
         let result = client.list_fetch(cache_name, list_name).await?;
 
-        assert_eq!(result, ListFetch::Miss {});
+        assert_eq!(result, ListFetchResponse::Miss {});
 
         Ok(())
     }

--- a/tests/cache/list.rs
+++ b/tests/cache/list.rs
@@ -1,7 +1,7 @@
 use momento::cache::{
     CollectionTtl, ListConcatenateBackRequest, ListConcatenateBackResponse,
-    ListConcatenateFrontRequest, ListConcatenateFrontResponse, ListFetchResponse, ListLength,
-    ListPopBack, ListPopFront, ListRemoveValue,
+    ListConcatenateFrontRequest, ListConcatenateFrontResponse, ListFetchResponse,
+    ListLengthResponse, ListPopBack, ListPopFront, ListRemoveValue,
 };
 use momento::{MomentoErrorCode, MomentoResult};
 
@@ -185,7 +185,7 @@ mod list_length {
 
         let result = client.list_length(cache_name, list_name).await?;
 
-        assert_eq!(result, ListLength::Miss {});
+        assert_eq!(result, ListLengthResponse::Miss {});
 
         Ok(())
     }
@@ -204,7 +204,7 @@ mod list_length {
 
         // Fetch list length
         let result = client.list_length(cache_name, test_list.name()).await?;
-        assert_eq!(result, ListLength::Hit { length: 2 });
+        assert_eq!(result, ListLengthResponse::Hit { length: 2 });
 
         Ok(())
     }

--- a/tests/cache/list.rs
+++ b/tests/cache/list.rs
@@ -1,5 +1,5 @@
 use momento::cache::{
-    CollectionTtl, ListConcatenateBack, ListConcatenateBackRequest, ListConcatenateFront,
+    CollectionTtl, ListConcatenateBackRequest, ListConcatenateBackResponse, ListConcatenateFront,
     ListConcatenateFrontRequest, ListFetch, ListLength, ListPopBack, ListPopFront, ListRemoveValue,
 };
 use momento::{MomentoErrorCode, MomentoResult};
@@ -46,7 +46,7 @@ mod list_concatenate_back {
         let result = client
             .list_concatenate_back(cache_name, test_list.name(), test_list.values().to_vec())
             .await?;
-        assert_eq!(result, ListConcatenateBack {});
+        assert_eq!(result, ListConcatenateBackResponse {});
         assert_list_eq(
             client.list_fetch(cache_name, test_list.name()).await?,
             test_list.values().to_vec(),
@@ -70,7 +70,7 @@ mod list_concatenate_back {
         .truncate_back_to_size(2)
         .ttl(CollectionTtl::new(Some(Duration::from_secs(3)), false));
         let result = client.send_request(request).await?;
-        assert_eq!(result, ListConcatenateBack {});
+        assert_eq!(result, ListConcatenateBackResponse {});
 
         // Should have truncated to only 2 elements
         assert_list_eq(
@@ -196,7 +196,7 @@ mod list_length {
         let result = client
             .list_concatenate_back(cache_name, test_list.name(), test_list.values().to_vec())
             .await?;
-        assert_eq!(result, ListConcatenateBack {});
+        assert_eq!(result, ListConcatenateBackResponse {});
 
         // Fetch list length
         let result = client.list_length(cache_name, test_list.name()).await?;
@@ -251,7 +251,7 @@ mod list_fetch {
                 [list1.values().to_vec(), list2.values().to_vec()].concat(),
             )
             .await?;
-        assert_eq!(result, ListConcatenateBack {});
+        assert_eq!(result, ListConcatenateBackResponse {});
 
         // Fetch entire list
         let fetch_full_list = client.list_fetch(cache_name, list1.name()).await?;
@@ -311,7 +311,7 @@ mod list_pop_back {
         let result = client
             .list_concatenate_back(cache_name, test_list.name(), test_list.values().to_vec())
             .await?;
-        assert_eq!(result, ListConcatenateBack {});
+        assert_eq!(result, ListConcatenateBackResponse {});
 
         // Pop first value from the back
         let popped_first: String = client
@@ -374,7 +374,7 @@ mod list_pop_front {
         let result = client
             .list_concatenate_back(cache_name, test_list.name(), test_list.values().to_vec())
             .await?;
-        assert_eq!(result, ListConcatenateBack {});
+        assert_eq!(result, ListConcatenateBackResponse {});
 
         // Pop first value from the front
         let popped_first: String = client
@@ -445,7 +445,7 @@ mod list_remove {
         let result = client
             .list_concatenate_back(cache_name, test_list.name(), test_list.values().to_vec())
             .await?;
-        assert_eq!(result, ListConcatenateBack {});
+        assert_eq!(result, ListConcatenateBackResponse {});
 
         let first_value = test_list
             .values()

--- a/tests/cache/list.rs
+++ b/tests/cache/list.rs
@@ -1,7 +1,7 @@
 use momento::cache::{
     CollectionTtl, ListConcatenateBackRequest, ListConcatenateBackResponse,
     ListConcatenateFrontRequest, ListConcatenateFrontResponse, ListFetchResponse,
-    ListLengthResponse, ListPopBackResponse, ListPopFront, ListRemoveValue,
+    ListLengthResponse, ListPopBackResponse, ListPopFrontResponse, ListRemoveValue,
 };
 use momento::{MomentoErrorCode, MomentoResult};
 
@@ -363,7 +363,7 @@ mod list_pop_front {
 
         let result = client.list_pop_front(cache_name, list_name).await?;
 
-        assert_eq!(result, ListPopFront::Miss {});
+        assert_eq!(result, ListPopFrontResponse::Miss {});
 
         Ok(())
     }

--- a/tests/cache/list.rs
+++ b/tests/cache/list.rs
@@ -1,6 +1,7 @@
 use momento::cache::{
-    CollectionTtl, ListConcatenateBackRequest, ListConcatenateBackResponse, ListConcatenateFront,
-    ListConcatenateFrontRequest, ListFetch, ListLength, ListPopBack, ListPopFront, ListRemoveValue,
+    CollectionTtl, ListConcatenateBackRequest, ListConcatenateBackResponse,
+    ListConcatenateFrontRequest, ListConcatenateFrontResponse, ListFetch, ListLength, ListPopBack,
+    ListPopFront, ListRemoveValue,
 };
 use momento::{MomentoErrorCode, MomentoResult};
 
@@ -116,7 +117,7 @@ mod list_concatenate_front {
         let result = client
             .list_concatenate_front(cache_name, test_list.name(), test_list.values().to_vec())
             .await?;
-        assert_eq!(result, ListConcatenateFront {});
+        assert_eq!(result, ListConcatenateFrontResponse {});
         assert_list_eq(
             client.list_fetch(cache_name, test_list.name()).await?,
             test_list.values().to_vec(),
@@ -140,7 +141,7 @@ mod list_concatenate_front {
         .truncate_back_to_size(2)
         .ttl(CollectionTtl::new(Some(Duration::from_secs(3)), false));
         let result = client.send_request(request).await?;
-        assert_eq!(result, ListConcatenateFront {});
+        assert_eq!(result, ListConcatenateFrontResponse {});
 
         // Should have truncated to only 2 elements
         assert_list_eq(


### PR DESCRIPTION
Adds the suffix Response to all dictionary response types to code and docstrings.

Work towards #285 