### PR TITLE
feat: add response suffix to sorted set types

### DIFF
--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -29,7 +29,7 @@ use crate::cache::{
     SetIfEqualRequest, SetIfEqualResponse, SetIfNotEqualRequest, SetIfNotEqualResponse,
     SetIfPresentAndNotEqualRequest, SetIfPresentAndNotEqualResponse, SetIfPresentRequest,
     SetIfPresentResponse, SetRemoveElementsRequest, SetRemoveElementsResponse, SetRequest,
-    SetResponse, SortedSetFetch, SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest,
+    SetResponse, SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest, SortedSetFetchResponse,
     SortedSetGetRank, SortedSetGetRankRequest, SortedSetGetScore, SortedSetGetScoreRequest,
     SortedSetLength, SortedSetLengthRequest, SortedSetOrder, SortedSetPutElement,
     SortedSetPutElementRequest, SortedSetPutElements, SortedSetPutElementsRequest,
@@ -980,7 +980,7 @@ impl CacheClient {
     /// # use momento::MomentoResult;
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::{SortedSetOrder, SortedSetFetch};
+    /// use momento::cache::{SortedSetOrder, SortedSetFetchResponse};
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let sorted_set_name = "sorted_set";
     ///
@@ -993,7 +993,7 @@ impl CacheClient {
     /// ).await?;
     ///
     /// match fetch_response {
-    ///     SortedSetFetch::Hit{ value } => {
+    ///     SortedSetFetchResponse::Hit{ value } => {
     ///         match value.into_strings() {
     ///             Ok(vec) => {
     ///                 println!("Fetched elements: {:?}", vec);
@@ -1003,7 +1003,7 @@ impl CacheClient {
     ///             }
     ///         }
     ///     }
-    ///     SortedSetFetch::Miss => println!("Cache miss"),
+    ///     SortedSetFetchResponse::Miss => println!("Cache miss"),
     /// }
     /// # Ok(())
     /// # })
@@ -1017,7 +1017,7 @@ impl CacheClient {
         order: SortedSetOrder,
         start_rank: Option<i32>,
         end_rank: Option<i32>,
-    ) -> MomentoResult<SortedSetFetch> {
+    ) -> MomentoResult<SortedSetFetchResponse> {
         let mut request =
             SortedSetFetchByRankRequest::new(cache_name, sorted_set_name).order(order);
 
@@ -1058,7 +1058,7 @@ impl CacheClient {
     /// # use momento::MomentoResult;
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::{SortedSetOrder, SortedSetFetch};
+    /// use momento::cache::{SortedSetOrder, SortedSetFetchResponse};
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let sorted_set_name = "sorted_set";
     ///
@@ -1069,7 +1069,7 @@ impl CacheClient {
     /// ).await?;
     ///
     /// match fetch_response {
-    ///     SortedSetFetch::Hit{ value } => {
+    ///     SortedSetFetchResponse::Hit{ value } => {
     ///         match value.into_strings() {
     ///             Ok(vec) => {
     ///                 println!("Fetched elements: {:?}", vec);
@@ -1079,7 +1079,7 @@ impl CacheClient {
     ///             }
     ///         }
     ///     }
-    ///     SortedSetFetch::Miss => println!("Cache miss"),
+    ///     SortedSetFetchResponse::Miss => println!("Cache miss"),
     /// }
     /// # Ok(())
     /// # })
@@ -1092,7 +1092,7 @@ impl CacheClient {
         cache_name: impl Into<String>,
         sorted_set_name: impl IntoBytes,
         order: SortedSetOrder,
-    ) -> MomentoResult<SortedSetFetch> {
+    ) -> MomentoResult<SortedSetFetchResponse> {
         let request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name).order(order);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -33,7 +33,7 @@ use crate::cache::{
     SortedSetGetRankRequest, SortedSetGetRankResponse, SortedSetGetScoreRequest,
     SortedSetGetScoreResponse, SortedSetLengthRequest, SortedSetLengthResponse, SortedSetOrder,
     SortedSetPutElementRequest, SortedSetPutElementResponse, SortedSetPutElementsRequest,
-    SortedSetPutElementsResponse, SortedSetRemoveElements, SortedSetRemoveElementsRequest,
+    SortedSetPutElementsResponse, SortedSetRemoveElementsRequest, SortedSetRemoveElementsResponse,
     UpdateTtlRequest, UpdateTtlResponse,
 };
 use crate::grpc::header_interceptor::HeaderInterceptor;
@@ -1111,7 +1111,7 @@ impl CacheClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::SortedSetRemoveElements;
+    /// use momento::cache::SortedSetRemoveElementsResponse;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let sorted_set_name = "sorted_set";
     ///
@@ -1135,7 +1135,7 @@ impl CacheClient {
         cache_name: impl Into<String>,
         sorted_set_name: impl IntoBytes,
         values: V,
-    ) -> MomentoResult<SortedSetRemoveElements> {
+    ) -> MomentoResult<SortedSetRemoveElementsResponse> {
         let request = SortedSetRemoveElementsRequest::new(cache_name, sorted_set_name, values);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -30,10 +30,11 @@ use crate::cache::{
     SetIfPresentAndNotEqualRequest, SetIfPresentAndNotEqualResponse, SetIfPresentRequest,
     SetIfPresentResponse, SetRemoveElementsRequest, SetRemoveElementsResponse, SetRequest,
     SetResponse, SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest, SortedSetFetchResponse,
-    SortedSetGetRankRequest, SortedSetGetRankResponse, SortedSetGetScore, SortedSetGetScoreRequest,
-    SortedSetLength, SortedSetLengthRequest, SortedSetOrder, SortedSetPutElement,
-    SortedSetPutElementRequest, SortedSetPutElements, SortedSetPutElementsRequest,
-    SortedSetRemoveElements, SortedSetRemoveElementsRequest, UpdateTtlRequest, UpdateTtlResponse,
+    SortedSetGetRankRequest, SortedSetGetRankResponse, SortedSetGetScoreRequest,
+    SortedSetGetScoreResponse, SortedSetLength, SortedSetLengthRequest, SortedSetOrder,
+    SortedSetPutElement, SortedSetPutElementRequest, SortedSetPutElements,
+    SortedSetPutElementsRequest, SortedSetRemoveElements, SortedSetRemoveElementsRequest,
+    UpdateTtlRequest, UpdateTtlResponse,
 };
 use crate::grpc::header_interceptor::HeaderInterceptor;
 
@@ -1226,7 +1227,7 @@ impl CacheClient {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
     /// use std::convert::TryInto;
-    /// use momento::cache::{SortedSetGetScore, SortedSetGetScoreRequest};
+    /// use momento::cache::{SortedSetGetScoreResponse, SortedSetGetScoreRequest};
     /// use momento::MomentoErrorCode;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let sorted_set_name = "sorted_set";
@@ -1245,7 +1246,7 @@ impl CacheClient {
         cache_name: impl Into<String>,
         sorted_set_name: impl IntoBytes,
         value: impl IntoBytes,
-    ) -> MomentoResult<SortedSetGetScore> {
+    ) -> MomentoResult<SortedSetGetScoreResponse> {
         let request = SortedSetGetScoreRequest::new(cache_name, sorted_set_name, value);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -30,7 +30,7 @@ use crate::cache::{
     SetIfPresentAndNotEqualRequest, SetIfPresentAndNotEqualResponse, SetIfPresentRequest,
     SetIfPresentResponse, SetRemoveElementsRequest, SetRemoveElementsResponse, SetRequest,
     SetResponse, SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest, SortedSetFetchResponse,
-    SortedSetGetRank, SortedSetGetRankRequest, SortedSetGetScore, SortedSetGetScoreRequest,
+    SortedSetGetRankRequest, SortedSetGetRankResponse, SortedSetGetScore, SortedSetGetScoreRequest,
     SortedSetLength, SortedSetLengthRequest, SortedSetOrder, SortedSetPutElement,
     SortedSetPutElementRequest, SortedSetPutElements, SortedSetPutElementsRequest,
     SortedSetRemoveElements, SortedSetRemoveElementsRequest, UpdateTtlRequest, UpdateTtlResponse,
@@ -1188,7 +1188,7 @@ impl CacheClient {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
     /// use std::convert::TryInto;
-    /// use momento::cache::{SortedSetGetRank, SortedSetGetRankRequest};
+    /// use momento::cache::{SortedSetGetRankResponse, SortedSetGetRankRequest};
     /// use momento::MomentoErrorCode;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let sorted_set_name = "sorted_set";
@@ -1207,7 +1207,7 @@ impl CacheClient {
         cache_name: impl Into<String>,
         sorted_set_name: impl IntoBytes,
         value: impl IntoBytes,
-    ) -> MomentoResult<SortedSetGetRank> {
+    ) -> MomentoResult<SortedSetGetRankResponse> {
         let request = SortedSetGetRankRequest::new(cache_name, sorted_set_name, value);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -32,7 +32,7 @@ use crate::cache::{
     SetResponse, SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest, SortedSetFetchResponse,
     SortedSetGetRankRequest, SortedSetGetRankResponse, SortedSetGetScoreRequest,
     SortedSetGetScoreResponse, SortedSetLengthRequest, SortedSetLengthResponse, SortedSetOrder,
-    SortedSetPutElement, SortedSetPutElementRequest, SortedSetPutElements,
+    SortedSetPutElementRequest, SortedSetPutElementResponse, SortedSetPutElements,
     SortedSetPutElementsRequest, SortedSetRemoveElements, SortedSetRemoveElementsRequest,
     UpdateTtlRequest, UpdateTtlResponse,
 };
@@ -878,7 +878,7 @@ impl CacheClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::SortedSetPutElement;
+    /// use momento::cache::SortedSetPutElementResponse;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let sorted_set_name = "sorted_set";
     ///
@@ -905,7 +905,7 @@ impl CacheClient {
         sorted_set_name: impl IntoBytes,
         value: impl IntoBytes,
         score: f64,
-    ) -> MomentoResult<SortedSetPutElement> {
+    ) -> MomentoResult<SortedSetPutElementResponse> {
         let request = SortedSetPutElementRequest::new(cache_name, sorted_set_name, value, score);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -31,7 +31,7 @@ use crate::cache::{
     SetIfPresentResponse, SetRemoveElementsRequest, SetRemoveElementsResponse, SetRequest,
     SetResponse, SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest, SortedSetFetchResponse,
     SortedSetGetRankRequest, SortedSetGetRankResponse, SortedSetGetScoreRequest,
-    SortedSetGetScoreResponse, SortedSetLength, SortedSetLengthRequest, SortedSetOrder,
+    SortedSetGetScoreResponse, SortedSetLengthRequest, SortedSetLengthResponse, SortedSetOrder,
     SortedSetPutElement, SortedSetPutElementRequest, SortedSetPutElements,
     SortedSetPutElementsRequest, SortedSetRemoveElements, SortedSetRemoveElementsRequest,
     UpdateTtlRequest, UpdateTtlResponse,
@@ -1153,7 +1153,7 @@ impl CacheClient {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
     /// use std::convert::TryInto;
-    /// use momento::cache::{SortedSetLength, SortedSetLengthRequest};
+    /// use momento::cache::{SortedSetLengthResponse, SortedSetLengthRequest};
     /// use momento::MomentoErrorCode;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let sorted_set_name = "sorted_set";
@@ -1170,7 +1170,7 @@ impl CacheClient {
         &self,
         cache_name: impl Into<String>,
         sorted_set_name: impl IntoBytes,
-    ) -> MomentoResult<SortedSetLength> {
+    ) -> MomentoResult<SortedSetLengthResponse> {
         let request = SortedSetLengthRequest::new(cache_name, sorted_set_name);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -32,8 +32,8 @@ use crate::cache::{
     SetResponse, SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest, SortedSetFetchResponse,
     SortedSetGetRankRequest, SortedSetGetRankResponse, SortedSetGetScoreRequest,
     SortedSetGetScoreResponse, SortedSetLengthRequest, SortedSetLengthResponse, SortedSetOrder,
-    SortedSetPutElementRequest, SortedSetPutElementResponse, SortedSetPutElements,
-    SortedSetPutElementsRequest, SortedSetRemoveElements, SortedSetRemoveElementsRequest,
+    SortedSetPutElementRequest, SortedSetPutElementResponse, SortedSetPutElementsRequest,
+    SortedSetPutElementsResponse, SortedSetRemoveElements, SortedSetRemoveElementsRequest,
     UpdateTtlRequest, UpdateTtlResponse,
 };
 use crate::grpc::header_interceptor::HeaderInterceptor;
@@ -931,7 +931,7 @@ impl CacheClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::{SortedSetPutElements};
+    /// use momento::cache::{SortedSetPutElementsResponse};
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     /// let sorted_set_name = "sorted_set";
     ///
@@ -956,7 +956,7 @@ impl CacheClient {
         cache_name: impl Into<String>,
         sorted_set_name: impl IntoBytes,
         elements: impl IntoSortedSetElements<V>,
-    ) -> MomentoResult<SortedSetPutElements> {
+    ) -> MomentoResult<SortedSetPutElementsResponse> {
         let request = SortedSetPutElementsRequest::new(cache_name, sorted_set_name, elements);
         request.send(self).await
     }

--- a/src/cache/messages/sorted_set/sorted_set_fetch_by_rank.rs
+++ b/src/cache/messages/sorted_set/sorted_set_fetch_by_rank.rs
@@ -2,7 +2,7 @@ use momento_protos::cache_client::sorted_set_fetch_request::{by_index, ByIndex, 
 use momento_protos::cache_client::SortedSetFetchRequest;
 use momento_protos::common::Unbounded;
 
-use crate::cache::messages::sorted_set::sorted_set_fetch_response::SortedSetFetch;
+use crate::cache::messages::sorted_set::sorted_set_fetch_response::SortedSetFetchResponse;
 use crate::cache::messages::MomentoRequest;
 use crate::utils::prep_request_with_timeout;
 use crate::{CacheClient, IntoBytes, MomentoResult};
@@ -37,7 +37,7 @@ pub enum SortedSetOrder {
 /// # use std::convert::TryInto;
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
-/// use momento::cache::{SortedSetOrder, SortedSetFetch, SortedSetFetchByRankRequest};
+/// use momento::cache::{SortedSetOrder, SortedSetFetchResponse, SortedSetFetchByRankRequest};
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 /// let sorted_set_name = "sorted_set";
 ///
@@ -100,9 +100,9 @@ impl<S: IntoBytes> SortedSetFetchByRankRequest<S> {
 }
 
 impl<S: IntoBytes> MomentoRequest for SortedSetFetchByRankRequest<S> {
-    type Response = SortedSetFetch;
+    type Response = SortedSetFetchResponse;
 
-    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetFetch> {
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetFetchResponse> {
         let set_name = self.sorted_set_name.into_bytes();
         let cache_name = &self.cache_name;
 
@@ -137,6 +137,6 @@ impl<S: IntoBytes> MomentoRequest for SortedSetFetchByRankRequest<S> {
             .await?
             .into_inner();
 
-        SortedSetFetch::from_fetch_response(response)
+        SortedSetFetchResponse::from_fetch_response(response)
     }
 }

--- a/src/cache/messages/sorted_set/sorted_set_fetch_by_score.rs
+++ b/src/cache/messages/sorted_set/sorted_set_fetch_by_score.rs
@@ -5,7 +5,7 @@ use momento_protos::common::Unbounded;
 
 use crate::cache::messages::sorted_set::sorted_set_fetch_by_rank::SortedSetOrder;
 use crate::cache::messages::sorted_set::sorted_set_fetch_by_rank::SortedSetOrder::Ascending;
-use crate::cache::messages::sorted_set::sorted_set_fetch_response::SortedSetFetch;
+use crate::cache::messages::sorted_set::sorted_set_fetch_response::SortedSetFetchResponse;
 use crate::cache::messages::MomentoRequest;
 use crate::utils::prep_request_with_timeout;
 use crate::{CacheClient, IntoBytes, MomentoResult};
@@ -37,7 +37,7 @@ use crate::{CacheClient, IntoBytes, MomentoResult};
 /// # use std::convert::TryInto;
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
-/// use momento::cache::{SortedSetOrder, SortedSetFetch, SortedSetFetchByScoreRequest};
+/// use momento::cache::{SortedSetOrder, SortedSetFetchResponse, SortedSetFetchByScoreRequest};
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 /// let sorted_set_name = "sorted_set";
 ///
@@ -116,9 +116,9 @@ impl<S: IntoBytes> SortedSetFetchByScoreRequest<S> {
 }
 
 impl<S: IntoBytes> MomentoRequest for SortedSetFetchByScoreRequest<S> {
-    type Response = SortedSetFetch;
+    type Response = SortedSetFetchResponse;
 
-    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetFetch> {
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetFetchResponse> {
         let set_name = self.sorted_set_name.into_bytes();
         let cache_name = &self.cache_name;
 
@@ -165,6 +165,6 @@ impl<S: IntoBytes> MomentoRequest for SortedSetFetchByScoreRequest<S> {
             .await?
             .into_inner();
 
-        SortedSetFetch::from_fetch_response(response)
+        SortedSetFetchResponse::from_fetch_response(response)
     }
 }

--- a/src/cache/messages/sorted_set/sorted_set_put_element.rs
+++ b/src/cache/messages/sorted_set/sorted_set_put_element.rs
@@ -25,7 +25,7 @@ use crate::{CacheClient, IntoBytes, MomentoResult};
 /// # fn main() -> anyhow::Result<()> {
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
-/// use momento::cache::{CollectionTtl, SortedSetPutElement, SortedSetPutElementRequest};
+/// use momento::cache::{CollectionTtl, SortedSetPutElementResponse, SortedSetPutElementRequest};
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 /// let sorted_set_name = "sorted_set";
 ///
@@ -71,9 +71,9 @@ impl<S: IntoBytes, V: IntoBytes> SortedSetPutElementRequest<S, V> {
 }
 
 impl<S: IntoBytes, V: IntoBytes> MomentoRequest for SortedSetPutElementRequest<S, V> {
-    type Response = SortedSetPutElement;
+    type Response = SortedSetPutElementResponse;
 
-    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetPutElement> {
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetPutElementResponse> {
         let collection_ttl = self.collection_ttl.unwrap_or_default();
         let element = SortedSetElement {
             value: self.value.into_bytes(),
@@ -97,9 +97,9 @@ impl<S: IntoBytes, V: IntoBytes> MomentoRequest for SortedSetPutElementRequest<S
             .clone()
             .sorted_set_put(request)
             .await?;
-        Ok(SortedSetPutElement {})
+        Ok(SortedSetPutElementResponse {})
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct SortedSetPutElement {}
+pub struct SortedSetPutElementResponse {}

--- a/src/cache/messages/sorted_set/sorted_set_put_elements.rs
+++ b/src/cache/messages/sorted_set/sorted_set_put_elements.rs
@@ -123,7 +123,7 @@ impl<V: IntoBytes> IntoSortedSetElements<V> for HashMap<V, f64> {
 /// # fn main() -> anyhow::Result<()> {
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
-/// use momento::cache::{CollectionTtl, SortedSetPutElements, SortedSetPutElementsRequest};
+/// use momento::cache::{CollectionTtl, SortedSetPutElementsResponse, SortedSetPutElementsRequest};
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 /// let sorted_set_name = "sorted_set";
 ///
@@ -172,9 +172,9 @@ impl<S: IntoBytes, V: IntoBytes, E: IntoSortedSetElements<V>> SortedSetPutElemen
 impl<S: IntoBytes, V: IntoBytes, E: IntoSortedSetElements<V>> MomentoRequest
     for SortedSetPutElementsRequest<S, V, E>
 {
-    type Response = SortedSetPutElements;
+    type Response = SortedSetPutElementsResponse;
 
-    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetPutElements> {
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetPutElementsResponse> {
         let collection_ttl = self.collection_ttl.unwrap_or_default();
         let elements = self.elements.into_sorted_set_elements();
         let set_name = self.sorted_set_name.into_bytes();
@@ -201,9 +201,9 @@ impl<S: IntoBytes, V: IntoBytes, E: IntoSortedSetElements<V>> MomentoRequest
             .clone()
             .sorted_set_put(request)
             .await?;
-        Ok(SortedSetPutElements {})
+        Ok(SortedSetPutElementsResponse {})
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct SortedSetPutElements {}
+pub struct SortedSetPutElementsResponse {}

--- a/src/cache/messages/sorted_set/sorted_set_remove_elements.rs
+++ b/src/cache/messages/sorted_set/sorted_set_remove_elements.rs
@@ -53,9 +53,12 @@ impl<S: IntoBytes, V: IntoBytesIterable> SortedSetRemoveElementsRequest<S, V> {
 }
 
 impl<S: IntoBytes, V: IntoBytesIterable> MomentoRequest for SortedSetRemoveElementsRequest<S, V> {
-    type Response = SortedSetRemoveElements;
+    type Response = SortedSetRemoveElementsResponse;
 
-    async fn send(self, cache_client: &CacheClient) -> MomentoResult<SortedSetRemoveElements> {
+    async fn send(
+        self,
+        cache_client: &CacheClient,
+    ) -> MomentoResult<SortedSetRemoveElementsResponse> {
         let values = self.values.into_bytes();
         let set_name = self.sorted_set_name.into_bytes();
         let cache_name = &self.cache_name;
@@ -73,9 +76,9 @@ impl<S: IntoBytes, V: IntoBytesIterable> MomentoRequest for SortedSetRemoveEleme
             .clone()
             .sorted_set_remove(request)
             .await?;
-        Ok(SortedSetRemoveElements {})
+        Ok(SortedSetRemoveElementsResponse {})
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct SortedSetRemoveElements {}
+pub struct SortedSetRemoveElementsResponse {}

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -68,7 +68,9 @@ pub use messages::sorted_set::sorted_set_fetch_by_rank::{
     SortedSetFetchByRankRequest, SortedSetOrder,
 };
 pub use messages::sorted_set::sorted_set_fetch_by_score::SortedSetFetchByScoreRequest;
-pub use messages::sorted_set::sorted_set_fetch_response::{SortedSetElements, SortedSetFetch};
+pub use messages::sorted_set::sorted_set_fetch_response::{
+    SortedSetElements, SortedSetFetchResponse,
+};
 pub use messages::sorted_set::sorted_set_get_rank::{SortedSetGetRank, SortedSetGetRankRequest};
 pub use messages::sorted_set::sorted_set_get_score::{SortedSetGetScore, SortedSetGetScoreRequest};
 pub use messages::sorted_set::sorted_set_length::{SortedSetLength, SortedSetLengthRequest};

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -74,7 +74,9 @@ pub use messages::sorted_set::sorted_set_fetch_response::{
 pub use messages::sorted_set::sorted_set_get_rank::{
     SortedSetGetRankRequest, SortedSetGetRankResponse,
 };
-pub use messages::sorted_set::sorted_set_get_score::{SortedSetGetScore, SortedSetGetScoreRequest};
+pub use messages::sorted_set::sorted_set_get_score::{
+    SortedSetGetScoreRequest, SortedSetGetScoreResponse,
+};
 pub use messages::sorted_set::sorted_set_length::{SortedSetLength, SortedSetLengthRequest};
 pub use messages::sorted_set::sorted_set_put_element::{
     SortedSetPutElement, SortedSetPutElementRequest,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -71,7 +71,9 @@ pub use messages::sorted_set::sorted_set_fetch_by_score::SortedSetFetchByScoreRe
 pub use messages::sorted_set::sorted_set_fetch_response::{
     SortedSetElements, SortedSetFetchResponse,
 };
-pub use messages::sorted_set::sorted_set_get_rank::{SortedSetGetRank, SortedSetGetRankRequest};
+pub use messages::sorted_set::sorted_set_get_rank::{
+    SortedSetGetRankRequest, SortedSetGetRankResponse,
+};
 pub use messages::sorted_set::sorted_set_get_score::{SortedSetGetScore, SortedSetGetScoreRequest};
 pub use messages::sorted_set::sorted_set_length::{SortedSetLength, SortedSetLengthRequest};
 pub use messages::sorted_set::sorted_set_put_element::{

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -88,7 +88,7 @@ pub use messages::sorted_set::sorted_set_put_elements::{
     SortedSetPutElementsResponse,
 };
 pub use messages::sorted_set::sorted_set_remove_elements::{
-    SortedSetRemoveElements, SortedSetRemoveElementsRequest,
+    SortedSetRemoveElementsRequest, SortedSetRemoveElementsResponse,
 };
 
 pub use messages::list::list_concatenate_back::{

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -77,7 +77,9 @@ pub use messages::sorted_set::sorted_set_get_rank::{
 pub use messages::sorted_set::sorted_set_get_score::{
     SortedSetGetScoreRequest, SortedSetGetScoreResponse,
 };
-pub use messages::sorted_set::sorted_set_length::{SortedSetLength, SortedSetLengthRequest};
+pub use messages::sorted_set::sorted_set_length::{
+    SortedSetLengthRequest, SortedSetLengthResponse,
+};
 pub use messages::sorted_set::sorted_set_put_element::{
     SortedSetPutElement, SortedSetPutElementRequest,
 };

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -81,7 +81,7 @@ pub use messages::sorted_set::sorted_set_length::{
     SortedSetLengthRequest, SortedSetLengthResponse,
 };
 pub use messages::sorted_set::sorted_set_put_element::{
-    SortedSetPutElement, SortedSetPutElementRequest,
+    SortedSetPutElementRequest, SortedSetPutElementResponse,
 };
 pub use messages::sorted_set::sorted_set_put_elements::{
     IntoSortedSetElements, SortedSetElement, SortedSetPutElements, SortedSetPutElementsRequest,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -84,7 +84,8 @@ pub use messages::sorted_set::sorted_set_put_element::{
     SortedSetPutElementRequest, SortedSetPutElementResponse,
 };
 pub use messages::sorted_set::sorted_set_put_elements::{
-    IntoSortedSetElements, SortedSetElement, SortedSetPutElements, SortedSetPutElementsRequest,
+    IntoSortedSetElements, SortedSetElement, SortedSetPutElementsRequest,
+    SortedSetPutElementsResponse,
 };
 pub use messages::sorted_set::sorted_set_remove_elements::{
     SortedSetRemoveElements, SortedSetRemoveElementsRequest,

--- a/test-util/src/test_data.rs
+++ b/test-util/src/test_data.rs
@@ -1,6 +1,7 @@
 use momento::{
     cache::{
-        GetResponse, GetValue, ListFetchResponse, ListFetchValue, SortedSetElements, SortedSetFetch,
+        GetResponse, GetValue, ListFetchResponse, ListFetchValue, SortedSetElements,
+        SortedSetFetchResponse,
     },
     IntoBytes,
 };
@@ -156,9 +157,9 @@ impl Default for TestSortedSet {
     }
 }
 
-impl From<&TestSortedSet> for SortedSetFetch {
+impl From<&TestSortedSet> for SortedSetFetchResponse {
     fn from(test_sorted_set: &TestSortedSet) -> Self {
-        SortedSetFetch::Hit {
+        SortedSetFetchResponse::Hit {
             value: SortedSetElements::new(
                 test_sorted_set
                     .value()

--- a/tests/cache/sorted_set.rs
+++ b/tests/cache/sorted_set.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use momento::cache::{
     IntoSortedSetElements, SortedSetElement, SortedSetElements, SortedSetFetchByRankRequest,
     SortedSetFetchByScoreRequest, SortedSetFetchResponse, SortedSetGetRankResponse,
-    SortedSetGetScoreResponse, SortedSetLength,
+    SortedSetGetScoreResponse, SortedSetLengthResponse,
     SortedSetOrder::{Ascending, Descending},
     SortedSetPutElements, SortedSetRemoveElements,
 };
@@ -612,7 +612,7 @@ mod sorted_set_length {
 
         // Miss before sorted set exists
         let result = client.sorted_set_length(cache_name, item.name()).await?;
-        assert_eq!(result, SortedSetLength::Miss);
+        assert_eq!(result, SortedSetLengthResponse::Miss);
 
         let result = client
             .sorted_set_put_elements(cache_name, item.name(), item.value().to_vec())
@@ -621,7 +621,7 @@ mod sorted_set_length {
 
         // Nonzero length after sorted set exists
         let result = client.sorted_set_length(cache_name, item.name()).await?;
-        assert_eq!(result, SortedSetLength::Hit { length: 2 });
+        assert_eq!(result, SortedSetLengthResponse::Hit { length: 2 });
 
         Ok(())
     }

--- a/tests/cache/sorted_set.rs
+++ b/tests/cache/sorted_set.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use momento::cache::{
-    IntoSortedSetElements, SortedSetElement, SortedSetElements, SortedSetFetch,
-    SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest, SortedSetGetRank, SortedSetGetScore,
+    IntoSortedSetElements, SortedSetElement, SortedSetElements, SortedSetFetchByRankRequest,
+    SortedSetFetchByScoreRequest, SortedSetFetchResponse, SortedSetGetRank, SortedSetGetScore,
     SortedSetLength,
     SortedSetOrder::{Ascending, Descending},
     SortedSetPutElements, SortedSetRemoveElements,
@@ -14,10 +14,10 @@ use momento_test_util::{
 };
 
 fn assert_fetched_sorted_set_eq(
-    sorted_set_fetch_result: SortedSetFetch,
+    sorted_set_fetch_result: SortedSetFetchResponse,
     expected: Vec<(String, f64)>,
 ) -> MomentoResult<()> {
-    let expected: SortedSetFetch = expected.into();
+    let expected: SortedSetFetchResponse = expected.into();
     assert_eq!(
         sorted_set_fetch_result, expected,
         "Expected SortedSetFetch::Hit to be equal to {:?}, but got {:?}",
@@ -27,7 +27,7 @@ fn assert_fetched_sorted_set_eq(
 }
 
 fn assert_fetched_sorted_set_eq_after_sorting(
-    sorted_set_fetch_result: SortedSetFetch,
+    sorted_set_fetch_result: SortedSetFetchResponse,
     expected: Vec<(String, f64)>,
 ) -> MomentoResult<()> {
     let sort_by_score = |a: &(_, f64), b: &(_, f64)| -> std::cmp::Ordering {
@@ -36,10 +36,10 @@ fn assert_fetched_sorted_set_eq_after_sorting(
     };
 
     let sorted_set_fetch_result = match sorted_set_fetch_result {
-        SortedSetFetch::Hit { value } => {
+        SortedSetFetchResponse::Hit { value } => {
             let mut elements = value.elements.clone();
             elements.sort_by(sort_by_score);
-            SortedSetFetch::Hit {
+            SortedSetFetchResponse::Hit {
                 value: SortedSetElements { elements },
             }
         }
@@ -75,7 +75,7 @@ mod sorted_set_fetch_by_rank {
         let result = client
             .sorted_set_fetch_by_rank(cache_name, item.name(), Ascending, None, None)
             .await?;
-        assert_eq!(result, SortedSetFetch::Miss);
+        assert_eq!(result, SortedSetFetchResponse::Miss);
 
         client
             .sorted_set_put_elements(cache_name, item.name(), item.value().to_vec())
@@ -174,7 +174,7 @@ mod sorted_set_fetch_by_score {
         let result = client
             .sorted_set_fetch_by_score(cache_name, item.name(), Ascending)
             .await?;
-        assert_eq!(result, SortedSetFetch::Miss);
+        assert_eq!(result, SortedSetFetchResponse::Miss);
 
         client
             .sorted_set_put_elements(cache_name, item.name(), item.value().to_vec())
@@ -483,7 +483,7 @@ mod sorted_set_put_element {
         let result = client
             .sorted_set_fetch_by_rank(cache_name, item.name(), Ascending, None, None)
             .await?;
-        assert_eq!(result, SortedSetFetch::Miss);
+        assert_eq!(result, SortedSetFetchResponse::Miss);
 
         client
             .sorted_set_put_element(

--- a/tests/cache/sorted_set.rs
+++ b/tests/cache/sorted_set.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use momento::cache::{
     IntoSortedSetElements, SortedSetElement, SortedSetElements, SortedSetFetchByRankRequest,
-    SortedSetFetchByScoreRequest, SortedSetFetchResponse, SortedSetGetRank, SortedSetGetScore,
-    SortedSetLength,
+    SortedSetFetchByScoreRequest, SortedSetFetchResponse, SortedSetGetRankResponse,
+    SortedSetGetScore, SortedSetLength,
     SortedSetOrder::{Ascending, Descending},
     SortedSetPutElements, SortedSetRemoveElements,
 };
@@ -291,13 +291,13 @@ mod sorted_set_get_rank {
         let result = client
             .sorted_set_get_rank(cache_name, item.name(), item.value[0].0.as_str())
             .await?;
-        assert_eq!(result, SortedSetGetRank::Hit { rank: 0 });
+        assert_eq!(result, SortedSetGetRankResponse::Hit { rank: 0 });
 
         // Miss for nonexistent value
         let result = client
             .sorted_set_get_rank(cache_name, item.name(), "nonexistent")
             .await?;
-        assert_eq!(result, SortedSetGetRank::Miss);
+        assert_eq!(result, SortedSetGetRankResponse::Miss);
 
         Ok(())
     }
@@ -326,7 +326,7 @@ mod sorted_set_get_rank {
         let result = client
             .sorted_set_get_rank(cache_name, sorted_set_name, "element1")
             .await?;
-        assert_eq!(result, SortedSetGetRank::Miss);
+        assert_eq!(result, SortedSetGetRankResponse::Miss);
         Ok(())
     }
 }

--- a/tests/cache/sorted_set.rs
+++ b/tests/cache/sorted_set.rs
@@ -5,7 +5,7 @@ use momento::cache::{
     SortedSetFetchByScoreRequest, SortedSetFetchResponse, SortedSetGetRankResponse,
     SortedSetGetScoreResponse, SortedSetLengthResponse,
     SortedSetOrder::{Ascending, Descending},
-    SortedSetPutElements, SortedSetRemoveElements,
+    SortedSetPutElementsResponse, SortedSetRemoveElements,
 };
 use momento::{CacheClient, MomentoErrorCode, MomentoResult};
 
@@ -285,7 +285,7 @@ mod sorted_set_get_rank {
         let result = client
             .sorted_set_put_elements(cache_name, item.name(), item.value().to_vec())
             .await?;
-        assert_eq!(result, SortedSetPutElements {});
+        assert_eq!(result, SortedSetPutElementsResponse {});
 
         // Hit for existing value
         let result = client
@@ -343,7 +343,7 @@ mod sorted_set_get_score {
         let result = client
             .sorted_set_put_elements(cache_name, item.name(), item.value().to_vec())
             .await?;
-        assert_eq!(result, SortedSetPutElements {});
+        assert_eq!(result, SortedSetPutElementsResponse {});
 
         // Hit for existing value
         let result = client
@@ -408,7 +408,7 @@ mod sorted_set_remove_elements {
         let result = client
             .sorted_set_put_elements(cache_name, item.name(), item.value().to_vec())
             .await?;
-        assert_eq!(result, SortedSetPutElements {});
+        assert_eq!(result, SortedSetPutElementsResponse {});
 
         // does nothing for nonexistent values
         let result = client
@@ -617,7 +617,7 @@ mod sorted_set_length {
         let result = client
             .sorted_set_put_elements(cache_name, item.name(), item.value().to_vec())
             .await?;
-        assert_eq!(result, SortedSetPutElements {});
+        assert_eq!(result, SortedSetPutElementsResponse {});
 
         // Nonzero length after sorted set exists
         let result = client.sorted_set_length(cache_name, item.name()).await?;

--- a/tests/cache/sorted_set.rs
+++ b/tests/cache/sorted_set.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use momento::cache::{
     IntoSortedSetElements, SortedSetElement, SortedSetElements, SortedSetFetchByRankRequest,
     SortedSetFetchByScoreRequest, SortedSetFetchResponse, SortedSetGetRankResponse,
-    SortedSetGetScore, SortedSetLength,
+    SortedSetGetScoreResponse, SortedSetLength,
     SortedSetOrder::{Ascending, Descending},
     SortedSetPutElements, SortedSetRemoveElements,
 };
@@ -349,13 +349,13 @@ mod sorted_set_get_score {
         let result = client
             .sorted_set_get_score(cache_name, item.name(), item.value[0].0.as_str())
             .await?;
-        assert_eq!(result, SortedSetGetScore::Hit { score: 1.0 });
+        assert_eq!(result, SortedSetGetScoreResponse::Hit { score: 1.0 });
 
         // Miss for nonexistent value
         let result = client
             .sorted_set_get_score(cache_name, item.name(), unique_value())
             .await?;
-        assert_eq!(result, SortedSetGetScore::Miss);
+        assert_eq!(result, SortedSetGetScoreResponse::Miss);
 
         Ok(())
     }
@@ -384,7 +384,7 @@ mod sorted_set_get_score {
         let result = client
             .sorted_set_get_score(cache_name, sorted_set_name, "element1")
             .await?;
-        assert_eq!(result, SortedSetGetScore::Miss);
+        assert_eq!(result, SortedSetGetScoreResponse::Miss);
         Ok(())
     }
 }

--- a/tests/cache/sorted_set.rs
+++ b/tests/cache/sorted_set.rs
@@ -5,7 +5,7 @@ use momento::cache::{
     SortedSetFetchByScoreRequest, SortedSetFetchResponse, SortedSetGetRankResponse,
     SortedSetGetScoreResponse, SortedSetLengthResponse,
     SortedSetOrder::{Ascending, Descending},
-    SortedSetPutElementsResponse, SortedSetRemoveElements,
+    SortedSetPutElementsResponse, SortedSetRemoveElementsResponse,
 };
 use momento::{CacheClient, MomentoErrorCode, MomentoResult};
 
@@ -418,7 +418,7 @@ mod sorted_set_remove_elements {
                 vec![unique_value(), unique_value()],
             )
             .await?;
-        assert_eq!(result, SortedSetRemoveElements {});
+        assert_eq!(result, SortedSetRemoveElementsResponse {});
         assert_fetched_sorted_set_eq(
             client
                 .sorted_set_fetch_by_score(cache_name, item.name(), Ascending)
@@ -431,7 +431,7 @@ mod sorted_set_remove_elements {
         let result = client
             .sorted_set_remove_elements(cache_name, item.name(), values)
             .await?;
-        assert_eq!(result, SortedSetRemoveElements {});
+        assert_eq!(result, SortedSetRemoveElementsResponse {});
         assert_fetched_sorted_set_eq(
             client
                 .sorted_set_fetch_by_score(cache_name, item.name(), Ascending)
@@ -466,7 +466,7 @@ mod sorted_set_remove_elements {
         let result = client
             .sorted_set_remove_elements(cache_name, sorted_set_name, vec!["element1", "element2"])
             .await?;
-        assert_eq!(result, SortedSetRemoveElements {});
+        assert_eq!(result, SortedSetRemoveElementsResponse {});
         Ok(())
     }
 }


### PR DESCRIPTION
Adds the suffix Response to all sorted set types in code and docstrings.

Work towards https://github.com/momentohq/client-sdk-rust/issues/285