### PR TITLE
chore: add sdk/README to gitignore to prevent attempt to publish from dirty tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,4 +79,7 @@ help:
 
 .PHONY: publish
 publish:
-	cd sdk && cp ../README.md . && cargo publish
+	cd sdk && \
+ 	cp ../README.md . && \
+ 	cargo publish
+

--- a/sdk/.gitignore
+++ b/sdk/.gitignore
@@ -1,0 +1,6 @@
+# During publish operations, we temporarily copy the README.md file from the parent dir
+# into this dir so that it can be published to crates.io. However, the `cargo publish`
+# command will fail if the working tree is dirty, which it will be if the README.md
+# file is recognized as a potential source file. Including it in the .gitignore here
+# prevents the working tree from being flagged as dirty.
+README.md


### PR DESCRIPTION
In an earlier commit we moved the sdk to a subdir to prevent issues
with Cargo workspaces related to having a Cargo.toml file in a
parent dir of the examples.

We are now trying to publish the SDK from this new `sdk` subdir,
but it needs a README.md, so we are copying that file from the root
dir of the github repo into the `sdk` dir prior to publishing.

However, the `cargo publish` operation doesn't allow publishing
from a dirty git working tree. This commit adds the README to
the sdk/.gitignore so that the tree won't be flagged as dirty.

Another option we could consider in the future would be to add
another README generator action to the github actions, to just
generate a second copy of the root README and output it to the
`sdk` directory.
