### PR TITLE
refactor: rename various response value types to `Value` and update traits

### DIFF
--- a/src/cache/messages/control/list_caches.rs
+++ b/src/cache/messages/control/list_caches.rs
@@ -46,25 +46,38 @@ impl MomentoRequest for ListCachesRequest {
     }
 }
 
+/// Limits for a cache.
 #[derive(Debug, PartialEq, Eq)]
 pub struct CacheLimits {
+    /// The maximum traffic rate in requests per second.
     pub max_traffic_rate: u32,
+    /// The maximum throughput in kilobytes per second.
     pub max_throughput_kbps: u32,
+    /// The maximum item size in kilobytes.
     pub max_item_size_kb: u32,
+    /// The maximum time-to-live in seconds.
     pub max_ttl_seconds: u64,
 }
 
+/// Limits for topics in a cache.
 #[derive(Debug, PartialEq, Eq)]
 pub struct TopicLimits {
+    /// The maximum publish rate in requests per second.
     pub max_publish_rate: u32,
+    /// The maximum number of subscriptions.
     pub max_subscription_count: u32,
+    /// The maximum publish message size in kilobytes.
     pub max_publish_message_size_kb: u32,
 }
 
+/// Information about a cache.
 #[derive(Debug, PartialEq, Eq)]
 pub struct CacheInfo {
+    /// The name of the cache.
     pub name: String,
+    /// The limits for the cache.
     pub cache_limits: CacheLimits,
+    /// The limits for topics in the cache.
     pub topic_limits: TopicLimits,
 }
 

