### PR TITLE
fix: publish task broken with sdk subdir

### DIFF
--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -93,6 +93,5 @@ jobs:
 
       - name: Publish
         run: |
-          cd sdk
-          cargo publish
+          make publish
           

--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,7 @@ run-examples:
 .PHONY: help
 help:
 	@echo "$$(tput bold)Available rules:$$(tput sgr0)";echo;sed -ne"/^## /{h;s/.*//;:d" -e"H;n;s/^## //;td" -e"s/:.*//;G;s/\\n## /---/;s/\\n/ /g;p;}" ${MAKEFILE_LIST}|LC_ALL='C' sort -f|awk -F --- -v n=$$(tput cols) -v i=19 -v a="$$(tput setaf 6)" -v z="$$(tput sgr0)" '{printf"%s%*s%s ",a,-i,$$1,z;m=split($$2,w," ");l=n-i;for(j=1;j<=m;j++){l-=length(w[j])+1;if(l<= 0){l=n-i-length(w[j])-1;printf"\n%*s ",-i," ";}printf"%s ",w[j];}printf"\n";}'|more $(shell test $(shell uname) == Darwin && echo '-Xr')
+
+.PHONY: publish
+publish:
+	cd sdk && cp ../README.md . && cargo publish


### PR DESCRIPTION
In a recent commit we moved the sdk code into a subdir to avoid
Cargo workspace collisions. That caused the publish to fail
because it expects a README to exist in the directory we're publishing
from.

This commit moves the publish logic into the Makefile to centralize it
like the other build tasks, and adds a step to copy the README from
the parent directory before we execute the publish.
