### PR TITLE
feat: add response suffix to control commands

### DIFF
--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -8,7 +8,7 @@ use tonic::transport::Channel;
 
 use crate::cache::{
     Configuration, CreateCacheRequest, CreateCacheResponse, DecreaseTtlRequest,
-    DecreaseTtlResponse, DeleteCache, DeleteCacheRequest, DeleteRequest, DeleteResponse,
+    DecreaseTtlResponse, DeleteCacheRequest, DeleteCacheResponse, DeleteRequest, DeleteResponse,
     DictionaryFetchRequest, DictionaryFetchResponse, DictionaryGetFieldRequest,
     DictionaryGetFieldResponse, DictionaryGetFieldsRequest, DictionaryGetFieldsResponse,
     DictionaryIncrementRequest, DictionaryIncrementResponse, DictionaryLengthRequest,
@@ -104,7 +104,7 @@ impl CacheClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::DeleteCache;
+    /// use momento::cache::DeleteCacheResponse;
     /// use momento::MomentoErrorCode;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     ///
@@ -121,7 +121,10 @@ impl CacheClient {
     /// # }
     /// ```
     /// You can also use the [send_request](CacheClient::send_request) method to delete a cache using a [DeleteCacheRequest].
-    pub async fn delete_cache(&self, cache_name: impl Into<String>) -> MomentoResult<DeleteCache> {
+    pub async fn delete_cache(
+        &self,
+        cache_name: impl Into<String>,
+    ) -> MomentoResult<DeleteCacheResponse> {
         let request = DeleteCacheRequest::new(cache_name);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -15,7 +15,7 @@ use crate::cache::{
     DictionaryLengthResponse, DictionaryRemoveFieldRequest, DictionaryRemoveFieldResponse,
     DictionaryRemoveFieldsRequest, DictionaryRemoveFieldsResponse, DictionarySetFieldRequest,
     DictionarySetFieldResponse, DictionarySetFieldsRequest, DictionarySetFieldsResponse,
-    FlushCache, FlushCacheRequest, GetRequest, GetResponse, IncreaseTtlRequest,
+    FlushCacheRequest, FlushCacheResponse, GetRequest, GetResponse, IncreaseTtlRequest,
     IncreaseTtlResponse, IncrementRequest, IncrementResponse, IntoDictionaryFieldValuePairs,
     IntoSortedSetElements, ItemGetTtlRequest, ItemGetTtlResponse, ItemGetTypeRequest,
     ItemGetTypeResponse, KeyExistsRequest, KeyExistsResponse, KeysExistRequest, KeysExistResponse,
@@ -166,7 +166,7 @@ impl CacheClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::FlushCache;
+    /// use momento::cache::FlushCacheResponse;
     /// use momento::MomentoErrorCode;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     ///
@@ -185,7 +185,10 @@ impl CacheClient {
     /// # }
     /// ```
     /// You can also use the [send_request](CacheClient::send_request) method to delete a cache using a [FlushCacheRequest].
-    pub async fn flush_cache(&self, cache_name: impl Into<String>) -> MomentoResult<FlushCache> {
+    pub async fn flush_cache(
+        &self,
+        cache_name: impl Into<String>,
+    ) -> MomentoResult<FlushCacheResponse> {
         let request = FlushCacheRequest::new(cache_name);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -7,34 +7,35 @@ use tonic::codegen::InterceptedService;
 use tonic::transport::Channel;
 
 use crate::cache::{
-    Configuration, CreateCache, CreateCacheRequest, DecreaseTtlRequest, DecreaseTtlResponse,
-    DeleteCache, DeleteCacheRequest, DeleteRequest, DeleteResponse, DictionaryFetchRequest,
-    DictionaryFetchResponse, DictionaryGetFieldRequest, DictionaryGetFieldResponse,
-    DictionaryGetFieldsRequest, DictionaryGetFieldsResponse, DictionaryIncrementRequest,
-    DictionaryIncrementResponse, DictionaryLengthRequest, DictionaryLengthResponse,
-    DictionaryRemoveFieldRequest, DictionaryRemoveFieldResponse, DictionaryRemoveFieldsRequest,
-    DictionaryRemoveFieldsResponse, DictionarySetFieldRequest, DictionarySetFieldResponse,
-    DictionarySetFieldsRequest, DictionarySetFieldsResponse, FlushCache, FlushCacheRequest,
-    GetRequest, GetResponse, IncreaseTtlRequest, IncreaseTtlResponse, IncrementRequest,
-    IncrementResponse, IntoDictionaryFieldValuePairs, IntoSortedSetElements, ItemGetTtlRequest,
-    ItemGetTtlResponse, ItemGetTypeRequest, ItemGetTypeResponse, KeyExistsRequest,
-    KeyExistsResponse, KeysExistRequest, KeysExistResponse, ListCaches, ListCachesRequest,
-    ListConcatenateBackRequest, ListConcatenateBackResponse, ListConcatenateFrontRequest,
-    ListConcatenateFrontResponse, ListFetchRequest, ListFetchResponse, ListLengthRequest,
-    ListLengthResponse, ListPopBackRequest, ListPopBackResponse, ListPopFrontRequest,
-    ListPopFrontResponse, ListPushBackRequest, ListPushBackResponse, ListPushFrontRequest,
-    ListPushFrontResponse, ListRemoveValueRequest, ListRemoveValueResponse, MomentoRequest,
-    SetAddElementsRequest, SetAddElementsResponse, SetFetchRequest, SetFetchResponse,
-    SetIfAbsentOrEqualRequest, SetIfAbsentOrEqualResponse, SetIfAbsentRequest, SetIfAbsentResponse,
-    SetIfEqualRequest, SetIfEqualResponse, SetIfNotEqualRequest, SetIfNotEqualResponse,
-    SetIfPresentAndNotEqualRequest, SetIfPresentAndNotEqualResponse, SetIfPresentRequest,
-    SetIfPresentResponse, SetRemoveElementsRequest, SetRemoveElementsResponse, SetRequest,
-    SetResponse, SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest, SortedSetFetchResponse,
-    SortedSetGetRankRequest, SortedSetGetRankResponse, SortedSetGetScoreRequest,
-    SortedSetGetScoreResponse, SortedSetLengthRequest, SortedSetLengthResponse, SortedSetOrder,
-    SortedSetPutElementRequest, SortedSetPutElementResponse, SortedSetPutElementsRequest,
-    SortedSetPutElementsResponse, SortedSetRemoveElementsRequest, SortedSetRemoveElementsResponse,
-    UpdateTtlRequest, UpdateTtlResponse,
+    Configuration, CreateCacheRequest, CreateCacheResponse, DecreaseTtlRequest,
+    DecreaseTtlResponse, DeleteCache, DeleteCacheRequest, DeleteRequest, DeleteResponse,
+    DictionaryFetchRequest, DictionaryFetchResponse, DictionaryGetFieldRequest,
+    DictionaryGetFieldResponse, DictionaryGetFieldsRequest, DictionaryGetFieldsResponse,
+    DictionaryIncrementRequest, DictionaryIncrementResponse, DictionaryLengthRequest,
+    DictionaryLengthResponse, DictionaryRemoveFieldRequest, DictionaryRemoveFieldResponse,
+    DictionaryRemoveFieldsRequest, DictionaryRemoveFieldsResponse, DictionarySetFieldRequest,
+    DictionarySetFieldResponse, DictionarySetFieldsRequest, DictionarySetFieldsResponse,
+    FlushCache, FlushCacheRequest, GetRequest, GetResponse, IncreaseTtlRequest,
+    IncreaseTtlResponse, IncrementRequest, IncrementResponse, IntoDictionaryFieldValuePairs,
+    IntoSortedSetElements, ItemGetTtlRequest, ItemGetTtlResponse, ItemGetTypeRequest,
+    ItemGetTypeResponse, KeyExistsRequest, KeyExistsResponse, KeysExistRequest, KeysExistResponse,
+    ListCaches, ListCachesRequest, ListConcatenateBackRequest, ListConcatenateBackResponse,
+    ListConcatenateFrontRequest, ListConcatenateFrontResponse, ListFetchRequest, ListFetchResponse,
+    ListLengthRequest, ListLengthResponse, ListPopBackRequest, ListPopBackResponse,
+    ListPopFrontRequest, ListPopFrontResponse, ListPushBackRequest, ListPushBackResponse,
+    ListPushFrontRequest, ListPushFrontResponse, ListRemoveValueRequest, ListRemoveValueResponse,
+    MomentoRequest, SetAddElementsRequest, SetAddElementsResponse, SetFetchRequest,
+    SetFetchResponse, SetIfAbsentOrEqualRequest, SetIfAbsentOrEqualResponse, SetIfAbsentRequest,
+    SetIfAbsentResponse, SetIfEqualRequest, SetIfEqualResponse, SetIfNotEqualRequest,
+    SetIfNotEqualResponse, SetIfPresentAndNotEqualRequest, SetIfPresentAndNotEqualResponse,
+    SetIfPresentRequest, SetIfPresentResponse, SetRemoveElementsRequest, SetRemoveElementsResponse,
+    SetRequest, SetResponse, SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest,
+    SortedSetFetchResponse, SortedSetGetRankRequest, SortedSetGetRankResponse,
+    SortedSetGetScoreRequest, SortedSetGetScoreResponse, SortedSetLengthRequest,
+    SortedSetLengthResponse, SortedSetOrder, SortedSetPutElementRequest,
+    SortedSetPutElementResponse, SortedSetPutElementsRequest, SortedSetPutElementsResponse,
+    SortedSetRemoveElementsRequest, SortedSetRemoveElementsResponse, UpdateTtlRequest,
+    UpdateTtlResponse,
 };
 use crate::grpc::header_interceptor::HeaderInterceptor;
 
@@ -71,19 +72,22 @@ impl CacheClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::CreateCache;
+    /// use momento::cache::CreateCacheResponse;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     ///
     /// match cache_client.create_cache(&cache_name).await? {
-    ///     CreateCache::Created => println!("Cache {} created", &cache_name),
-    ///     CreateCache::AlreadyExists => println!("Cache {} already exists", &cache_name),
+    ///     CreateCacheResponse::Created => println!("Cache {} created", &cache_name),
+    ///     CreateCacheResponse::AlreadyExists => println!("Cache {} already exists", &cache_name),
     /// }
     /// # Ok(())
     /// # })
     /// # }
     /// ```
     /// You can also use the [send_request](CacheClient::send_request) method to create a cache using a [CreateCacheRequest].
-    pub async fn create_cache(&self, cache_name: impl Into<String>) -> MomentoResult<CreateCache> {
+    pub async fn create_cache(
+        &self,
+        cache_name: impl Into<String>,
+    ) -> MomentoResult<CreateCacheResponse> {
         let request = CreateCacheRequest::new(cache_name);
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -19,7 +19,7 @@ use crate::cache::{
     IncreaseTtlResponse, IncrementRequest, IncrementResponse, IntoDictionaryFieldValuePairs,
     IntoSortedSetElements, ItemGetTtlRequest, ItemGetTtlResponse, ItemGetTypeRequest,
     ItemGetTypeResponse, KeyExistsRequest, KeyExistsResponse, KeysExistRequest, KeysExistResponse,
-    ListCaches, ListCachesRequest, ListConcatenateBackRequest, ListConcatenateBackResponse,
+    ListCachesRequest, ListCachesResponse, ListConcatenateBackRequest, ListConcatenateBackResponse,
     ListConcatenateFrontRequest, ListConcatenateFrontResponse, ListFetchRequest, ListFetchResponse,
     ListLengthRequest, ListLengthResponse, ListPopBackRequest, ListPopBackResponse,
     ListPopFrontRequest, ListPopFrontResponse, ListPushBackRequest, ListPushBackResponse,
@@ -137,7 +137,7 @@ impl CacheClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # use momento_test_util::create_doctest_cache_client;
     /// # tokio_test::block_on(async {
-    /// use momento::cache::ListCaches;
+    /// use momento::cache::ListCachesResponse;
     /// # let (cache_client, cache_name) = create_doctest_cache_client();
     ///
     /// match cache_client.list_caches().await {
@@ -149,7 +149,7 @@ impl CacheClient {
     /// # }
     /// ```
     /// You can also use the [send_request](CacheClient::send_request) method to list caches using a [ListCachesRequest].
-    pub async fn list_caches(&self) -> MomentoResult<ListCaches> {
+    pub async fn list_caches(&self) -> MomentoResult<ListCachesResponse> {
         let request = ListCachesRequest {};
         request.send(self).await
     }

--- a/src/cache/messages/create_cache.rs
+++ b/src/cache/messages/create_cache.rs
@@ -17,14 +17,14 @@ use crate::{utils, CacheClient, MomentoResult};
 /// # fn main() -> anyhow::Result<()> {
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
-/// use momento::cache::{CreateCache, CreateCacheRequest};
+/// use momento::cache::{CreateCacheResponse, CreateCacheRequest};
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 ///
 /// let create_cache_request = CreateCacheRequest::new(&cache_name);
 ///
 /// match cache_client.send_request(create_cache_request).await? {
-///     CreateCache::Created => println!("Cache {} created", &cache_name),
-///     CreateCache::AlreadyExists => println!("Cache {} already exists", &cache_name),
+///     CreateCacheResponse::Created => println!("Cache {} created", &cache_name),
+///     CreateCacheResponse::AlreadyExists => println!("Cache {} already exists", &cache_name),
 /// }
 /// # Ok(())
 /// # })
@@ -43,9 +43,9 @@ impl CreateCacheRequest {
 }
 
 impl MomentoRequest for CreateCacheRequest {
-    type Response = CreateCache;
+    type Response = CreateCacheResponse;
 
-    async fn send(self, cache_client: &CacheClient) -> MomentoResult<CreateCache> {
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<CreateCacheResponse> {
         utils::is_cache_name_valid(&self.cache_name)?;
         let request = Request::new(control_client::CreateCacheRequest {
             cache_name: self.cache_name,
@@ -57,10 +57,10 @@ impl MomentoRequest for CreateCacheRequest {
             .create_cache(request)
             .await;
         match result {
-            Ok(_) => Ok(CreateCache::Created {}),
+            Ok(_) => Ok(CreateCacheResponse::Created {}),
             Err(e) => {
                 if e.code() == tonic::Code::AlreadyExists {
-                    return Ok(CreateCache::AlreadyExists {});
+                    return Ok(CreateCacheResponse::AlreadyExists {});
                 }
                 Err(status_to_error(e))
             }
@@ -69,7 +69,7 @@ impl MomentoRequest for CreateCacheRequest {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum CreateCache {
+pub enum CreateCacheResponse {
     Created,
     AlreadyExists,
 }

--- a/src/cache/messages/delete_cache.rs
+++ b/src/cache/messages/delete_cache.rs
@@ -16,7 +16,7 @@ use crate::{utils, CacheClient, MomentoResult};
 /// # fn main() -> anyhow::Result<()> {
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
-/// use momento::cache::{DeleteCache, DeleteCacheRequest};
+/// use momento::cache::{DeleteCacheResponse, DeleteCacheRequest};
 /// use momento::MomentoErrorCode;
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 ///
@@ -47,9 +47,9 @@ impl DeleteCacheRequest {
 }
 
 impl MomentoRequest for DeleteCacheRequest {
-    type Response = DeleteCache;
+    type Response = DeleteCacheResponse;
 
-    async fn send(self, cache_client: &CacheClient) -> MomentoResult<DeleteCache> {
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<DeleteCacheResponse> {
         let cache_name = &self.cache_name;
 
         utils::is_cache_name_valid(cache_name)?;
@@ -62,9 +62,9 @@ impl MomentoRequest for DeleteCacheRequest {
             .clone()
             .delete_cache(request)
             .await?;
-        Ok(DeleteCache {})
+        Ok(DeleteCacheResponse {})
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct DeleteCache {}
+pub struct DeleteCacheResponse {}

--- a/src/cache/messages/flush_cache.rs
+++ b/src/cache/messages/flush_cache.rs
@@ -16,7 +16,7 @@ use crate::{utils, CacheClient, MomentoResult};
 /// # fn main() -> anyhow::Result<()> {
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
-/// use momento::cache::{FlushCache, FlushCacheRequest};
+/// use momento::cache::{FlushCacheResponse, FlushCacheRequest};
 /// use momento::MomentoErrorCode;
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 ///
@@ -49,9 +49,9 @@ impl FlushCacheRequest {
 }
 
 impl MomentoRequest for FlushCacheRequest {
-    type Response = FlushCache;
+    type Response = FlushCacheResponse;
 
-    async fn send(self, cache_client: &CacheClient) -> MomentoResult<FlushCache> {
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<FlushCacheResponse> {
         let cache_name = &self.cache_name;
 
         utils::is_cache_name_valid(cache_name)?;
@@ -64,9 +64,9 @@ impl MomentoRequest for FlushCacheRequest {
             .clone()
             .flush_cache(request)
             .await?;
-        Ok(FlushCache {})
+        Ok(FlushCacheResponse {})
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct FlushCache {}
+pub struct FlushCacheResponse {}

--- a/src/cache/messages/list_caches.rs
+++ b/src/cache/messages/list_caches.rs
@@ -12,7 +12,7 @@ use crate::{CacheClient, MomentoResult};
 /// # fn main() -> anyhow::Result<()> {
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
-/// use momento::cache::{ListCaches, ListCachesRequest};
+/// use momento::cache::{ListCachesResponse, ListCachesRequest};
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 ///
 /// let list_caches_request = ListCachesRequest {};
@@ -28,9 +28,9 @@ use crate::{CacheClient, MomentoResult};
 pub struct ListCachesRequest {}
 
 impl MomentoRequest for ListCachesRequest {
-    type Response = ListCaches;
+    type Response = ListCachesResponse;
 
-    async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListCaches> {
+    async fn send(self, cache_client: &CacheClient) -> MomentoResult<ListCachesResponse> {
         let request = Request::new(control_client::ListCachesRequest {
             next_token: "".to_string(),
         });
@@ -42,7 +42,7 @@ impl MomentoRequest for ListCachesRequest {
             .await?
             .into_inner();
 
-        Ok(ListCaches::from_response(response))
+        Ok(ListCachesResponse::from_response(response))
     }
 }
 
@@ -73,19 +73,19 @@ pub struct CacheInfo {
 /// You can cast your result directly into a `Result<Vec<CacheInfo>, MomentoError>` suitable for
 /// ?-propagation if you know you are expecting a `Vec<CacheInfo>` item.
 /// ```
-/// # use momento::cache::{CacheInfo, ListCaches};
+/// # use momento::cache::{CacheInfo, ListCachesResponse};
 /// # use momento::MomentoResult;
-/// # let list_caches_response = ListCaches { caches: vec![] };
+/// # let list_caches_response = ListCachesResponse { caches: vec![] };
 /// let caches: Vec<CacheInfo> = list_caches_response.into();
 /// ```
 #[derive(Debug, PartialEq, Eq)]
-pub struct ListCaches {
+pub struct ListCachesResponse {
     pub caches: Vec<CacheInfo>,
 }
 
-/// Convert a ListCachesResponse from the server into a ListCaches.
-impl ListCaches {
-    pub fn from_response(response: control_client::ListCachesResponse) -> ListCaches {
+/// Convert a ListCachesResponse from the server into a ListCachesResponse.
+impl ListCachesResponse {
+    pub fn from_response(response: control_client::ListCachesResponse) -> ListCachesResponse {
         let mut caches = Vec::new();
         for cache in response.cache {
             let cache_limits = cache.cache_limits.clone().unwrap_or_default();
@@ -105,12 +105,12 @@ impl ListCaches {
                 },
             });
         }
-        ListCaches { caches }
+        ListCachesResponse { caches }
     }
 }
 
-impl From<ListCaches> for Vec<CacheInfo> {
-    fn from(response: ListCaches) -> Self {
+impl From<ListCachesResponse> for Vec<CacheInfo> {
+    fn from(response: ListCachesResponse) -> Self {
         response.caches
     }
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -6,7 +6,7 @@ pub use messages::create_cache::{CreateCacheRequest, CreateCacheResponse};
 pub use messages::delete_cache::{DeleteCacheRequest, DeleteCacheResponse};
 pub use messages::flush_cache::{FlushCacheRequest, FlushCacheResponse};
 pub use messages::list_caches::{
-    CacheInfo, CacheLimits, ListCaches, ListCachesRequest, TopicLimits,
+    CacheInfo, CacheLimits, ListCachesRequest, ListCachesResponse, TopicLimits,
 };
 
 pub use messages::dictionary::dictionary_fetch::{

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -2,7 +2,7 @@ mod messages;
 
 pub use messages::MomentoRequest;
 
-pub use messages::create_cache::{CreateCache, CreateCacheRequest};
+pub use messages::create_cache::{CreateCacheRequest, CreateCacheResponse};
 pub use messages::delete_cache::{DeleteCache, DeleteCacheRequest};
 pub use messages::flush_cache::{FlushCache, FlushCacheRequest};
 pub use messages::list_caches::{

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -3,7 +3,7 @@ mod messages;
 pub use messages::MomentoRequest;
 
 pub use messages::create_cache::{CreateCacheRequest, CreateCacheResponse};
-pub use messages::delete_cache::{DeleteCache, DeleteCacheRequest};
+pub use messages::delete_cache::{DeleteCacheRequest, DeleteCacheResponse};
 pub use messages::flush_cache::{FlushCache, FlushCacheRequest};
 pub use messages::list_caches::{
     CacheInfo, CacheLimits, ListCaches, ListCachesRequest, TopicLimits,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -4,7 +4,7 @@ pub use messages::MomentoRequest;
 
 pub use messages::create_cache::{CreateCacheRequest, CreateCacheResponse};
 pub use messages::delete_cache::{DeleteCacheRequest, DeleteCacheResponse};
-pub use messages::flush_cache::{FlushCache, FlushCacheRequest};
+pub use messages::flush_cache::{FlushCacheRequest, FlushCacheResponse};
 pub use messages::list_caches::{
     CacheInfo, CacheLimits, ListCaches, ListCachesRequest, TopicLimits,
 };

--- a/test-util/src/cache_test_state.rs
+++ b/test-util/src/cache_test_state.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use momento::cache::CreateCache;
+use momento::cache::CreateCacheResponse;
 use once_cell::sync::Lazy;
 use tokio::sync::watch::channel;
 
@@ -47,8 +47,8 @@ impl CacheTestState {
 
             match cache_client.clone().create_cache(thread_cache_name).await {
                 Ok(ok) => match ok {
-                    CreateCache::Created => println!("Cache created."),
-                    CreateCache::AlreadyExists => println!("Cache already exists."),
+                    CreateCacheResponse::Created => println!("Cache created."),
+                    CreateCacheResponse::AlreadyExists => println!("Cache already exists."),
                 },
                 Err(e) => panic!("Failed to create cache: {:?}", e),
             }

--- a/tests/cache/control.rs
+++ b/tests/cache/control.rs
@@ -1,4 +1,4 @@
-use momento::cache::{CreateCacheResponse, FlushCache, GetResponse, GetValue, SetResponse};
+use momento::cache::{CreateCacheResponse, FlushCacheResponse, GetResponse, GetValue, SetResponse};
 use momento::MomentoErrorCode;
 use momento::MomentoResult;
 use momento_test_util::CACHE_TEST_STATE;
@@ -98,7 +98,7 @@ mod flush_cache {
 
         // Flush the cache
         let result = client.flush_cache(cache_name).await?;
-        assert_eq!(result, FlushCache {});
+        assert_eq!(result, FlushCacheResponse {});
 
         // Verify that the elements were flushed from the cache
         let get_result3 = client.get(cache_name, item1.key()).await?;

--- a/tests/cache/control.rs
+++ b/tests/cache/control.rs
@@ -27,7 +27,7 @@ mod create_delete_list_cache {
 }
 
 mod flush_cache {
-    use momento::cache::DeleteCache;
+    use momento::cache::DeleteCacheResponse;
 
     use super::*;
 
@@ -108,7 +108,7 @@ mod flush_cache {
 
         // Delete the cache
         let delete_result = client.delete_cache(cache_name).await?;
-        assert_eq!(delete_result, DeleteCache {});
+        assert_eq!(delete_result, DeleteCacheResponse {});
 
         Ok(())
     }

--- a/tests/cache/control.rs
+++ b/tests/cache/control.rs
@@ -1,4 +1,4 @@
-use momento::cache::{CreateCache, FlushCache, GetResponse, GetValue, SetResponse};
+use momento::cache::{CreateCacheResponse, FlushCache, GetResponse, GetValue, SetResponse};
 use momento::MomentoErrorCode;
 use momento::MomentoResult;
 use momento_test_util::CACHE_TEST_STATE;
@@ -21,7 +21,7 @@ mod create_delete_list_cache {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = &CACHE_TEST_STATE.cache_name;
         let result = client.create_cache(cache_name).await?;
-        assert_eq!(result, CreateCache::AlreadyExists {});
+        assert_eq!(result, CreateCacheResponse::AlreadyExists {});
         Ok(())
     }
 }
@@ -69,7 +69,7 @@ mod flush_cache {
 
         // Create isolated cache for this test
         let create_result = client.create_cache(cache_name).await?;
-        assert_eq!(create_result, CreateCache::Created {});
+        assert_eq!(create_result, CreateCacheResponse::Created {});
 
         // Insert some elements
         let item1 = TestScalar::new();


### PR DESCRIPTION
Adds the suffix Response to cache control types in code and docstrings.

Work towards https://github.com/momentohq/client-sdk-rust/issues/285