--- a/src/cache/messages/data/dictionary/dictionary_fetch.rs
+++ b/src/cache/messages/data/dictionary/dictionary_fetch.rs
@@ -104,9 +104,9 @@ impl<D: IntoBytes> MomentoRequest for DictionaryFetchRequest<D> {
 /// ```
 /// fn main() -> anyhow::Result<()> {
 /// # use std::collections::HashMap;
-/// # use momento::cache::DictionaryFetchResponse;
+/// # use momento::cache::{DictionaryFetchResponse, messages::data::dictionary::dictionary_fetch::Value};
 /// # use momento::MomentoResult;
-/// # let fetch_response = DictionaryFetchResponse::default();
+/// # let fetch_response = DictionaryFetchResponse::Hit { value: Value::default() };
 /// use std::convert::TryInto;
 /// let item: HashMap<String, String> = match fetch_response {
 ///    DictionaryFetchResponse::Hit { value } => value.try_into().expect("I stored strings!"),
@@ -119,9 +119,9 @@ impl<D: IntoBytes> MomentoRequest for DictionaryFetchRequest<D> {
 /// Or, if you're storing raw bytes you can get at them simply:
 /// ```
 /// # use std::collections::HashMap;
-/// # use momento::cache::DictionaryFetchResponse;
+/// # use momento::cache::{DictionaryFetchResponse, messages::data::dictionary::dictionary_fetch::Value};
 /// # use momento::MomentoResult;
-/// # let fetch_response = DictionaryFetchResponse::default();
+/// # let fetch_response = DictionaryFetchResponse::Hit { value: Value::default() };
 /// use std::convert::TryInto;
 /// let item: HashMap<Vec<u8>, Vec<u8>> = match fetch_response {
 ///   DictionaryFetchResponse::Hit { value } => value.into(),
@@ -136,9 +136,9 @@ impl<D: IntoBytes> MomentoRequest for DictionaryFetchRequest<D> {
 /// this is what you're after:
 /// ```
 /// # use std::collections::HashMap;
-/// # use momento::cache::DictionaryFetchResponse;
+/// # use momento::cache::{DictionaryFetchResponse, messages::data::dictionary::dictionary_fetch::Value};
 /// # use momento::MomentoResult;
-/// # let fetch_response = DictionaryFetchResponse::default();
+/// # let fetch_response = DictionaryFetchResponse::Hit { value: Value::default() };
 /// use std::convert::TryInto;
 /// let item: MomentoResult<HashMap<String, String>> = fetch_response.try_into();
 /// ```
@@ -146,9 +146,9 @@ impl<D: IntoBytes> MomentoRequest for DictionaryFetchRequest<D> {
 /// You can also go straight into a `HashMap<Vec<u8>, Vec<u8>>` if you prefer:
 /// ```
 /// # use std::collections::HashMap;
-/// # use momento::cache::DictionaryFetchResponse;
+/// # use momento::cache::{DictionaryFetchResponse, messages::data::dictionary::dictionary_fetch::Value};
 /// # use momento::MomentoResult;
-/// # let fetch_response = DictionaryFetchResponse::default();
+/// # let fetch_response = DictionaryFetchResponse::Hit { value: Value::default() };
 /// use std::convert::TryInto;
 /// let item: MomentoResult<HashMap<Vec<u8>, Vec<u8>>> = fetch_response.try_into();
 /// ```
@@ -156,14 +156,6 @@ impl<D: IntoBytes> MomentoRequest for DictionaryFetchRequest<D> {
 pub enum DictionaryFetchResponse {
     Hit { value: Value },
     Miss,
-}
-
-impl Default for DictionaryFetchResponse {
-    fn default() -> Self {
-        DictionaryFetchResponse::Hit {
-            value: Value::default(),
-        }
-    }
 }
 
 /// A dictionary fetched from a cache.

--- a/src/cache/messages/data/dictionary/dictionary_get_field.rs
+++ b/src/cache/messages/data/dictionary/dictionary_get_field.rs
@@ -96,7 +96,7 @@ impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryGetFieldRequest<D,
                 match responses.pop() {
                     Some(value) => match value.result() {
                         ECacheResult::Hit => Ok(DictionaryGetFieldResponse::Hit {
-                            value: DictionaryGetFieldValue::new(value.cache_body),
+                            value: Value::new(value.cache_body),
                         }),
                         ECacheResult::Miss => Ok(DictionaryGetFieldResponse::Miss),
                         _ => Err(MomentoError::unknown_error(
@@ -167,14 +167,14 @@ impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryGetFieldRequest<D,
 /// ```
 #[derive(Debug, PartialEq, Eq)]
 pub enum DictionaryGetFieldResponse {
-    Hit { value: DictionaryGetFieldValue },
+    Hit { value: Value },
     Miss,
 }
 
 impl Default for DictionaryGetFieldResponse {
     fn default() -> Self {
         DictionaryGetFieldResponse::Hit {
-            value: DictionaryGetFieldValue::new(Vec::new()),
+            value: Value::new(Vec::new()),
         }
     }
 }
@@ -202,26 +202,26 @@ impl TryFrom<DictionaryGetFieldResponse> for Vec<u8> {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct DictionaryGetFieldValue {
+pub struct Value {
     pub(crate) raw_item: Vec<u8>,
 }
 
-impl DictionaryGetFieldValue {
+impl Value {
     pub fn new(raw_item: Vec<u8>) -> Self {
         Self { raw_item }
     }
 }
 
-impl TryFrom<DictionaryGetFieldValue> for String {
+impl TryFrom<Value> for String {
     type Error = MomentoError;
 
-    fn try_from(value: DictionaryGetFieldValue) -> Result<Self, Self::Error> {
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
         parse_string(value.raw_item)
     }
 }
 
-impl From<DictionaryGetFieldValue> for Vec<u8> {
-    fn from(value: DictionaryGetFieldValue) -> Self {
+impl From<Value> for Vec<u8> {
+    fn from(value: Value) -> Self {
         value.raw_item
     }
 }

--- a/src/cache/messages/data/dictionary/dictionary_get_field.rs
+++ b/src/cache/messages/data/dictionary/dictionary_get_field.rs
@@ -123,9 +123,9 @@ impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryGetFieldRequest<D,
 /// If you'd like to handle misses you can simply match and handle your response:
 /// ```
 /// fn main() -> anyhow::Result<()> {
-/// # use momento::cache::DictionaryGetFieldResponse;
+/// # use momento::cache::{DictionaryGetFieldResponse, messages::data::dictionary::dictionary_get_field::Value};
 /// # use momento::MomentoResult;
-/// # let fetch_response: DictionaryGetFieldResponse = DictionaryGetFieldResponse::default();
+/// # let fetch_response: DictionaryGetFieldResponse = DictionaryGetFieldResponse::Hit { value: Value::default() };
 /// use std::convert::TryInto;
 /// let item: String = match fetch_response {
 ///    DictionaryGetFieldResponse::Hit { value } => value.try_into().expect("I stored a string!"),
@@ -137,9 +137,9 @@ impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryGetFieldRequest<D,
 ///
 /// Or if you're storing raw bytes you can get at them simply:
 /// ```
-/// # use momento::cache::DictionaryGetFieldResponse;
+/// # use momento::cache::{DictionaryGetFieldResponse, messages::data::dictionary::dictionary_get_field::Value};
 /// # use momento::MomentoResult;
-/// # let fetch_response: DictionaryGetFieldResponse = DictionaryGetFieldResponse::default();
+/// # let fetch_response: DictionaryGetFieldResponse = DictionaryGetFieldResponse::Hit { value: Value::default() };
 /// use std::convert::TryInto;
 /// let item: Vec<u8> = match fetch_response {
 ///   DictionaryGetFieldResponse::Hit { value } => value.into(),
@@ -153,18 +153,18 @@ impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryGetFieldRequest<D,
 /// Of course, a Miss in this case will be turned into an Error. If that's what you want, then
 /// this is what you're after:
 /// ```
-/// # use momento::cache::DictionaryGetFieldResponse;
+/// # use momento::cache::{DictionaryGetFieldResponse, messages::data::dictionary::dictionary_get_field::Value};
 /// # use momento::MomentoResult;
-/// # let fetch_response = DictionaryGetFieldResponse::default();
+/// # let fetch_response: DictionaryGetFieldResponse = DictionaryGetFieldResponse::Hit { value: Value::default() };
 /// use std::convert::TryInto;
 /// let item: MomentoResult<String> = fetch_response.try_into();
 /// ```
 ///
 /// You can also go straight into a `Vec<u8>` if you prefer:
 /// ```
-/// # use momento::cache::DictionaryGetFieldResponse;
+/// # use momento::cache::{DictionaryGetFieldResponse, messages::data::dictionary::dictionary_get_field::Value};
 /// # use momento::MomentoResult;
-/// # let fetch_response: DictionaryGetFieldResponse = DictionaryGetFieldResponse::default();
+/// # let fetch_response: DictionaryGetFieldResponse = DictionaryGetFieldResponse::Hit { value: Value::default() };
 /// use std::convert::TryInto;
 /// let item: MomentoResult<Vec<u8>> = fetch_response.try_into();
 /// ```
@@ -172,14 +172,6 @@ impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryGetFieldRequest<D,
 pub enum DictionaryGetFieldResponse {
     Hit { value: Value },
     Miss,
-}
-
-impl Default for DictionaryGetFieldResponse {
-    fn default() -> Self {
-        DictionaryGetFieldResponse::Hit {
-            value: Value::new(Vec::new()),
-        }
-    }
 }
 
 impl TryFrom<DictionaryGetFieldResponse> for String {
@@ -204,7 +196,7 @@ impl TryFrom<DictionaryGetFieldResponse> for Vec<u8> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Default)]
 pub struct Value {
     pub(crate) raw_item: Vec<u8>,
 }

--- a/src/cache/messages/data/dictionary/dictionary_get_field.rs
+++ b/src/cache/messages/data/dictionary/dictionary_get_field.rs
@@ -115,7 +115,7 @@ impl<D: IntoBytes, F: IntoBytes> MomentoRequest for DictionaryGetFieldRequest<D,
     }
 }
 
-/// Response object for a [DictionaryGetFieldRequest](crate::cache::DictionaryGetFieldRequest).
+/// Response object for a [DictionaryGetFieldRequest].
 ///
 /// If you'd like to handle misses you can simply match and handle your response:
 /// ```

--- a/src/cache/messages/data/dictionary/dictionary_get_fields.rs
+++ b/src/cache/messages/data/dictionary/dictionary_get_fields.rs
@@ -126,7 +126,7 @@ impl<D: IntoBytes, F: IntoBytesIterable + Clone> MomentoRequest
     }
 }
 
-/// Response object for a [DictionaryGetFieldsRequest](crate::cache::DictionaryGetFieldsRequest).
+/// Response object for a [DictionaryGetFieldsRequest].
 ///
 /// If you'd like to handle misses you can simply match and handle your response:
 /// ```

--- a/src/cache/messages/data/dictionary/dictionary_get_fields.rs
+++ b/src/cache/messages/data/dictionary/dictionary_get_fields.rs
@@ -1,4 +1,4 @@
-use super::dictionary_get_field::{DictionaryGetFieldResponse, DictionaryGetFieldValue};
+use super::dictionary_get_field::{DictionaryGetFieldResponse, Value};
 use crate::cache::messages::MomentoRequest;
 use crate::utils::{parse_string, prep_request_with_timeout};
 use crate::{
@@ -100,7 +100,7 @@ impl<D: IntoBytes, F: IntoBytesIterable + Clone> MomentoRequest
                     .into_iter()
                     .map(|value| match value.result() {
                         ECacheResult::Hit => Ok(DictionaryGetFieldResponse::Hit {
-                            value: DictionaryGetFieldValue::new(value.cache_body),
+                            value: Value::new(value.cache_body),
                         }),
                         ECacheResult::Miss => Ok(DictionaryGetFieldResponse::Miss),
                         _ => Err(MomentoError::unknown_error(

--- a/src/cache/messages/data/list/list_fetch.rs
+++ b/src/cache/messages/data/list/list_fetch.rs
@@ -181,11 +181,7 @@ impl TryFrom<Value> for Vec<String> {
     type Error = MomentoError;
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
-        Ok(value
-            .raw_item
-            .into_iter()
-            .map(parse_string)
-            .collect())
+        Ok(value.raw_item.into_iter().map(parse_string).collect())
     }
 }
 

--- a/src/cache/messages/data/list/list_fetch.rs
+++ b/src/cache/messages/data/list/list_fetch.rs
@@ -181,7 +181,7 @@ impl TryFrom<Value> for Vec<String> {
     type Error = MomentoError;
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
-        Ok(value.raw_item.into_iter().map(parse_string).collect())
+        value.raw_item.into_iter().map(parse_string).collect()
     }
 }
 

--- a/src/cache/messages/data/list/list_fetch.rs
+++ b/src/cache/messages/data/list/list_fetch.rs
@@ -11,7 +11,7 @@ use momento_protos::{
 use crate::{
     cache::MomentoRequest,
     utils::{parse_string, prep_request_with_timeout},
-    CacheClient, IntoBytes, MomentoError, MomentoResult,
+    CacheClient, IntoBytes, IntoBytesIterable, MomentoError, MomentoResult,
 };
 
 /// Gets a list item from a cache with optional slices.
@@ -106,7 +106,7 @@ impl<L: IntoBytes> MomentoRequest for ListFetchRequest<L> {
         match response.list {
             Some(list_fetch_response::List::Missing(_)) => Ok(ListFetchResponse::Miss),
             Some(list_fetch_response::List::Found(found)) => Ok(ListFetchResponse::Hit {
-                values: ListFetchValue {
+                values: Value {
                     raw_item: found.values,
                 },
             }),
@@ -123,11 +123,9 @@ impl<L: IntoBytes> MomentoRequest for ListFetchRequest<L> {
 /// If you'd like to handle misses you can simply match and handle your response:
 /// ```
 /// # use momento::MomentoResult;
-/// # use momento::cache::ListFetchValue;
 /// use momento::cache::ListFetchResponse;
 /// use std::convert::TryInto;
-/// # let values = vec!["abc", "123"].iter().map(|s| s.as_bytes().to_vec()).collect();
-/// # let response = ListFetchResponse::Hit { values: ListFetchValue::new(values) };
+/// # let response: ListFetchResponse = vec!["abc", "123"].into();
 /// let fetched_values: Vec<String> = match response {
 ///     ListFetchResponse::Hit { values } => values.try_into().expect("Expected to fetch a list of strings!"),
 ///     ListFetchResponse::Miss => return // probably you'll do something else here
@@ -141,42 +139,48 @@ impl<L: IntoBytes> MomentoRequest for ListFetchRequest<L> {
 /// this is what you're after:
 /// ```
 /// # use momento::MomentoResult;
-/// # use momento::cache::ListFetchValue;
 /// use momento::cache::ListFetchResponse;
 /// use std::convert::TryInto;
-/// # let values = vec!["abc", "123"].iter().map(|s| s.as_bytes().to_vec()).collect();
-/// # let response = ListFetchResponse::Hit { values: ListFetchValue::new(values) };
+/// # let response: ListFetchResponse = vec!["abc", "123"].into();
 /// let fetched_values: Vec<String> = response.try_into().expect("Expected to fetch a list of strings!");
 /// ```
 #[derive(Debug, PartialEq, Eq)]
 pub enum ListFetchResponse {
-    Hit { values: ListFetchValue },
+    Hit { values: Value },
     Miss,
 }
 
+impl<I: IntoBytesIterable> From<I> for ListFetchResponse {
+    fn from(values: I) -> Self {
+        ListFetchResponse::Hit {
+            values: Value::new(values.into_bytes()),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
-pub struct ListFetchValue {
+pub struct Value {
     pub(crate) raw_item: Vec<Vec<u8>>,
 }
 
-impl ListFetchValue {
+impl Value {
     pub fn new(raw_item: Vec<Vec<u8>>) -> Self {
         Self { raw_item }
     }
 }
 
-impl TryFrom<ListFetchValue> for Vec<Vec<u8>> {
+impl TryFrom<Value> for Vec<Vec<u8>> {
     type Error = MomentoError;
 
-    fn try_from(value: ListFetchValue) -> Result<Self, Self::Error> {
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
         Ok(value.raw_item)
     }
 }
 
-impl TryFrom<ListFetchValue> for Vec<String> {
+impl TryFrom<Value> for Vec<String> {
     type Error = MomentoError;
 
-    fn try_from(value: ListFetchValue) -> Result<Self, Self::Error> {
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
         Ok(value
             .raw_item
             .into_iter()
@@ -203,16 +207,6 @@ impl TryFrom<ListFetchResponse> for Vec<String> {
         match value {
             ListFetchResponse::Hit { values } => Ok(values.try_into()?),
             ListFetchResponse::Miss => Err(MomentoError::miss("ListFetch")),
-        }
-    }
-}
-
-impl From<Vec<String>> for ListFetchResponse {
-    fn from(values: Vec<String>) -> Self {
-        ListFetchResponse::Hit {
-            values: ListFetchValue::new(
-                values.into_iter().map(|v| v.as_bytes().to_vec()).collect(),
-            ),
         }
     }
 }

--- a/src/cache/messages/data/list/list_pop_back.rs
+++ b/src/cache/messages/data/list/list_pop_back.rs
@@ -142,7 +142,7 @@ impl TryFrom<Value> for String {
     type Error = MomentoError;
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
-        Ok(parse_string(value.raw_item)
+        parse_string(value.raw_item)
     }
 }
 

--- a/src/cache/messages/data/list/list_pop_back.rs
+++ b/src/cache/messages/data/list/list_pop_back.rs
@@ -69,7 +69,7 @@ impl<L: IntoBytes> MomentoRequest for ListPopBackRequest<L> {
         match response.list {
             Some(list_pop_back_response::List::Missing(_)) => Ok(ListPopBackResponse::Miss),
             Some(list_pop_back_response::List::Found(found)) => Ok(ListPopBackResponse::Hit {
-                value: ListPopBackValue::new(found.back),
+                value: Value::new(found.back),
             }),
             _ => Err(MomentoError::unknown_error(
                 "ListPopBack",
@@ -84,10 +84,9 @@ impl<L: IntoBytes> MomentoRequest for ListPopBackRequest<L> {
 /// If you'd like to handle misses you can simply match and handle your response:
 /// ```
 /// # use momento::MomentoResult;
-/// # use momento::cache::ListPopBackValue;
 /// use momento::cache::ListPopBackResponse;
 /// use std::convert::TryInto;
-/// # let response = ListPopBackResponse::Hit { value: ListPopBackValue::new("hi".into()) };
+/// # let response: ListPopBackResponse = "hi".into();
 /// let popped_value: String = match response {
 ///     ListPopBackResponse::Hit { value } => value.try_into().expect("Expected a popped list value!"),
 ///     ListPopBackResponse::Miss => return // probably you'll do something else here
@@ -101,41 +100,48 @@ impl<L: IntoBytes> MomentoRequest for ListPopBackRequest<L> {
 /// this is what you're after:
 /// ```
 /// # use momento::MomentoResult;
-/// # use momento::cache::ListPopBackValue;
 /// use momento::cache::ListPopBackResponse;
 /// use std::convert::TryInto;
-/// # let response = ListPopBackResponse::Hit { value: ListPopBackValue::new("hi".into()) };
+/// # let response: ListPopBackResponse = "hi".into();
 /// let popped_value: MomentoResult<String> = response.try_into();
 /// ```
 #[derive(Debug, PartialEq, Eq)]
 pub enum ListPopBackResponse {
-    Hit { value: ListPopBackValue },
+    Hit { value: Value },
     Miss,
 }
 
+impl<I: IntoBytes> From<I> for ListPopBackResponse {
+    fn from(value: I) -> Self {
+        ListPopBackResponse::Hit {
+            value: Value::new(value.into_bytes()),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
-pub struct ListPopBackValue {
+pub struct Value {
     pub(crate) raw_item: Vec<u8>,
 }
 
-impl ListPopBackValue {
+impl Value {
     pub fn new(raw_item: Vec<u8>) -> Self {
         Self { raw_item }
     }
 }
 
-impl TryFrom<ListPopBackValue> for Vec<u8> {
+impl TryFrom<Value> for Vec<u8> {
     type Error = MomentoError;
 
-    fn try_from(value: ListPopBackValue) -> Result<Self, Self::Error> {
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
         Ok(value.raw_item)
     }
 }
 
-impl TryFrom<ListPopBackValue> for String {
+impl TryFrom<Value> for String {
     type Error = MomentoError;
 
-    fn try_from(value: ListPopBackValue) -> Result<Self, Self::Error> {
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
         Ok(parse_string(value.raw_item).expect("expected a valid UTF-8 string"))
     }
 }

--- a/src/cache/messages/data/list/list_pop_front.rs
+++ b/src/cache/messages/data/list/list_pop_front.rs
@@ -142,7 +142,7 @@ impl TryFrom<Value> for String {
     type Error = MomentoError;
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
-        Ok(parse_string(value.raw_item))
+        parse_string(value.raw_item)
     }
 }
 

--- a/src/cache/messages/data/scalar/get.rs
+++ b/src/cache/messages/data/scalar/get.rs
@@ -89,9 +89,9 @@ impl<K: IntoBytes> MomentoRequest for GetRequest<K> {
 ///
 /// If you'd like to handle misses you can simply match and handle your response:
 /// ```
-/// # use momento::cache::GetResponse;
+/// # use momento::cache::{GetResponse, messages::data::scalar::get::Value};
 /// # use momento::MomentoResult;
-/// # let get_response = GetResponse::default();
+/// # let get_response = GetResponse::Hit { value: Value::default() };
 /// use std::convert::TryInto;
 /// let item: String = match get_response {
 ///     GetResponse::Hit { value } => value.try_into().expect("I stored a string!"),
@@ -101,9 +101,9 @@ impl<K: IntoBytes> MomentoRequest for GetRequest<K> {
 ///
 /// Or, if you're storing raw bytes you can get at them simply:
 /// ```
-/// # use momento::cache::GetResponse;
+/// # use momento::cache::{GetResponse, messages::data::scalar::get::Value};
 /// # use momento::MomentoResult;
-/// # let get_response = GetResponse::default();
+/// # let get_response = GetResponse::Hit { value: Value::default() };
 /// let item: Vec<u8> = match get_response {
 ///     GetResponse::Hit { value } => value.into(),
 ///     GetResponse::Miss => return // probably you'll do something else here
@@ -116,18 +116,18 @@ impl<K: IntoBytes> MomentoRequest for GetRequest<K> {
 /// Of course, a Miss in this case will be turned into an Error. If that's what you want, then
 /// this is what you're after:
 /// ```
-/// # use momento::cache::GetResponse;
+/// # use momento::cache::{GetResponse, messages::data::scalar::get::Value};
 /// # use momento::MomentoResult;
-/// # let get_response = GetResponse::default();
+/// # let get_response = GetResponse::Hit { value: Value::default() };
 /// use std::convert::TryInto;
 /// let item: MomentoResult<String> = get_response.try_into();
 /// ```
 ///
 /// You can also go straight into a `Vec<u8>` if you prefer:
 /// ```
-/// # use momento::cache::GetResponse;
+/// # use momento::cache::{GetResponse, messages::data::scalar::get::Value};
 /// # use momento::MomentoResult;
-/// # let get_response = GetResponse::default();
+/// # let get_response = GetResponse::Hit { value: Value::default() };
 /// use std::convert::TryInto;
 /// let item: MomentoResult<Vec<u8>> = get_response.try_into();
 /// ```
@@ -135,14 +135,6 @@ impl<K: IntoBytes> MomentoRequest for GetRequest<K> {
 pub enum GetResponse {
     Hit { value: Value },
     Miss,
-}
-
-impl Default for GetResponse {
-    fn default() -> Self {
-        GetResponse::Hit {
-            value: Value::default(),
-        }
-    }
 }
 
 impl<I: IntoBytes> From<I> for GetResponse {

--- a/src/cache/messages/data/set/set_fetch.rs
+++ b/src/cache/messages/data/set/set_fetch.rs
@@ -145,11 +145,7 @@ impl TryFrom<Value> for Vec<String> {
     type Error = MomentoError;
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
-        Ok(value
-            .raw_item
-            .into_iter()
-            .map(parse_string)
-            .collect())
+        Ok(value.raw_item.into_iter().map(parse_string).collect())
     }
 }
 

--- a/src/cache/messages/data/set/set_fetch.rs
+++ b/src/cache/messages/data/set/set_fetch.rs
@@ -145,7 +145,7 @@ impl TryFrom<Value> for Vec<String> {
     type Error = MomentoError;
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
-        Ok(value.raw_item.into_iter().map(parse_string).collect())
+        value.raw_item.into_iter().map(parse_string).collect()
     }
 }
 

--- a/src/cache/messages/data/set/set_fetch.rs
+++ b/src/cache/messages/data/set/set_fetch.rs
@@ -5,7 +5,7 @@ use momento_protos::cache_client::set_fetch_response;
 use crate::{
     cache::MomentoRequest,
     utils::{parse_string, prep_request_with_timeout},
-    CacheClient, IntoBytes, MomentoError, MomentoResult,
+    CacheClient, IntoBytes, IntoBytesIterable, MomentoError, MomentoResult,
 };
 
 /// Fetch the elements in the given set.
@@ -72,7 +72,7 @@ impl<S: IntoBytes> MomentoRequest for SetFetchRequest<S> {
         match response.set {
             Some(set_fetch_response::Set::Missing(_)) => Ok(SetFetchResponse::Miss),
             Some(set_fetch_response::Set::Found(found)) => Ok(SetFetchResponse::Hit {
-                values: SetFetchValue {
+                values: Value {
                     raw_item: found.elements,
                 },
             }),
@@ -89,11 +89,9 @@ impl<S: IntoBytes> MomentoRequest for SetFetchRequest<S> {
 /// If you'd like to handle misses you can simply match and handle your response:
 /// ```
 /// # use momento::MomentoResult;
-/// # use momento::cache::SetFetchValue;
 /// use momento::cache::SetFetchResponse;
 /// use std::convert::TryInto;
-/// # let values = vec!["abc", "123"].iter().map(|s| s.as_bytes().to_vec()).collect();
-/// # let response = SetFetchResponse::Hit { values: SetFetchValue::new(values) };
+/// # let response = SetFetchResponse::from(vec!["abc", "123"]);
 /// let fetched_values: Vec<String> = match response {
 ///     SetFetchResponse::Hit { values } => values.try_into().expect("Expected to fetch a set!"),
 ///     SetFetchResponse::Miss => return // probably you'll do something else here
@@ -107,40 +105,46 @@ impl<S: IntoBytes> MomentoRequest for SetFetchRequest<S> {
 /// this is what you're after:
 /// ```
 /// # use momento::MomentoResult;
-/// # use momento::cache::SetFetchValue;
 /// use momento::cache::SetFetchResponse;
 /// use std::convert::TryInto;
-/// # let values = vec!["abc", "123"].iter().map(|s| s.as_bytes().to_vec()).collect();
-/// # let response = SetFetchResponse::Hit { values: SetFetchValue::new(values) };
+/// # let response = SetFetchResponse::from(vec!["abc", "123"]);
 /// let fetched_values: Vec<String> = response.try_into().expect("Expected to fetch a set!");
 /// ```
 #[derive(Debug, PartialEq, Eq)]
 pub enum SetFetchResponse {
-    Hit { values: SetFetchValue },
+    Hit { values: Value },
     Miss,
 }
 
+impl<I: IntoBytesIterable> From<I> for SetFetchResponse {
+    fn from(values: I) -> Self {
+        SetFetchResponse::Hit {
+            values: Value::new(values.into_bytes()),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
-pub struct SetFetchValue {
+pub struct Value {
     pub(crate) raw_item: Vec<Vec<u8>>,
 }
 
-impl SetFetchValue {
+impl Value {
     pub fn new(raw_item: Vec<Vec<u8>>) -> Self {
         Self { raw_item }
     }
 }
 
-impl From<SetFetchValue> for Vec<Vec<u8>> {
-    fn from(value: SetFetchValue) -> Self {
+impl From<Value> for Vec<Vec<u8>> {
+    fn from(value: Value) -> Self {
         value.raw_item
     }
 }
 
-impl TryFrom<SetFetchValue> for Vec<String> {
+impl TryFrom<Value> for Vec<String> {
     type Error = MomentoError;
 
-    fn try_from(value: SetFetchValue) -> Result<Self, Self::Error> {
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
         Ok(value
             .raw_item
             .into_iter()
@@ -167,14 +171,6 @@ impl TryFrom<SetFetchResponse> for Vec<String> {
         match value {
             SetFetchResponse::Hit { values } => Ok(values.try_into()?),
             SetFetchResponse::Miss => Err(MomentoError::miss("SetFetch")),
-        }
-    }
-}
-
-impl From<Vec<String>> for SetFetchResponse {
-    fn from(values: Vec<String>) -> Self {
-        SetFetchResponse::Hit {
-            values: SetFetchValue::new(values.into_iter().map(|v| v.as_bytes().to_vec()).collect()),
         }
     }
 }

--- a/src/cache/messages/data/sorted_set/sorted_set_fetch_response.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_fetch_response.rs
@@ -11,9 +11,9 @@ use crate::{ErrorSource, MomentoError, MomentoErrorCode, MomentoResult};
 /// If you'd like to handle misses you can simply match and handle your response:
 /// ```
 /// fn main() -> anyhow::Result<()> {
-/// # use momento::cache::SortedSetFetchResponse;
+/// # use momento::cache::{SortedSetFetchResponse, SortedSetElements};
 /// # use momento::MomentoResult;
-/// # let fetch_response = SortedSetFetchResponse::default();
+/// # let fetch_response = SortedSetFetchResponse::Hit { value: SortedSetElements::default() };
 /// use std::convert::TryInto;
 /// let item: Vec<(String, f64)> = match fetch_response {
 ///   SortedSetFetchResponse::Hit { value } => value.try_into().expect("I stored strings!"),
@@ -25,9 +25,9 @@ use crate::{ErrorSource, MomentoError, MomentoErrorCode, MomentoResult};
 ///
 /// Or, if you're storing raw bytes you can get at them simply:
 /// ```
-/// # use momento::cache::SortedSetFetchResponse;
+/// # use momento::cache::{SortedSetFetchResponse, SortedSetElements};
 /// # use momento::MomentoResult;
-/// # let fetch_response = SortedSetFetchResponse::default();
+/// # let fetch_response = SortedSetFetchResponse::Hit { value: SortedSetElements::default() };
 /// use std::convert::TryInto;
 /// let item: Vec<(Vec<u8>, f64)> = match fetch_response {
 ///  SortedSetFetchResponse::Hit { value } => value.into(),
@@ -41,18 +41,18 @@ use crate::{ErrorSource, MomentoError, MomentoErrorCode, MomentoResult};
 /// Of course, a Miss in this case will be turned into an Error. If that's what you want, then
 /// this is what you're after:
 /// ```
-/// # use momento::cache::SortedSetFetchResponse;
+/// # use momento::cache::{SortedSetFetchResponse, SortedSetElements};
 /// # use momento::MomentoResult;
-/// # let fetch_response = SortedSetFetchResponse::default();
+/// # let fetch_response = SortedSetFetchResponse::Hit { value: SortedSetElements::default() };
 /// use std::convert::TryInto;
 /// let item: MomentoResult<Vec<(String, f64)>> = fetch_response.try_into();
 /// ```
 ///
 /// You can also go straight into a `Vec<(Vec<u8>, f64)>` if you prefer:
 /// ```
-/// # use momento::cache::SortedSetFetchResponse;
+/// # use momento::cache::{SortedSetFetchResponse, SortedSetElements};
 /// # use momento::MomentoResult;
-/// # let fetch_response = SortedSetFetchResponse::default();
+/// # let fetch_response = SortedSetFetchResponse::Hit { value: SortedSetElements::default() };
 /// use std::convert::TryInto;
 /// let item: MomentoResult<Vec<(Vec<u8>, f64)>> = fetch_response.try_into();
 /// ```
@@ -103,14 +103,6 @@ impl SortedSetFetchResponse {
                 "SortedSetFetch",
                 Some(format!("{:#?}", response)),
             )),
-        }
-    }
-}
-
-impl Default for SortedSetFetchResponse {
-    fn default() -> Self {
-        SortedSetFetchResponse::Hit {
-            value: SortedSetElements::new(Vec::new()),
         }
     }
 }

--- a/src/cache/messages/data/sorted_set/sorted_set_fetch_response.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_fetch_response.rs
@@ -11,9 +11,9 @@ use crate::{ErrorSource, MomentoError, MomentoErrorCode, MomentoResult};
 /// If you'd like to handle misses you can simply match and handle your response:
 /// ```
 /// fn main() -> anyhow::Result<()> {
-/// # use momento::cache::{SortedSetFetchResponse, SortedSetElements};
+/// # use momento::cache::SortedSetFetchResponse;
 /// # use momento::MomentoResult;
-/// # let fetch_response = SortedSetFetchResponse::Hit { value: SortedSetElements::default() };
+/// # let fetch_response = SortedSetFetchResponse::default();
 /// use std::convert::TryInto;
 /// let item: Vec<(String, f64)> = match fetch_response {
 ///   SortedSetFetchResponse::Hit { value } => value.try_into().expect("I stored strings!"),
@@ -25,9 +25,9 @@ use crate::{ErrorSource, MomentoError, MomentoErrorCode, MomentoResult};
 ///
 /// Or, if you're storing raw bytes you can get at them simply:
 /// ```
-/// # use momento::cache::{SortedSetFetchResponse, SortedSetElements};
+/// # use momento::cache::SortedSetFetchResponse;
 /// # use momento::MomentoResult;
-/// # let fetch_response = SortedSetFetchResponse::Hit { value: SortedSetElements::default() };
+/// # let fetch_response = SortedSetFetchResponse::default();
 /// use std::convert::TryInto;
 /// let item: Vec<(Vec<u8>, f64)> = match fetch_response {
 ///  SortedSetFetchResponse::Hit { value } => value.into(),
@@ -41,18 +41,18 @@ use crate::{ErrorSource, MomentoError, MomentoErrorCode, MomentoResult};
 /// Of course, a Miss in this case will be turned into an Error. If that's what you want, then
 /// this is what you're after:
 /// ```
-/// # use momento::cache::{SortedSetFetchResponse, SortedSetElements};
+/// # use momento::cache::SortedSetFetchResponse;
 /// # use momento::MomentoResult;
-/// # let fetch_response = SortedSetFetchResponse::Hit { value: SortedSetElements::default() };
+/// # let fetch_response = SortedSetFetchResponse::default();
 /// use std::convert::TryInto;
 /// let item: MomentoResult<Vec<(String, f64)>> = fetch_response.try_into();
 /// ```
 ///
 /// You can also go straight into a `Vec<(Vec<u8>, f64)>` if you prefer:
 /// ```
-/// # use momento::cache::{SortedSetFetchResponse, SortedSetElements};
+/// # use momento::cache::SortedSetFetchResponse;
 /// # use momento::MomentoResult;
-/// # let fetch_response = SortedSetFetchResponse::Hit { value: SortedSetElements::default() };
+/// # let fetch_response = SortedSetFetchResponse::default();
 /// use std::convert::TryInto;
 /// let item: MomentoResult<Vec<(Vec<u8>, f64)>> = fetch_response.try_into();
 /// ```
@@ -103,6 +103,14 @@ impl SortedSetFetchResponse {
                 "SortedSetFetch",
                 Some(format!("{:#?}", response)),
             )),
+        }
+    }
+}
+
+impl Default for SortedSetFetchResponse {
+    fn default() -> Self {
+        SortedSetFetchResponse::Hit {
+            value: SortedSetElements::new(Vec::new()),
         }
     }
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -40,7 +40,7 @@ pub use messages::data::dictionary::dictionary_set_fields::{
 
 pub use messages::data::scalar::decrease_ttl::{DecreaseTtlRequest, DecreaseTtlResponse};
 pub use messages::data::scalar::delete::{DeleteRequest, DeleteResponse};
-pub use messages::data::scalar::get::{GetRequest, GetResponse, GetValue};
+pub use messages::data::scalar::get::{GetRequest, GetResponse};
 pub use messages::data::scalar::increase_ttl::{IncreaseTtlRequest, IncreaseTtlResponse};
 pub use messages::data::scalar::increment::{IncrementRequest, IncrementResponse};
 pub use messages::data::scalar::item_get_ttl::{ItemGetTtlRequest, ItemGetTtlResponse};

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -10,7 +10,7 @@ pub use messages::control::list_caches::{
 };
 
 pub use messages::data::dictionary::dictionary_fetch::{
-    DictionaryFetchRequest, DictionaryFetchResponse, DictionaryFetchValue,
+    DictionaryFetchRequest, DictionaryFetchResponse,
 };
 pub use messages::data::dictionary::dictionary_get_field::{
     DictionaryGetFieldRequest, DictionaryGetFieldResponse,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -63,7 +63,7 @@ pub use messages::data::scalar::set_if_present_and_not_equal::{
 pub use messages::data::scalar::update_ttl::{UpdateTtlRequest, UpdateTtlResponse};
 
 pub use messages::data::set::set_add_elements::{SetAddElementsRequest, SetAddElementsResponse};
-pub use messages::data::set::set_fetch::{SetFetchRequest, SetFetchResponse, SetFetchValue};
+pub use messages::data::set::set_fetch::{SetFetchRequest, SetFetchResponse};
 pub use messages::data::set::set_remove_elements::{
     SetRemoveElementsRequest, SetRemoveElementsResponse,
 };

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,4 +1,4 @@
-mod messages;
+pub mod messages;
 
 pub use messages::MomentoRequest;
 
@@ -101,7 +101,7 @@ pub use messages::data::list::list_concatenate_back::{
 pub use messages::data::list::list_concatenate_front::{
     ListConcatenateFrontRequest, ListConcatenateFrontResponse,
 };
-pub use messages::data::list::list_fetch::{ListFetchRequest, ListFetchResponse, ListFetchValue};
+pub use messages::data::list::list_fetch::{ListFetchRequest, ListFetchResponse};
 pub use messages::data::list::list_length::{ListLengthRequest, ListLengthResponse};
 pub use messages::data::list::list_pop_back::{
     ListPopBackRequest, ListPopBackResponse, ListPopBackValue,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -104,9 +104,7 @@ pub use messages::data::list::list_concatenate_front::{
 pub use messages::data::list::list_fetch::{ListFetchRequest, ListFetchResponse};
 pub use messages::data::list::list_length::{ListLengthRequest, ListLengthResponse};
 pub use messages::data::list::list_pop_back::{ListPopBackRequest, ListPopBackResponse};
-pub use messages::data::list::list_pop_front::{
-    ListPopFrontRequest, ListPopFrontResponse, ListPopFrontValue,
-};
+pub use messages::data::list::list_pop_front::{ListPopFrontRequest, ListPopFrontResponse};
 pub use messages::data::list::list_push_back::{ListPushBackRequest, ListPushBackResponse};
 pub use messages::data::list::list_push_front::{ListPushFrontRequest, ListPushFrontResponse};
 pub use messages::data::list::list_remove_value::{

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -103,9 +103,7 @@ pub use messages::data::list::list_concatenate_front::{
 };
 pub use messages::data::list::list_fetch::{ListFetchRequest, ListFetchResponse};
 pub use messages::data::list::list_length::{ListLengthRequest, ListLengthResponse};
-pub use messages::data::list::list_pop_back::{
-    ListPopBackRequest, ListPopBackResponse, ListPopBackValue,
-};
+pub use messages::data::list::list_pop_back::{ListPopBackRequest, ListPopBackResponse};
 pub use messages::data::list::list_pop_front::{
     ListPopFrontRequest, ListPopFrontResponse, ListPopFrontValue,
 };

--- a/test-util/src/test_data.rs
+++ b/test-util/src/test_data.rs
@@ -200,14 +200,6 @@ impl From<&TestList> for ListFetchResponse {
 
 impl From<TestList> for ListFetchResponse {
     fn from(test_list: TestList) -> Self {
-        ListFetchResponse::Hit {
-            values: momento::cache::messages::data::list::list_fetch::Value::new(
-                test_list
-                    .values()
-                    .iter()
-                    .map(|element| element.as_bytes().to_vec())
-                    .collect(),
-            ),
-        }
+        test_list.values().clone().into()
     }
 }

--- a/test-util/src/test_data.rs
+++ b/test-util/src/test_data.rs
@@ -1,8 +1,5 @@
 use momento::{
-    cache::{
-        GetResponse, GetValue, ListFetchResponse, ListFetchValue, SortedSetElements,
-        SortedSetFetchResponse,
-    },
+    cache::{GetResponse, GetValue, ListFetchResponse, SortedSetElements, SortedSetFetchResponse},
     IntoBytes,
 };
 use std::collections::HashMap;
@@ -202,12 +199,18 @@ impl Default for TestList {
 
 impl From<&TestList> for ListFetchResponse {
     fn from(test_list: &TestList) -> Self {
+        test_list.into()
+    }
+}
+
+impl From<TestList> for ListFetchResponse {
+    fn from(test_list: TestList) -> Self {
         ListFetchResponse::Hit {
-            values: ListFetchValue::new(
+            values: momento::cache::messages::data::list::list_fetch::Value::new(
                 test_list
                     .values()
                     .iter()
-                    .map(|v| v.as_bytes().to_vec())
+                    .map(|element| element.as_bytes().to_vec())
                     .collect(),
             ),
         }

--- a/test-util/src/test_data.rs
+++ b/test-util/src/test_data.rs
@@ -1,7 +1,4 @@
-use momento::{
-    cache::{GetResponse, GetValue, ListFetchResponse, SortedSetElements, SortedSetFetchResponse},
-    IntoBytes,
-};
+use momento::cache::{GetResponse, ListFetchResponse, SortedSetElements, SortedSetFetchResponse};
 use std::collections::HashMap;
 use uuid::Uuid;
 
@@ -56,9 +53,7 @@ impl Default for TestScalar {
 
 impl From<&TestScalar> for GetResponse {
     fn from(test_scalar: &TestScalar) -> Self {
-        GetResponse::Hit {
-            value: GetValue::new(test_scalar.value().into_bytes()),
-        }
+        test_scalar.value().into()
     }
 }
 

--- a/tests/cache/control.rs
+++ b/tests/cache/control.rs
@@ -1,4 +1,4 @@
-use momento::cache::{CreateCacheResponse, FlushCacheResponse, GetResponse, GetValue, SetResponse};
+use momento::cache::{CreateCacheResponse, FlushCacheResponse, GetResponse, SetResponse};
 use momento::MomentoErrorCode;
 use momento::MomentoResult;
 use momento_test_util::CACHE_TEST_STATE;
@@ -82,19 +82,9 @@ mod flush_cache {
 
         // Verify that the elements are in the cache
         let get_result1 = client.get(cache_name, item1.key()).await?;
-        assert_eq!(
-            get_result1,
-            GetResponse::Hit {
-                value: GetValue::new(item1.value().into())
-            }
-        );
+        assert_eq!(get_result1, GetResponse::from(&item1));
         let get_result2 = client.get(cache_name, item2.key()).await?;
-        assert_eq!(
-            get_result2,
-            GetResponse::Hit {
-                value: GetValue::new(item2.value().into())
-            }
-        );
+        assert_eq!(get_result2, GetResponse::from(&item2));
 
         // Flush the cache
         let result = client.flush_cache(cache_name).await?;


### PR DESCRIPTION
Renames various collection inner value types to `Value` and updates conversion traits.

None of these types (except one) need to be rolled up to `momento::cache`. They are either only used in:
- doctests, or
- integration tests

In both of those cases we can avoid using them by using various `From` and `Default` traits. We keep the types publicly visible so a user can still `use` them, albeit with a longer fully qualified name.

The only inner value type we roll up to `momento::cache` is `SortedSetElements`. We still roll this one up since as user may want to pass a `Vec` of these to a `SortedSetPutElementsRequest`.

Closes #285 