### PR TITLE
chore: upgrade codeql action upload sarif version

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -51,7 +51,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: rust-clippy-results.sarif
           wait-for-processing: true


### PR DESCRIPTION
v1 of upload-sarif is [deprecated](https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/). We upgrade to v2.

```
[Run rust-clippy analyzing](https://github.com/momentohq/client-sdk-rust/actions/runs/9103552264/job/25025625153#step:6:9)
This version of the CodeQL Action was deprecated on January 18th, 2023, and is no longer updated or supported. For better performance, improved security, and new features, upgrade to v2. For more information, see https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/
```