### PR TITLE
chore: run ci on ubuntu-24.04

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -46,7 +46,7 @@ jobs:
         run: make docs
 
   build_rust:
-    runs-on: macos-latest
+    runs-on: ubuntu-24.04
     env:
       MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
 


### PR DESCRIPTION
Previously we ran on `macos` to sidestep timeouts of uncertain origin on `ubuntu-22.04` + GitHub's Azure runners. This has resolved on `ubuntu-24.04`