### PR TITLE
feat: implement custom debug and display traits for byte-array types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ thiserror = "1.0"
 base64 = "0.21"
 futures = "0"
 zstd = "0.12.4"
+derive_more = "0.99.17"
 
 [dev-dependencies]
 base64-url = "2"

--- a/src/cache/messages/data/scalar/get.rs
+++ b/src/cache/messages/data/scalar/get.rs
@@ -2,6 +2,7 @@ use crate::cache::messages::MomentoRequest;
 use crate::utils;
 use crate::CacheClient;
 use crate::{IntoBytes, MomentoError, MomentoResult};
+use derive_more::Display;
 use momento_protos::cache_client::ECacheResult;
 use std::convert::{TryFrom, TryInto};
 
@@ -131,7 +132,7 @@ impl<K: IntoBytes> MomentoRequest for GetRequest<K> {
 /// use std::convert::TryInto;
 /// let item: MomentoResult<Vec<u8>> = get_response.try_into();
 /// ```
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Display, PartialEq, Eq)]
 pub enum GetResponse {
     /// The item was found in the cache.
     Hit {

--- a/src/cache/messages/data/scalar/get.rs
+++ b/src/cache/messages/data/scalar/get.rs
@@ -230,7 +230,16 @@ mod tests {
         );
         assert_eq!(
             format!("{:#?}", hit),
-            "Hit {\n    value: Value { raw_item: [\n        104,\n        101,\n        108,\n        108,\n        111,\n    ] (as string: \"hello\")\n    },\n}"
+            r#"Hit {
+    value: Value { raw_item: [
+        104,
+        101,
+        108,
+        108,
+        111,
+    ] (as string: "hello")
+    },
+}"#
         );
 
         let miss = GetResponse::Miss;

--- a/src/cache/messages/data/scalar/get.rs
+++ b/src/cache/messages/data/scalar/get.rs
@@ -160,7 +160,9 @@ pub struct Value {
 
 impl std::fmt::Debug for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        utils::write_bytes_for_debug(f, "raw_item", &self.raw_item)
+        utils::fmt::write_struct_begin(f, "Value")?;
+        utils::fmt::write_bytes_for_debug(f, "raw_item", &self.raw_item)?;
+        utils::fmt::write_struct_end(f)
     }
 }
 
@@ -210,5 +212,30 @@ impl TryFrom<GetResponse> for Vec<u8> {
             GetResponse::Hit { value } => Ok(value.into()),
             GetResponse::Miss => Err(MomentoError::miss("Get")),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_response_display() -> MomentoResult<()> {
+        let hit = GetResponse::Hit {
+            value: Value::new("hello".as_bytes().to_vec()),
+        };
+        assert_eq!(
+            format!("{:?}", hit),
+            "Hit { value: Value { raw_item: [104, 101, 108, 108, 111] (as string: \"hello\") } }"
+        );
+        assert_eq!(
+            format!("{:#?}", hit),
+            "Hit {\n    value: Value { raw_item: [\n        104,\n        101,\n        108,\n        108,\n        111,\n    ] (as string: \"hello\")\n    },\n}"
+        );
+
+        let miss = GetResponse::Miss;
+        assert_eq!(format!("{}", miss), "Miss");
+
+        Ok(())
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -174,7 +174,13 @@ where
     }
 }
 
+/// Some notes on the `fmt` module:
+/// There are two modes to debug print:
+/// - Regular: `{:?}`
+/// - Alternate (pretty): `{:#?}`
+/// We implement both modes for the `fmt` module.
 pub(crate) mod fmt {
+
     pub(crate) fn write_bytes_for_debug(
         f: &mut std::fmt::Formatter<'_>,
         name: &str,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -204,11 +204,7 @@ pub(crate) mod fmt {
         f: &mut std::fmt::Formatter<'_>,
         name: &str,
     ) -> std::fmt::Result {
-        if f.alternate() {
-            write!(f, "{:#} {{", name)
-        } else {
-            write!(f, "{} {{", name)
-        }
+        write!(f, "{} {{", name)
     }
 
     pub(crate) fn write_struct_end(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -174,16 +174,49 @@ where
     }
 }
 
-pub(crate) fn write_bytes_for_debug(
-    f: &mut std::fmt::Formatter<'_>,
-    name: &str,
-    bytes: &[u8],
-) -> std::fmt::Result {
-    let as_str = String::from_utf8(bytes.to_vec());
+pub(crate) mod fmt {
+    pub(crate) fn write_bytes_for_debug(
+        f: &mut std::fmt::Formatter<'_>,
+        name: &str,
+        bytes: &[u8],
+    ) -> std::fmt::Result {
+        let as_str = String::from_utf8(bytes.to_vec());
 
-    match as_str {
-        Ok(s) => write!(f, "{}: {:?} (as string: {:?})", name, bytes, s),
-        Err(_) => write!(f, "{}: {:?} (as string: <invalid UTF-8>)", name, bytes),
+        match as_str {
+            Ok(s) => {
+                if f.alternate() {
+                    write!(f, " {}: {:#?} (as string: {:#?})", name, bytes, s)
+                } else {
+                    write!(f, " {}: {:?} (as string: {:?})", name, bytes, s)
+                }
+            }
+            Err(_) => {
+                if f.alternate() {
+                    write!(f, " {}: {:#?} (as string: <invalid UTF-8>)", name, bytes)
+                } else {
+                    write!(f, " {}: {:?} (as string: <invalid UTF-8>)", name, bytes)
+                }
+            }
+        }
+    }
+
+    pub(crate) fn write_struct_begin(
+        f: &mut std::fmt::Formatter<'_>,
+        name: &str,
+    ) -> std::fmt::Result {
+        if f.alternate() {
+            write!(f, "{:#} {{", name)
+        } else {
+            write!(f, "{} {{", name)
+        }
+    }
+
+    pub(crate) fn write_struct_end(f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if f.alternate() {
+            write!(f, "\n}}")
+        } else {
+            write!(f, " }}")
+        }
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -174,6 +174,19 @@ where
     }
 }
 
+pub(crate) fn write_bytes_for_debug(
+    f: &mut std::fmt::Formatter<'_>,
+    name: &str,
+    bytes: &[u8],
+) -> std::fmt::Result {
+    let as_str = String::from_utf8(bytes.to_vec());
+
+    match as_str {
+        Ok(s) => write!(f, "{}: {:?} (as string: {:?})", name, bytes, s),
+        Err(_) => write!(f, "{}: {:?} (as string: <invalid UTF-8>)", name, bytes),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;


### PR DESCRIPTION
Presents a pattern we can use to get debug and display for response types.

Because our cache stores data as bytes, when users build a request or receive a response, they get back a wrapper around `Vec<u8>` of some form. This may be a `Vec<u8>` directly or another data structure like a `HashMap` or another `Vec`, for example.

In order to aid debugging and printing, we provide debug and display trait implementations that attempt to interpret and display the bytes as strings. There are two aspects to this:

1. For each `Value` type in a response, we manually implement `std::fmt::Debug` and `std::fmt::Display`. We have authored utility functions in `utils::fmt` to aid with this. See the `get_response::Value` implementation.
2. We auto-derive `Debug` and `Display` for the response type (`GetResponse` in this PR). Unfortunately Rust does not allow one to auto-derive `Display`, so we had to use the third-party library `derive_more` for that. Hence this PR adds that as a dependency.

Going forward, we can implement debug and display as appropriate for the `Value` types and auto-derive `Debug` and `Display` for the response types. We can also add truncation in the utility functions.

Closes #282