### PR TITLE
chore: improve error messages in tests

### DIFF
--- a/src/cache/messages/data/sorted_set/sorted_set_length.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_length.rs
@@ -28,7 +28,7 @@ use crate::{
 /// # cache_client.sorted_set_put_elements(&cache_name, sorted_set_name.to_string(), vec![("value1", 1.0), ("value2", 2.0)]).await;
 ///
 /// let length_request = SortedSetLengthRequest::new(cache_name, sorted_set_name);
-/// let length: u32 = cache_client.send_request(length_request).await?.try_into().expect("Expected a list length!");
+/// let length: u32 = cache_client.send_request(length_request).await?.try_into().expect("Expected a sorted set length!");
 /// # Ok(())
 /// # })
 /// # }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -185,7 +185,7 @@ mod tests {
         let mut request = tonic::Request::new(());
         let cache_name = "my_cache";
         let result = request_meta_data(&mut request, cache_name);
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "Expected Ok, but got {:?}", result);
         assert_eq!(
             request.metadata().get("cache"),
             Some(&tonic::metadata::AsciiMetadataValue::from_str(cache_name).unwrap())
@@ -196,7 +196,7 @@ mod tests {
     fn test_is_ttl_valid() {
         let ttl = Duration::from_secs(10);
         let result = is_ttl_valid(ttl);
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "Expected Ok, but got {:?}", result);
     }
 
     #[test]
@@ -220,14 +220,14 @@ mod tests {
     fn test_is_cache_name_valid() {
         let cache_name = "my_cache";
         let result = is_cache_name_valid(cache_name);
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "Expected Ok, but got {:?}", result);
     }
 
     #[test]
     fn test_is_cache_name_valid_empty() {
         let cache_name = "";
         let result = is_cache_name_valid(cache_name);
-        assert!(result.is_err());
+        assert!(result.is_err(), "Expected Err, but got {:?}", result);
         let error = result.unwrap_err();
         assert_eq!(error.error_code, MomentoErrorCode::InvalidArgumentError);
         assert_eq!(error.message, "Cache name cannot be empty");
@@ -237,7 +237,7 @@ mod tests {
     async fn test_connect_channel_lazily() {
         let uri_string = "http://localhost:50051";
         let result = connect_channel_lazily(uri_string);
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "Expected Ok, but got {:?}", result);
     }
 
     #[tokio::test]
@@ -250,7 +250,7 @@ mod tests {
             deadline: Duration::from_secs(30),
         };
         let result = connect_channel_lazily_configurable(uri_string, grpc_config);
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "Expected Ok, but got {:?}", result);
     }
 
     #[test]
@@ -265,8 +265,9 @@ mod tests {
     fn test_parse_string() {
         let raw = vec![104, 101, 108, 108, 111];
         let result = parse_string(raw);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "hello");
+        assert!(result.is_ok(), "Expected Ok, but got {:?}", result);
+        let parsed_string = result.expect("Expected a string");
+        assert_eq!(parsed_string, "hello");
     }
 
     #[test]

--- a/tests/cache/dictionary.rs
+++ b/tests/cache/dictionary.rs
@@ -14,7 +14,9 @@ fn assert_fetched_dictionary_equals_test_data(
     dictionary_fetch_result: DictionaryFetchResponse,
     expected: &TestDictionary,
 ) -> Result<(), MomentoError> {
-    let actual: HashMap<String, String> = dictionary_fetch_result.try_into()?;
+    let actual: HashMap<String, String> = dictionary_fetch_result
+        .try_into()
+        .expect("Could not convert dictionary fetch result into HashMap<String, String>");
     assert_eq!(actual, *expected.value());
     Ok(())
 }

