### PR TITLE
feat: basic subscriptions should return only SubscriptionValues

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -108,15 +108,6 @@ impl MomentoError {
             details: None,
         }
     }
-
-    pub(crate) fn discontinuity() -> Self {
-        Self {
-            message: "Received a Discontinuity in a Topics subscription".to_string(),
-            error_code: MomentoErrorCode::UnknownError,
-            inner_error: None,
-            details: None,
-        }
-    }
 }
 
 /// Indicates an error source

--- a/src/topics/config/configuration.rs
+++ b/src/topics/config/configuration.rs
@@ -37,6 +37,7 @@ pub struct Configuration {
 }
 
 impl Configuration {
+    /// First level of constructing a TopicClient. Must provide a [TransportStrategy] to continue.
     pub fn builder() -> ConfigurationBuilder<NeedsTransportStrategy> {
         ConfigurationBuilder(NeedsTransportStrategy(()))
     }

--- a/src/topics/messages/momento_request.rs
+++ b/src/topics/messages/momento_request.rs
@@ -1,7 +1,9 @@
 use crate::MomentoResult;
 use crate::TopicClient;
 
+/// A trait that allows Momento request types to define their interaction with the gRPC client.
 pub trait MomentoRequest {
+    /// The response type expected from the TopicClient
     type Response;
 
     /// An internal fn that allows Momento request types to define their interaction with

--- a/src/topics/messages/publish.rs
+++ b/src/topics/messages/publish.rs
@@ -21,13 +21,13 @@ use crate::{
 /// # fn main() -> anyhow::Result<()> {
 /// # tokio_test::block_on(async {
 /// use momento::{CredentialProvider, TopicClient};
-/// use momento::topics::{TopicPublish, PublishRequest};
+/// use momento::topics::{TopicPublishResponse, PublishRequest};
 /// # let (topic_client, cache_name) = momento_test_util::create_doctest_topic_client();
 ///
 /// // Publish to a topic
 /// let request = PublishRequest::new(cache_name, "topic", "value");
 /// match topic_client.send_request(request).await? {
-///     TopicPublish {} => println!("Published message!"),
+///     TopicPublishResponse {} => println!("Published message!"),
 /// }
 /// # Ok(())
 /// # })
@@ -40,6 +40,7 @@ pub struct PublishRequest<V: IntoTopicValue> {
 }
 
 impl<V: IntoTopicValue> PublishRequest<V> {
+    /// Create a new PublishRequest.
     pub fn new(cache_name: impl Into<String>, topic: impl Into<String>, value: V) -> Self {
         Self {
             cache_name: cache_name.into(),
@@ -50,9 +51,9 @@ impl<V: IntoTopicValue> PublishRequest<V> {
 }
 
 impl<V: IntoTopicValue + std::marker::Send> MomentoRequest for PublishRequest<V> {
-    type Response = TopicPublish;
+    type Response = TopicPublishResponse;
 
-    async fn send(self, topic_client: &TopicClient) -> MomentoResult<TopicPublish> {
+    async fn send(self, topic_client: &TopicClient) -> MomentoResult<TopicPublishResponse> {
         let request = prep_request_with_timeout(
             &self.cache_name.to_string(),
             topic_client.configuration.deadline_millis(),
@@ -66,9 +67,10 @@ impl<V: IntoTopicValue + std::marker::Send> MomentoRequest for PublishRequest<V>
         )?;
 
         let _ = topic_client.client.clone().publish(request).await?;
-        Ok(TopicPublish {})
+        Ok(TopicPublishResponse {})
     }
 }
 
+/// The response type for a successful publish request.
 #[derive(Debug, PartialEq, Eq)]
-pub struct TopicPublish {}
+pub struct TopicPublishResponse {}

--- a/src/topics/messages/subscribe.rs
+++ b/src/topics/messages/subscribe.rs
@@ -35,7 +35,10 @@ use crate::{
 ///
 /// // Consume messages from the subscription using `next()`
 /// while let Some(message) = subscription.next().await {
-///    println!("Received message: {:?}", message);
+///    match message.kind {
+///             momento::topics::ValueKind::Text(t) => println!("Received message as string: {:?}", t),
+///             momento::topics::ValueKind::Binary(b) => println!("Received message as bytes: {:?}", b),
+///         }
 /// }
 /// # Ok(())
 /// # })
@@ -50,6 +53,7 @@ pub struct SubscribeRequest {
 }
 
 impl SubscribeRequest {
+    /// Create a new SubscribeRequest.
     pub fn new(
         cache_name: impl Into<String>,
         topic: impl Into<String>,

--- a/src/topics/mod.rs
+++ b/src/topics/mod.rs
@@ -1,5 +1,5 @@
 mod messages;
-pub use messages::publish::{PublishRequest, TopicPublish};
+pub use messages::publish::{PublishRequest, TopicPublishResponse};
 pub use messages::subscribe::SubscribeRequest;
 pub use messages::subscription::*;
 pub use messages::MomentoRequest;

--- a/src/topics/topic_client.rs
+++ b/src/topics/topic_client.rs
@@ -64,12 +64,12 @@ impl TopicClient {
     /// # fn main() -> anyhow::Result<()> {
     /// # tokio_test::block_on(async {
     /// use momento::{CredentialProvider, TopicClient};
-    /// use momento::topics::TopicPublish;
+    /// use momento::topics::TopicPublishResponse;
     /// # let (topic_client, cache_name) = momento_test_util::create_doctest_topic_client();
     ///
     /// // Publish to a topic
     /// match topic_client.publish(cache_name, "topic", "value").await? {
-    ///     TopicPublish {} => println!("Published message!"),
+    ///     TopicPublishResponse {} => println!("Published message!"),
     /// }
     /// # Ok(())
     /// # })

--- a/src/topics/topic_client.rs
+++ b/src/topics/topic_client.rs
@@ -7,7 +7,7 @@ use crate::topics::topic_client_builder::{NeedsConfiguration, TopicClientBuilder
 use crate::topics::{Configuration, IntoTopicValue, PublishRequest, Subscription};
 use crate::{MomentoError, MomentoResult};
 
-use crate::topics::messages::publish::TopicPublish;
+use crate::topics::messages::publish::TopicPublishResponse;
 use crate::topics::messages::subscribe::SubscribeRequest;
 
 type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
@@ -43,7 +43,7 @@ pub struct TopicClient {
 }
 
 impl TopicClient {
-    /* constructor */
+    /// Constructs a TopicClient to use Momento Topics
     pub fn builder() -> TopicClientBuilder<NeedsConfiguration> {
         TopicClientBuilder(NeedsConfiguration(()))
     }
@@ -80,7 +80,7 @@ impl TopicClient {
         cache_name: impl Into<String>,
         topic: impl Into<String>,
         value: impl IntoTopicValue + std::marker::Send,
-    ) -> MomentoResult<TopicPublish> {
+    ) -> MomentoResult<TopicPublishResponse> {
         let request = PublishRequest::new(cache_name, topic, value);
         request.send(self).await
     }
@@ -108,7 +108,10 @@ impl TopicClient {
     ///
     /// // Consume messages from the subscription using `next()`
     /// while let Some(message) = subscription.next().await {
-    ///    println!("Received message: {:?}", message);
+    ///    match message.kind {
+    ///             momento::topics::ValueKind::Text(t) => println!("Received message as string: {:?}", t),
+    ///             momento::topics::ValueKind::Binary(b) => println!("Received message as bytes: {:?}", b),
+    ///         }
     /// }
     /// # Ok(())
     /// # })

--- a/tests/topics/pubsub.rs
+++ b/tests/topics/pubsub.rs
@@ -1,5 +1,5 @@
 use futures::StreamExt;
-use momento::topics::TopicPublish;
+use momento::topics::TopicPublishResponse;
 use momento::{MomentoErrorCode, MomentoResult};
 use momento_test_util::CACHE_TEST_STATE;
 use momento_test_util::{unique_cache_name, unique_topic_name};
@@ -50,7 +50,7 @@ mod publish_and_subscribe {
         });
 
         let result = client.publish(cache_name, &topic_name, "value").await?;
-        assert_eq!(result, TopicPublish {});
+        assert_eq!(result, TopicPublishResponse {});
 
         subscription_handle.abort();
         Ok(())


### PR DESCRIPTION
Addresses https://github.com/momentohq/client-sdk-rust/issues/299

- The basic `subscribe` method returns only `SubscriptionValue`s now (only binary or string values, not discontinuities)
- Removed the discontinuity error and `TryFrom` that had been used in a test
- Renamed `TopicPublish` to `TopicPublishResponse` for consistency with the rest of the SDK
- Updated doctests and filled in more missing docstrings related to topics