### PR TITLE
chore: make optional things optional on request builders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@
 ## Generate sync unit tests, format, lint, and test
 all: precommit
 
+.PHONY: format
+## Format all files
+format:
+	cd sdk && cargo fmt
+
 .PHONY: lint
 ## Check the formatting of all files, run clippy on the source code, then run
 ## clippy on the tests (but allow expect to be used in tests)

--- a/sdk/src/cache/messages/data/dictionary/dictionary_increment.rs
+++ b/sdk/src/cache/messages/data/dictionary/dictionary_increment.rs
@@ -68,8 +68,8 @@ impl<D: IntoBytes, F: IntoBytes> DictionaryIncrementRequest<D, F> {
     }
 
     /// Set the time-to-live for the collection.
-    pub fn ttl(mut self, collection_ttl: CollectionTtl) -> Self {
-        self.collection_ttl = Some(collection_ttl);
+    pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
+        self.collection_ttl = collection_ttl.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/dictionary/dictionary_set_field.rs
+++ b/sdk/src/cache/messages/data/dictionary/dictionary_set_field.rs
@@ -77,8 +77,8 @@ where
     }
 
     /// Set the time-to-live for the dictionary.
-    pub fn ttl(mut self, collection_ttl: CollectionTtl) -> Self {
-        self.collection_ttl = Some(collection_ttl);
+    pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
+        self.collection_ttl = collection_ttl.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/dictionary/dictionary_set_fields.rs
+++ b/sdk/src/cache/messages/data/dictionary/dictionary_set_fields.rs
@@ -125,8 +125,8 @@ where
     }
 
     /// Set the time-to-live for the collection.