--- a/tests/cache/item.rs
+++ b/tests/cache/item.rs
@@ -5,6 +5,8 @@ use momento::{
 use momento_test_util::{unique_cache_name, TestScalar, TestSet, TestSortedSet, CACHE_TEST_STATE};
 
 mod item_get_type {
+    use std::convert::TryInto;
+
     use super::*;
 
     #[tokio::test]
@@ -37,15 +39,13 @@ mod item_get_type {
         // Expect Scalar after using set
         client.set(cache_name, item.key(), item.value()).await?;
         let result = client.item_get_type(cache_name, item.key()).await?;
-        match result {
-            ItemGetTypeResponse::Hit { key_type } => assert_eq!(
-                key_type,
-                ItemType::Scalar,
-                "Expected Scalar, got {:?}",
-                key_type
-            ),
-            _ => panic!("Expected Hit, got {:?}", result),
-        }
+        let item_type: ItemType = result.try_into().expect("Expected ItemType, got Miss");
+        assert_eq!(
+            item_type,
+            ItemType::Scalar,
+            "Expected Scalar, got {:?}",
+            item_type
+        );
         Ok(())
     }
 
@@ -60,12 +60,13 @@ mod item_get_type {
             .set_add_elements(cache_name, item.name(), item.value().to_vec())
             .await?;
         let result = client.item_get_type(cache_name, item.name()).await?;
-        match result {
-            ItemGetTypeResponse::Hit { key_type } => {
-                assert_eq!(key_type, ItemType::Set, "Expected Set, got {:?}", key_type)
-            }
-            _ => panic!("Expected Hit, got {:?}", result),
-        }
+        let item_type: ItemType = result.try_into().expect("Expected ItemType, got Miss");
+        assert_eq!(
+            item_type,
+            ItemType::Set,
+            "Expected Set, got {:?}",
+            item_type
+        );
         Ok(())
     }
 
@@ -80,15 +81,13 @@ mod item_get_type {
             .sorted_set_put_elements(cache_name, item.name(), item.value().to_vec())
             .await?;
         let result = client.item_get_type(cache_name, item.name()).await?;
-        match result {
-            ItemGetTypeResponse::Hit { key_type } => assert_eq!(
-                key_type,
-                ItemType::SortedSet,
-                "Expected SortedSet, got {:?}",
-                key_type
-            ),
-            _ => panic!("Expected Hit, got {:?}", result),
-        }
+        let item_type: ItemType = result.try_into().expect("Expected ItemType, got Miss");
+        assert_eq!(
+            item_type,
+            ItemType::SortedSet,
+            "Expected SortedSet, got {:?}",
+            item_type
+        );
         Ok(())
     }
 }

--- a/tests/cache/key_existence.rs
+++ b/tests/cache/key_existence.rs
@@ -120,12 +120,28 @@ mod keys_exists {
         let keys_dict: HashMap<String, bool> = result.into();
 
         // these dictionary entries should be true
-        assert!(keys_dict[items[0].key()]);
-        assert!(keys_dict[items[2].key()]);
+        assert!(
+            keys_dict[items[0].key()],
+            "Key {} should exist",
+            items[0].key()
+        );
+        assert!(
+            keys_dict[items[2].key()],
+            "Key {} should exist",
+            items[2].key()
+        );
 
         // these dictionary entries should be false
-        assert!(!keys_dict[items[1].key()]);
-        assert!(!keys_dict[items[3].key()]);
+        assert!(
+            !keys_dict[items[1].key()],
+            "Key {} should not exist",
+            items[1].key()
+        );
+        assert!(
+            !keys_dict[items[3].key()],
+            "Key {} should not exist",
+            items[3].key()
+        );
 
         Ok(())
     }

--- a/tests/cache/scalar.rs
+++ b/tests/cache/scalar.rs
@@ -283,8 +283,13 @@ mod set_if_absent {
         let result_ttl: Duration = client
             .item_get_ttl(cache_name, item.key())
             .await?
-            .try_into()?;
-        assert!(result_ttl.as_millis() > 0);
+            .try_into()
+            .expect("Expected to get an item ttl");
+        assert!(
+            result_ttl.as_millis() > 0,
+            "Expected ttl > 0, got {:?}",
+            result_ttl
+        );
 
         // Wait for ttl to expire
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -369,8 +374,13 @@ mod set_if_present {
         let result_ttl: Duration = client
             .item_get_ttl(cache_name, item.key())
             .await?
-            .try_into()?;
-        assert!(result_ttl.as_millis() > 0);
+            .try_into()
+            .expect("Expected to get an item ttl");
+        assert!(
+            result_ttl.as_millis() > 0,
+            "Expected ttl > 0, got {:?}",
+            result_ttl
+        );
 
         // Wait for ttl to expire
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -466,7 +476,11 @@ mod set_if_equal {
             .await?
             .try_into()
             .expect("Expected to get an item ttl");
-        assert!(result_ttl.as_millis() > 0);
+        assert!(
+            result_ttl.as_millis() > 0,
+            "Expected ttl > 0, got {:?}",
+            result_ttl
+        );
 
         // Wait for ttl to expire
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -560,8 +574,13 @@ mod set_if_not_equal {
         let result_ttl: Duration = client
             .item_get_ttl(cache_name, item.key())
             .await?
-            .try_into()?;
-        assert!(result_ttl.as_millis() > 0);
+            .try_into()
+            .expect("Expected to get an item ttl");
+        assert!(
+            result_ttl.as_millis() > 0,
+            "Expected ttl > 0, got {:?}",
+            result_ttl
+        );
 
         // Wait for ttl to expire
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -658,7 +677,11 @@ mod set_if_present_and_not_equal {
             .await?
             .try_into()
             .expect("Expected to get an item ttl");
-        assert!(result_ttl.as_millis() > 0);
+        assert!(
+            result_ttl.as_millis() > 0,
+            "Expected ttl > 0, got {:?}",
+            result_ttl
+        );
 
         // Wait for ttl to expire
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -752,7 +775,11 @@ mod set_if_absent_or_equal {
             .await?
             .try_into()
             .expect("Expected to get an item ttl");
-        assert!(result_ttl.as_millis() > 0);
+        assert!(
+            result_ttl.as_millis() > 0,
+            "Expected ttl > 0, got {:?}",
+            result_ttl
+        );
 
         // Wait for ttl to expire
         tokio::time::sleep(Duration::from_secs(2)).await;

--- a/tests/cache/ttl.rs
+++ b/tests/cache/ttl.rs
@@ -60,7 +60,11 @@ mod item_get_ttl {
             .await?
             .try_into()
             .expect("Expected an item ttl!");
-        assert!(ttl.as_secs() > 0);
+        assert!(
+            ttl.as_secs() > 0,
+            "Expected ttl to be positive, got {:?}",
+            ttl
+        );
 
         // Sleep for 2 seconds
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -91,7 +95,11 @@ mod item_get_ttl {
             .await?
             .try_into()
             .expect("Expected an item ttl!");
-        assert!(ttl.as_secs() > 0);
+        assert!(
+            ttl.as_secs() > 0,
+            "Expected ttl to be positive, got {:?}",
+            ttl
+        );
 
         // Sleep for 2 seconds
         tokio::time::sleep(Duration::from_secs(2)).await;
@@ -160,7 +168,11 @@ mod increase_ttl {
             .await?
             .try_into()
             .expect("Expected an item ttl!");
-        assert!(ttl_before.as_secs() > 0 && ttl_before.as_secs() < 5);
+        assert!(
+            ttl_before.as_secs() > 0 && ttl_before.as_secs() < 5,
+            "Expected ttl to be <5 seconds, got {:?}",
+            ttl_before
+        );
 
         // Set a higher TTL
         let result = client
@@ -173,7 +185,11 @@ mod increase_ttl {
             .await?
             .try_into()
             .expect("Expected an item ttl!");
-        assert!(ttl_after.as_secs() > 15 && ttl_after.as_secs() < 20);
+        assert!(
+            ttl_after.as_secs() > 15 && ttl_after.as_secs() < 20,
+            "Expected ttl to be >15 and <20 seconds, got {:?}",
+            ttl_after
+        );
 
         // Setting TTL lower than current TTL should not change the TTL
         let result = client
@@ -186,7 +202,11 @@ mod increase_ttl {
             .await?
             .try_into()
             .expect("Expected an item ttl!");
-        assert!(ttl_lower.as_secs() > 15 && ttl_lower.as_secs() < 20);
+        assert!(
+            ttl_lower.as_secs() > 15 && ttl_lower.as_secs() < 20,
+            "Expected ttl to be >15 and <20 seconds, got {:?}",
+            ttl_lower
+        );
         Ok(())
     }
 }
@@ -247,7 +267,11 @@ mod decrease_ttl {
             .await?
             .try_into()
             .expect("Expected an item ttl!");
-        assert!(ttl_before.as_secs() > 15 && ttl_before.as_secs() < 20);
+        assert!(
+            ttl_before.as_secs() > 15 && ttl_before.as_secs() < 20,
+            "Expected ttl to be >15 and <20 seconds, got {:?}",
+            ttl_before
+        );
 
         // Set a lower TTL
         let result = client
@@ -260,7 +284,11 @@ mod decrease_ttl {
             .await?
             .try_into()
             .expect("Expected an item ttl!");
-        assert!(ttl_after.as_secs() > 0 && ttl_after.as_secs() < 5);
+        assert!(
+            ttl_after.as_secs() > 0 && ttl_after.as_secs() < 5,
+            "Expected ttl to be <5 seconds, got {:?}",
+            ttl_after
+        );
 
         // Setting TTL higher than current TTL should not change the TTL
         let result = client
@@ -273,7 +301,11 @@ mod decrease_ttl {
             .await?
             .try_into()
             .expect("Expected an item ttl!");
-        assert!(ttl_lower.as_secs() > 0 && ttl_lower.as_secs() < 5);
+        assert!(
+            ttl_lower.as_secs() > 0 && ttl_lower.as_secs() < 5,
+            "Expected ttl to be <5 seconds, got {:?}",
+            ttl_lower
+        );
         Ok(())
     }
 }
@@ -333,7 +365,11 @@ mod update_ttl {
             .await?
             .try_into()
             .expect("Expected an item ttl!");
-        assert!(ttl_before.as_secs() > 0 && ttl_before.as_secs() < 10);
+        assert!(
+            ttl_before.as_secs() > 0 && ttl_before.as_secs() < 10,
+            "Expected ttl to be <10 seconds, got {:?}",
+            ttl_before
+        );
 
         client
             .update_ttl(cache_name, item.key(), Duration::from_secs(20))
@@ -344,7 +380,11 @@ mod update_ttl {
             .await?
             .try_into()
             .expect("Expected an item ttl!");
-        assert!(ttl_after.as_secs() > 10 && ttl_after.as_secs() < 20);
+        assert!(
+            ttl_after.as_secs() > 10 && ttl_after.as_secs() < 20,
+            "Expected ttl to be >10 and <20 seconds, got {:?}",
+            ttl_after
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
Addresses https://github.com/momentohq/client-sdk-rust/issues/270 

It seems like we used `expect` where appropriate for the most part, added a few more.
This PR also adds informative failure messages to the `assert!` statements.