### PR TITLE
feat: add example for preview storage client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,14 @@ build-examples:
 .PHONY: run-examples
 ## Run example code
 run-examples:
-	cd example/rust && make lint && cargo run --bin=readme && cargo run --bin=cache && cargo run --bin=topics && cargo run --bin=docs_examples && cargo run --bin=cheat_sheet_client_instantiation
+	cd example/rust \
+	&& make lint \
+	&& cargo run --bin=readme \
+	&& cargo run --bin=cache \
+	&& cargo run --bin=topics \
+	&& cargo run --bin=storage \
+	&& cargo run --bin=docs_examples \
+	&& cargo run --bin=cheat_sheet_client_instantiation
 
 # See <https://gist.github.com/klmr/575726c7e05d8780505a> for explanation.
 .PHONY: help

--- a/example/rust/Cargo.lock
+++ b/example/rust/Cargo.lock
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.41.0"
+version = "0.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01485ce865a7d8c5efbb5cba62114d29aff935c29900353c3d225ea53d116a81"
+checksum = "730ce69e550d1401c0faee9fecdbda1af0fbf18765f10bc77f1667cde5a26b06"
 dependencies = [
  "base64",
  "derive_more",

--- a/example/rust/Cargo.lock
+++ b/example/rust/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -42,7 +42,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn",
 ]
 
 [[package]]
@@ -53,7 +53,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn",
 ]
 
 [[package]]
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -136,9 +136,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bytes"
@@ -148,9 +148,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
 dependencies = [
  "jobserver",
  "libc",
@@ -187,22 +187,22 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "equivalent"
@@ -272,7 +272,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn",
 ]
 
 [[package]]
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "h2"
@@ -383,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -395,9 +395,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "matchit"
@@ -503,9 +503,9 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -515,9 +515,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -576,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -597,9 +597,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -641,7 +641,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn",
 ]
 
 [[package]]
@@ -670,9 +670,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -697,7 +697,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn",
 ]
 
 [[package]]
@@ -741,11 +741,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -875,7 +875,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -900,29 +900,29 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -971,20 +971,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1014,14 +1003,14 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1048,13 +1037,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn",
 ]
 
 [[package]]
@@ -1174,7 +1163,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn",
 ]
 
 [[package]]
@@ -1206,9 +1195,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "getrandom",
 ]
