### PR TITLE
fix: clippy error on gh with doctest signature

### DIFF
--- a/test-util/src/test_utils.rs
+++ b/test-util/src/test_utils.rs
@@ -17,10 +17,10 @@ pub type DoctestResult = anyhow::Result<()>;
 /// - Reading the auth token from the environment
 /// - Creating a cache for the doctest to use.
 /// - Ensuring that cache is deleted, even if the test case panics.
-pub fn doctest<'ctx, Fn: 'ctx, Fut: 'ctx>(func: Fn) -> DoctestResult
+pub fn doctest<'ctx, Fn, Fut>(func: Fn) -> DoctestResult
 where
-    Fn: FnOnce(String, CredentialProvider) -> Fut,
-    Fut: Future<Output = DoctestResult>,
+    Fn: 'ctx + FnOnce(String, CredentialProvider) -> Fut,
+    Fut: 'ctx + Future<Output = DoctestResult>,
 {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()


### PR DESCRIPTION
Changes the doctest signature to fix clippy error regarding trait
bounds.

The previous version started failing on GitHub on the `lint` make target
but continues to succeed locally. I have verified my `cargo` and `clippy`
versions are identical to those used in the GitHub Action runner. 

I do not know why it does not fail locally, and I have exhausted my timebox.

This fix directly addresses the clippy error on GitHub and has appeased it.

Closes #326 