-    pub fn ttl(mut self, collection_ttl: CollectionTtl) -> Self {
-        self.collection_ttl = Some(collection_ttl);
+    pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
+        self.collection_ttl = collection_ttl.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/list/list_concatenate_back.rs
+++ b/sdk/src/cache/messages/data/list/list_concatenate_back.rs
@@ -61,14 +61,17 @@ impl<L: IntoBytes, V: IntoBytesIterable> ListConcatenateBackRequest<L, V> {
     }
 
     /// Set the time-to-live for the collection.
-    pub fn ttl(mut self, collection_ttl: CollectionTtl) -> Self {
-        self.collection_ttl = Some(collection_ttl);
+    pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
+        self.collection_ttl = collection_ttl.into();
         self
     }
 
     /// If the list exceeds this length, remove excess from the front of the list.
-    pub fn truncate_front_to_size(mut self, truncate_front_to_size: u32) -> Self {
-        self.truncate_front_to_size = Some(truncate_front_to_size);
+    pub fn truncate_front_to_size(
+        mut self,
+        truncate_front_to_size: impl Into<Option<u32>>,
+    ) -> Self {
+        self.truncate_front_to_size = truncate_front_to_size.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/list/list_concatenate_front.rs
+++ b/sdk/src/cache/messages/data/list/list_concatenate_front.rs
@@ -61,14 +61,14 @@ impl<L: IntoBytes, V: IntoBytesIterable> ListConcatenateFrontRequest<L, V> {
     }
 
     /// Set the time-to-live for the collection.
-    pub fn ttl(mut self, collection_ttl: CollectionTtl) -> Self {
-        self.collection_ttl = Some(collection_ttl);
+    pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
+        self.collection_ttl = collection_ttl.into();
         self
     }
 
     /// If the list exceeds this length, remove excess from the back of the list.
-    pub fn truncate_back_to_size(mut self, truncate_back_to_size: u32) -> Self {
-        self.truncate_back_to_size = Some(truncate_back_to_size);
+    pub fn truncate_back_to_size(mut self, truncate_back_to_size: impl Into<Option<u32>>) -> Self {
+        self.truncate_back_to_size = truncate_back_to_size.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/list/list_fetch.rs
+++ b/sdk/src/cache/messages/data/list/list_fetch.rs
@@ -63,14 +63,14 @@ impl<L: IntoBytes> ListFetchRequest<L> {
     }
 
     /// Set the starting inclusive element of the list to fetch.
-    pub fn start_index(mut self, start_index: i32) -> Self {
-        self.start_index = Some(start_index);
+    pub fn start_index(mut self, start_index: impl Into<Option<i32>>) -> Self {
+        self.start_index = start_index.into();
         self
     }
 
     /// Set the ending exclusive element of the list to fetch.
-    pub fn end_index(mut self, end_index: i32) -> Self {
-        self.end_index = Some(end_index);
+    pub fn end_index(mut self, end_index: impl Into<Option<i32>>) -> Self {
+        self.end_index = end_index.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/list/list_push_back.rs
+++ b/sdk/src/cache/messages/data/list/list_push_back.rs
@@ -58,14 +58,17 @@ impl<L: IntoBytes, V: IntoBytes> ListPushBackRequest<L, V> {
     }
 
     /// Set the time-to-live for the collection.
-    pub fn ttl(mut self, collection_ttl: CollectionTtl) -> Self {
-        self.collection_ttl = Some(collection_ttl);
+    pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
+        self.collection_ttl = collection_ttl.into();
         self
     }
 
     /// If the list exceeds this length, remove excess from the front of the list.
-    pub fn truncate_front_to_size(mut self, truncate_front_to_size: u32) -> Self {
-        self.truncate_front_to_size = Some(truncate_front_to_size);
+    pub fn truncate_front_to_size(
+        mut self,
+        truncate_front_to_size: impl Into<Option<u32>>,
+    ) -> Self {
+        self.truncate_front_to_size = truncate_front_to_size.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/list/list_push_front.rs
+++ b/sdk/src/cache/messages/data/list/list_push_front.rs
@@ -58,14 +58,14 @@ impl<L: IntoBytes, V: IntoBytes> ListPushFrontRequest<L, V> {
     }
 
     /// Set the time-to-live for the collection.
-    pub fn ttl(mut self, collection_ttl: CollectionTtl) -> Self {
-        self.collection_ttl = Some(collection_ttl);
+    pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
+        self.collection_ttl = collection_ttl.into();
         self
     }
 
     /// If the list exceeds this length, remove excess from the front of the list.
-    pub fn truncate_back_to_size(mut self, truncate_back_to_size: u32) -> Self {
-        self.truncate_back_to_size = Some(truncate_back_to_size);
+    pub fn truncate_back_to_size(mut self, truncate_back_to_size: impl Into<Option<u32>>) -> Self {
+        self.truncate_back_to_size = truncate_back_to_size.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/scalar/increment.rs
+++ b/sdk/src/cache/messages/data/scalar/increment.rs
@@ -66,8 +66,8 @@ impl<K: IntoBytes> IncrementRequest<K> {
     }
 
     /// Set the time-to-live for the item.
-    pub fn ttl(mut self, ttl: Duration) -> Self {
-        self.ttl = Some(ttl);
+    pub fn ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
+        self.ttl = ttl.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/scalar/set.rs
+++ b/sdk/src/cache/messages/data/scalar/set.rs
@@ -65,8 +65,8 @@ impl<K: IntoBytes, V: IntoBytes> SetRequest<K, V> {
     }
 
     /// Set the time-to-live for the item.
-    pub fn ttl(mut self, ttl: Duration) -> Self {
-        self.ttl = Some(ttl);
+    pub fn ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
+        self.ttl = ttl.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/scalar/set_if_absent.rs
+++ b/sdk/src/cache/messages/data/scalar/set_if_absent.rs
@@ -71,8 +71,8 @@ impl<K: IntoBytes, V: IntoBytes> SetIfAbsentRequest<K, V> {
     }
 
     /// Set the time-to-live for the item.
-    pub fn ttl(mut self, ttl: Duration) -> Self {
-        self.ttl = Some(ttl);
+    pub fn ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
+        self.ttl = ttl.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/scalar/set_if_absent_or_equal.rs
+++ b/sdk/src/cache/messages/data/scalar/set_if_absent_or_equal.rs
@@ -76,8 +76,8 @@ impl<K: IntoBytes, V: IntoBytes, E: IntoBytes> SetIfAbsentOrEqualRequest<K, V, E
     }
 
     /// Set the time-to-live for the item.
-    pub fn ttl(mut self, ttl: Duration) -> Self {
-        self.ttl = Some(ttl);
+    pub fn ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
+        self.ttl = ttl.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/scalar/set_if_equal.rs
+++ b/sdk/src/cache/messages/data/scalar/set_if_equal.rs
@@ -76,8 +76,8 @@ impl<K: IntoBytes, V: IntoBytes, E: IntoBytes> SetIfEqualRequest<K, V, E> {
     }
 
     /// Set the time-to-live for the item.
-    pub fn ttl(mut self, ttl: Duration) -> Self {
-        self.ttl = Some(ttl);
+    pub fn ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
+        self.ttl = ttl.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/scalar/set_if_not_equal.rs
+++ b/sdk/src/cache/messages/data/scalar/set_if_not_equal.rs
@@ -76,8 +76,8 @@ impl<K: IntoBytes, V: IntoBytes, E: IntoBytes> SetIfNotEqualRequest<K, V, E> {
     }
 
     /// Set the time-to-live for the item.
-    pub fn ttl(mut self, ttl: Duration) -> Self {
-        self.ttl = Some(ttl);
+    pub fn ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
+        self.ttl = ttl.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/scalar/set_if_present.rs
+++ b/sdk/src/cache/messages/data/scalar/set_if_present.rs
@@ -71,8 +71,8 @@ impl<K: IntoBytes, V: IntoBytes> SetIfPresentRequest<K, V> {
     }
 
     /// Set the time-to-live for the item.
-    pub fn ttl(mut self, ttl: Duration) -> Self {
-        self.ttl = Some(ttl);
+    pub fn ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
+        self.ttl = ttl.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/scalar/set_if_present_and_not_equal.rs
+++ b/sdk/src/cache/messages/data/scalar/set_if_present_and_not_equal.rs
@@ -76,8 +76,8 @@ impl<K: IntoBytes, V: IntoBytes, E: IntoBytes> SetIfPresentAndNotEqualRequest<K,
     }
 
     /// Set the time-to-live for the item.
-    pub fn ttl(mut self, ttl: Duration) -> Self {
-        self.ttl = Some(ttl);
+    pub fn ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
+        self.ttl = ttl.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/set/set_add_elements.rs
+++ b/sdk/src/cache/messages/data/set/set_add_elements.rs
@@ -62,8 +62,8 @@ impl<S: IntoBytes, E: IntoBytesIterable> SetAddElementsRequest<S, E> {
     }
 
     /// Set the time-to-live for the collection.
-    pub fn ttl(mut self, collection_ttl: CollectionTtl) -> Self {
-        self.collection_ttl = Some(collection_ttl);
+    pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
+        self.collection_ttl = collection_ttl.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/sorted_set/sorted_set_fetch_by_rank.rs
+++ b/sdk/src/cache/messages/data/sorted_set/sorted_set_fetch_by_rank.rs
@@ -11,6 +11,7 @@ use crate::{CacheClient, IntoBytes, MomentoResult};
 /// The sort order determines the rank of the elements.
 /// The elements with same score are ordered lexicographically.
 #[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum SortedSetOrder {
     /// Scores are ordered from low to high. This is the default order.
     Ascending = 0,

--- a/sdk/src/cache/messages/data/sorted_set/sorted_set_fetch_by_rank.rs
+++ b/sdk/src/cache/messages/data/sorted_set/sorted_set_fetch_by_rank.rs
@@ -88,20 +88,20 @@ impl<S: IntoBytes> SortedSetFetchByRankRequest<S> {
     }
 
     /// Set the start rank of the request.
-    pub fn start_rank(mut self, start_rank: i32) -> Self {
-        self.start_rank = Some(start_rank);
+    pub fn start_rank(mut self, start_rank: impl Into<Option<i32>>) -> Self {
+        self.start_rank = start_rank.into();
         self
     }
 
     /// Set the end rank of the request.
-    pub fn end_rank(mut self, end_rank: i32) -> Self {
-        self.end_rank = Some(end_rank);
+    pub fn end_rank(mut self, end_rank: impl Into<Option<i32>>) -> Self {
+        self.end_rank = end_rank.into();
         self
     }
 
     /// Set the order of the request.
-    pub fn order(mut self, order: SortedSetOrder) -> Self {
-        self.order = order;
+    pub fn order(mut self, order: impl Into<Option<SortedSetOrder>>) -> Self {
+        self.order = order.into().unwrap_or(SortedSetOrder::Ascending);
         self
     }
 }
@@ -145,5 +145,61 @@ impl<S: IntoBytes> MomentoRequest for SortedSetFetchByRankRequest<S> {
             .into_inner();
 
         SortedSetFetchResponse::from_fetch_response(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sorted_set_fetch_by_rank_request_builder() {
+        let cache_name = "my_cache";
+        let sorted_set_name = "my_sorted_set";
+
+        // Test with explicit values
+        let request = SortedSetFetchByRankRequest::new(cache_name, sorted_set_name)
+            .order(SortedSetOrder::Ascending)
+            .start_rank(1)
+            .end_rank(3);
+
+        assert_eq!(request.cache_name, cache_name);
+        assert_eq!(
+            request.sorted_set_name.into_bytes(),
+            sorted_set_name.as_bytes()
+        );
+        assert_eq!(request.start_rank, Some(1));
+        assert_eq!(request.end_rank, Some(3));
+        assert_eq!(request.order, SortedSetOrder::Ascending);
+
+        // Test with Some values
+        let request = SortedSetFetchByRankRequest::new(cache_name, sorted_set_name)
+            .order(SortedSetOrder::Descending)
+            .start_rank(Some(2))
+            .end_rank(Some(4));
+
+        assert_eq!(request.cache_name, cache_name);
+        assert_eq!(
+            request.sorted_set_name.into_bytes(),
+            sorted_set_name.as_bytes()
+        );
+        assert_eq!(request.start_rank, Some(2));
+        assert_eq!(request.end_rank, Some(4));
+        assert_eq!(request.order, SortedSetOrder::Descending);
+
+        // Test with None values
+        let request = SortedSetFetchByRankRequest::new(cache_name, sorted_set_name)
+            .order(None)
+            .start_rank(None)
+            .end_rank(None);
+
+        assert_eq!(request.cache_name, cache_name);
+        assert_eq!(
+            request.sorted_set_name.into_bytes(),
+            sorted_set_name.as_bytes()
+        );
+        assert_eq!(request.start_rank, None);
+        assert_eq!(request.end_rank, None);
+        assert_eq!(request.order, SortedSetOrder::Ascending);
     }
 }

--- a/sdk/src/cache/messages/data/sorted_set/sorted_set_fetch_by_score.rs
+++ b/sdk/src/cache/messages/data/sorted_set/sorted_set_fetch_by_score.rs
@@ -86,32 +86,32 @@ impl<S: IntoBytes> SortedSetFetchByScoreRequest<S> {
     }
 
     /// Set the minimum score of the request.
-    pub fn min_score(mut self, min_score: f64) -> Self {
-        self.min_score = Some(min_score);
+    pub fn min_score(mut self, min_score: impl Into<Option<f64>>) -> Self {
+        self.min_score = min_score.into();
         self
     }
 
     /// Set the maximum score of the request.
-    pub fn max_score(mut self, max_score: f64) -> Self {
-        self.max_score = Some(max_score);
+    pub fn max_score(mut self, max_score: impl Into<Option<f64>>) -> Self {
+        self.max_score = max_score.into();
         self
     }
 
     /// Set the order of the request.
-    pub fn order(mut self, order: SortedSetOrder) -> Self {
-        self.order = order;
+    pub fn order(mut self, order: impl Into<Option<SortedSetOrder>>) -> Self {
+        self.order = order.into().unwrap_or(SortedSetOrder::Ascending);
         self
     }
 
     /// Set the offset of the request.
-    pub fn offset(mut self, offset: u32) -> Self {
-        self.offset = Some(offset);
+    pub fn offset(mut self, offset: impl Into<Option<u32>>) -> Self {
+        self.offset = offset.into();
         self
     }
 
     /// Set the count of the request.
-    pub fn count(mut self, count: i32) -> Self {
-        self.count = Some(count);
+    pub fn count(mut self, count: impl Into<Option<i32>>) -> Self {
+        self.count = count.into();
         self
     }
 }
@@ -167,5 +167,70 @@ impl<S: IntoBytes> MomentoRequest for SortedSetFetchByScoreRequest<S> {
             .into_inner();
 
         SortedSetFetchResponse::from_fetch_response(response)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::SortedSetFetchByScoreRequest;
+    use crate::cache::SortedSetOrder;
+
+    // test the sorted set request with options
+    #[tokio::test]
+    async fn test_sorted_set_fetch_by_score_request_with_options() {
+        // Define the cache name and sorted set name
+        let cache_name = "test_cache";
+        let sorted_set_name = "test_sorted_set";
+
+        // Create the fetch request with options
+        let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
+            .order(SortedSetOrder::Ascending)
+            .min_score(2.0)
+            .max_score(3.0)
+            .offset(1)
+            .count(2);
+
+        // Verify the built request
+        assert_eq!(fetch_request.cache_name, cache_name);
+        assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
+        assert_eq!(fetch_request.min_score, Some(2.0));
+        assert_eq!(fetch_request.max_score, Some(3.0));
+        assert_eq!(fetch_request.order, SortedSetOrder::Ascending);
+        assert_eq!(fetch_request.offset, Some(1));
+        assert_eq!(fetch_request.count, Some(2));
+
+        // Now pass in explicit Options to min score, max score, offset, and count
+        let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
+            .order(SortedSetOrder::Ascending)
+            .min_score(Some(2.0))
+            .max_score(Some(3.0))
+            .offset(Some(1))
+            .count(Some(2));
+
+        // Verify the built request
+        assert_eq!(fetch_request.cache_name, cache_name);
+        assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
+        assert_eq!(fetch_request.min_score, Some(2.0));
+        assert_eq!(fetch_request.max_score, Some(3.0));
+        assert_eq!(fetch_request.order, SortedSetOrder::Ascending);
+        assert_eq!(fetch_request.offset, Some(1));
+        assert_eq!(fetch_request.count, Some(2));
+
+        // Now pass in explicit None to min score, max score, offset, and count
+        let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
+            .order(SortedSetOrder::Ascending)
+            .min_score(None)
+            .max_score(None)
+            .offset(None)
+            .count(None);
+
+        // Verify the built request
+        assert_eq!(fetch_request.cache_name, cache_name);
+        assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
+        assert_eq!(fetch_request.min_score, None);
+        assert_eq!(fetch_request.max_score, None);
+        assert_eq!(fetch_request.order, SortedSetOrder::Ascending);
+        assert_eq!(fetch_request.offset, None);
+        assert_eq!(fetch_request.count, None);
     }
 }

--- a/sdk/src/cache/messages/data/sorted_set/sorted_set_put_element.rs
+++ b/sdk/src/cache/messages/data/sorted_set/sorted_set_put_element.rs
@@ -65,8 +65,8 @@ impl<S: IntoBytes, V: IntoBytes> SortedSetPutElementRequest<S, V> {
     }
 
     /// Set the time-to-live for the collection.
-    pub fn ttl(mut self, collection_ttl: CollectionTtl) -> Self {
-        self.collection_ttl = Some(collection_ttl);
+    pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
+        self.collection_ttl = collection_ttl.into();
         self
     }
 }

--- a/sdk/src/cache/messages/data/sorted_set/sorted_set_put_elements.rs
+++ b/sdk/src/cache/messages/data/sorted_set/sorted_set_put_elements.rs
@@ -166,8 +166,8 @@ impl<S: IntoBytes, V: IntoBytes, E: IntoSortedSetElements<V>> SortedSetPutElemen
     }
 
     /// Set the time-to-live for the collection.
-    pub fn ttl(mut self, collection_ttl: CollectionTtl) -> Self {
-        self.collection_ttl = Some(collection_ttl);
+    pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
+        self.collection_ttl = collection_ttl.into();
         self
     }
 }


### PR DESCRIPTION
Per user feedback, we should support `Option` parameters on builders when the parameter is actually optional. Currently the SDK expects mandatory values for those builder functions, even when the parameter is actually optional.

To do this, where applicable, we change each parameter type to be `impl Into<Option<>>` which is backwards compatible.

Closes #356 