@@ -1394,9 +1383,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
+version = "2.0.11+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
 dependencies = [
  "cc",
  "pkg-config",

--- a/example/rust/Cargo.toml
+++ b/example/rust/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/docs_examples/docs_examples.rs"
 
 [dependencies]
 futures = "0.3.30"
-momento = { version = "0.41.0" }
+momento = { version = "0.41.1" }
 tokio = { version = "1.37.0", features = ["full"] }
 uuid = { version = "1.8.0", features = ["v4"] }
 anyhow = "1"

--- a/example/rust/src/bin/storage.rs
+++ b/example/rust/src/bin/storage.rs
@@ -24,11 +24,10 @@ async fn main() -> Result<(), MomentoError> {
 
     // List all stores and validate my_momento_store was created
     let list_stores_response = storage_client.list_stores().await?;
-    if list_stores_response
+    if !list_stores_response
         .stores
         .iter()
         .any(|x| x.name == store_name)
-        == false
     {
         eprintln!("{store_name} was not created");
         process::exit(1);
@@ -51,11 +50,8 @@ async fn main() -> Result<(), MomentoError> {
 
     // Get the key from store and validate it got persisted
     match storage_client.get(store_name, key).await {
-        Ok(res) => match res.value {
-            Some(val) => {
-                println!("Key {key} found in {store_name} with value {val}");
-            }
-            None => {}
+        Ok(res) => if let Some(val) = res.value {
+            println!("Key {key} found in {store_name} with value {val}");
         },
         Err(err) => {
             eprint!("error while getting key: {err}");
@@ -76,12 +72,9 @@ async fn main() -> Result<(), MomentoError> {
 
     // Get the key from storage and validate it doesn't exist
     match storage_client.get(store_name, key).await {
-        Ok(res) => match res.value {
-            Some(val) => {
-                eprint!("Key {key} should have been deleted; instead got value as {val}");
-                process::exit(1);
-            }
-            None => {}
+        Ok(res) => if let Some(val) = res.value {
+            eprint!("Key {key} should have been deleted; instead got value as {val}");    
+            process::exit(1);    
         },
         Err(err) => {
             eprint!("error while getting key: {err}");
@@ -96,7 +89,6 @@ async fn main() -> Result<(), MomentoError> {
         .stores
         .iter()
         .any(|x| x.name == store_name)
-        == true
     {
         eprintln!("{store_name} was not deleted");
         process::exit(1);

--- a/example/rust/src/bin/storage.rs
+++ b/example/rust/src/bin/storage.rs
@@ -53,6 +53,9 @@ async fn main() -> Result<(), MomentoError> {
         Ok(res) => {
             if let Some(val) = res.value {
                 println!("Key {key} found in {store_name} with value {val}");
+            } else {
+                eprintln!("Key {key} was not found!");
+                process::exit(1);
             }
         }
         Err(err) => {
@@ -86,8 +89,10 @@ async fn main() -> Result<(), MomentoError> {
         }
     }
 
+    // Delete store
     storage_client.delete_store(store_name).await?;
 
+    // Validate store was deleted
     let list_stores_response = storage_client.list_stores().await?;
     if list_stores_response
         .stores

--- a/example/rust/src/bin/storage.rs
+++ b/example/rust/src/bin/storage.rs
@@ -50,9 +50,11 @@ async fn main() -> Result<(), MomentoError> {
 
     // Get the key from store and validate it got persisted
     match storage_client.get(store_name, key).await {
-        Ok(res) => if let Some(val) = res.value {
-            println!("Key {key} found in {store_name} with value {val}");
-        },
+        Ok(res) => {
+            if let Some(val) = res.value {
+                println!("Key {key} found in {store_name} with value {val}");
+            }
+        }
         Err(err) => {
             eprint!("error while getting key: {err}");
             process::exit(1);
@@ -72,10 +74,12 @@ async fn main() -> Result<(), MomentoError> {
 
     // Get the key from storage and validate it doesn't exist
     match storage_client.get(store_name, key).await {
-        Ok(res) => if let Some(val) = res.value {
-            eprint!("Key {key} should have been deleted; instead got value as {val}");    
-            process::exit(1);    
-        },
+        Ok(res) => {
+            if let Some(val) = res.value {
+                eprint!("Key {key} should have been deleted; instead got value as {val}");
+                process::exit(1);
+            }
+        }
         Err(err) => {
             eprint!("error while getting key: {err}");
             process::exit(1);

--- a/example/rust/src/bin/storage.rs
+++ b/example/rust/src/bin/storage.rs
@@ -24,7 +24,12 @@ async fn main() -> Result<(), MomentoError> {
 
     // List all stores and validate my_momento_store was created
     let list_stores_response = storage_client.list_stores().await?;
-    if list_stores_response.stores.iter().any(|x| { x.name == store_name}) == false {
+    if list_stores_response
+        .stores
+        .iter()
+        .any(|x| x.name == store_name)
+        == false
+    {
         eprintln!("{store_name} was not created");
         process::exit(1);
     }
@@ -46,14 +51,12 @@ async fn main() -> Result<(), MomentoError> {
 
     // Get the key from store and validate it got persisted
     match storage_client.get(store_name, key).await {
-        Ok(res) => {
-            match res.value {
-                Some(val) => {
-                    println!("Key {key} found in {store_name} with value {val}");
-                },
-                None => {},
+        Ok(res) => match res.value {
+            Some(val) => {
+                println!("Key {key} found in {store_name} with value {val}");
             }
-        }
+            None => {}
+        },
         Err(err) => {
             eprint!("error while getting key: {err}");
             process::exit(1);
@@ -64,34 +67,37 @@ async fn main() -> Result<(), MomentoError> {
     match storage_client.delete(store_name, key).await {
         Ok(_) => {
             println!("Key {key} was successfully deleted from {store_name}");
-        },
+        }
         Err(err) => {
             eprint!("error while deleting key: {err}");
             process::exit(1);
         }
     }
 
-     // Get the key from storage and validate it doesn't exist
-     match storage_client.get(store_name, key).await {
-        Ok(res) => {
-            match res.value {
-                Some(val) => {
-                    eprint!("Key {key} should have been deleted; instead got value as {val}");
-                    process::exit(1);
-                },
-                None => {},
+    // Get the key from storage and validate it doesn't exist
+    match storage_client.get(store_name, key).await {
+        Ok(res) => match res.value {
+            Some(val) => {
+                eprint!("Key {key} should have been deleted; instead got value as {val}");
+                process::exit(1);
             }
-        }
+            None => {}
+        },
         Err(err) => {
             eprint!("error while getting key: {err}");
             process::exit(1);
         }
     }
-    
+
     storage_client.delete_store(store_name).await?;
 
     let list_stores_response = storage_client.list_stores().await?;
-    if list_stores_response.stores.iter().any(|x| { x.name == store_name}) == true {
+    if list_stores_response
+        .stores
+        .iter()
+        .any(|x| x.name == store_name)
+        == true
+    {
         eprintln!("{store_name} was not deleted");
         process::exit(1);
     }

--- a/example/rust/src/bin/storage.rs
+++ b/example/rust/src/bin/storage.rs
@@ -1,0 +1,102 @@
+use std::process;
+
+use momento::{storage::configurations, CredentialProvider, MomentoError, PreviewStorageClient};
+
+#[tokio::main]
+async fn main() -> Result<(), MomentoError> {
+    let storage_client = match PreviewStorageClient::builder()
+        .configuration(configurations::Laptop::latest())
+        .credential_provider(
+            CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())
+                .expect("auth token should be valid"),
+        )
+        .build()
+    {
+        Ok(client) => client,
+        Err(err) => {
+            eprintln!("{err}");
+            process::exit(1);
+        }
+    };
+
+    let store_name = "my_momento_store";
+    storage_client.create_store(store_name).await?;
+
+    // List all stores and validate my_momento_store was created
+    let list_stores_response = storage_client.list_stores().await?;
+    if list_stores_response.stores.iter().any(|x| { x.name == store_name}) == false {
+        eprintln!("{store_name} was not created");
+        process::exit(1);
+    }
+    println!("{store_name} was created");
+
+    let key = "foo";
+    let value = "bar";
+
+    // Put a key in store
+    match storage_client.put(store_name, key, value).await {
+        Ok(_) => {
+            println!("Key {key} was successfully persisted in {store_name}");
+        }
+        Err(err) => {
+            eprintln!("Failed to persist key {key} in {store_name}: {err}");
+            process::exit(1);
+        }
+    }
+
+    // Get the key from store and validate it got persisted
+    match storage_client.get(store_name, key).await {
+        Ok(res) => {
+            match res.value {
+                Some(val) => {
+                    println!("Key {key} found in {store_name} with value {val}");
+                },
+                None => {},
+            }
+        }
+        Err(err) => {
+            eprint!("error while getting key: {err}");
+            process::exit(1);
+        }
+    }
+
+    // Delete the key from storage
+    match storage_client.delete(store_name, key).await {
+        Ok(_) => {
+            println!("Key {key} was successfully deleted from {store_name}");
+        },
+        Err(err) => {
+            eprint!("error while deleting key: {err}");
+            process::exit(1);
+        }
+    }
+
+     // Get the key from storage and validate it doesn't exist
+     match storage_client.get(store_name, key).await {
+        Ok(res) => {
+            match res.value {
+                Some(val) => {
+                    eprint!("Key {key} should have been deleted; instead got value as {val}");
+                    process::exit(1);
+                },
+                None => {},
+            }
+        }
+        Err(err) => {
+            eprint!("error while getting key: {err}");
+            process::exit(1);
+        }
+    }
+    
+    storage_client.delete_store(store_name).await?;
+
+    let list_stores_response = storage_client.list_stores().await?;
+    if list_stores_response.stores.iter().any(|x| { x.name == store_name}) == true {
+        eprintln!("{store_name} was not deleted");
+        process::exit(1);
+    }
+
+    println!("Store was deleted");
+
+    Ok(())
+}

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "momento-test-util"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "anyhow",
  "momento",

--- a/sdk/tests/cache/control.rs
+++ b/sdk/tests/cache/control.rs
@@ -12,7 +12,7 @@ mod create_delete_list_cache {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = unique_cache_name();
         let result = client.delete_cache(cache_name).await.unwrap_err();
-        assert_eq!(result.error_code, MomentoErrorCode::CacheNotFoundError);
+        assert_eq!(result.error_code, MomentoErrorCode::StoreNotFoundError);
         Ok(())
     }
 

--- a/sdk/tests/cache/control.rs
+++ b/sdk/tests/cache/control.rs
@@ -12,7 +12,7 @@ mod create_delete_list_cache {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = unique_cache_name();
         let result = client.delete_cache(cache_name).await.unwrap_err();
-        assert_eq!(result.error_code, MomentoErrorCode::StoreNotFoundError);
+        assert_eq!(result.error_code, MomentoErrorCode::CacheNotFoundError);
         Ok(())
     }
 


### PR DESCRIPTION
I may have to leave the bug bash a little early so started early with the Rust SDK. This might have been in your backlog/WIP already but since I was about to follow examples pattern anyway, just decided to PR it.

Note that I did NOT update the CI workflows to run this due to alpha instability.

```
my_momento_store was created
Key foo was successfully persisted in my_momento_store
Key foo found in my_momento_store with value String("bar")
Key foo was successfully deleted from my_momento_store
Store was deleted
```