### PR TITLE
fix: export StorageValue and align the exports with the cache client.

### DIFF
--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "momento-test-util"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "momento",

--- a/sdk/src/errors.rs
+++ b/sdk/src/errors.rs
@@ -219,7 +219,7 @@ pub(crate) fn status_to_error(status: tonic::Status) -> MomentoError {
                                 inner_error: Some(status.clone().into()),
                                 details: Some(status.into())
                             },
-                            "element_not_found" => MomentoError {
+                            "item_not_found" => MomentoError {
                                 message: "An item with the specified key does not exist.  To resolve this error, make sure you have created the item before attempting to use it".into(),
                                 error_code: MomentoErrorCode::ItemNotFoundError,
                                 inner_error: Some(status.clone().into()),

--- a/sdk/src/storage/messages/control/create_store.rs
+++ b/sdk/src/storage/messages/control/create_store.rs
@@ -2,7 +2,7 @@ use momento_protos::control_client;
 use tonic::Request;
 
 use crate::status_to_error;
-use crate::storage::messages::momento_store_request::MomentoStorageRequest;
+use crate::storage::messages::momento_storage_request::MomentoStorageRequest;
 use crate::storage::PreviewStorageClient;
 use crate::{utils, MomentoResult};
 

--- a/sdk/src/storage/messages/control/delete_store.rs
+++ b/sdk/src/storage/messages/control/delete_store.rs
@@ -1,7 +1,7 @@
 use momento_protos::control_client;
 use tonic::Request;
 
-use crate::storage::messages::momento_store_request::MomentoStorageRequest;
+use crate::storage::messages::momento_storage_request::MomentoStorageRequest;
 use crate::storage::PreviewStorageClient;
 use crate::{utils, MomentoResult};
 

--- a/sdk/src/storage/messages/control/list_stores.rs
+++ b/sdk/src/storage/messages/control/list_stores.rs
@@ -1,7 +1,7 @@
 use momento_protos::control_client;
 use tonic::Request;
 
-use crate::storage::messages::momento_store_request::MomentoStorageRequest;
+use crate::storage::messages::momento_storage_request::MomentoStorageRequest;
 use crate::storage::PreviewStorageClient;
 use crate::MomentoResult;
 

--- a/sdk/src/storage/messages/control/mod.rs
+++ b/sdk/src/storage/messages/control/mod.rs
@@ -1,3 +1,6 @@
+/// Contains the request and response types for creating a store.
 pub mod create_store;
+/// Contains the request and response types for deleting a store.
 pub mod delete_store;
+/// Contains the request and response types for listing the stores in your account.
 pub mod list_stores;

--- a/sdk/src/storage/messages/data/delete.rs
+++ b/sdk/src/storage/messages/data/delete.rs
@@ -1,4 +1,4 @@
-use crate::storage::messages::momento_store_request::MomentoStorageRequest;
+use crate::storage::messages::momento_storage_request::MomentoStorageRequest;
 use crate::storage::PreviewStorageClient;
 use crate::utils::prep_storage_request_with_timeout;
 use crate::MomentoResult;

--- a/sdk/src/storage/messages/data/get.rs
+++ b/sdk/src/storage/messages/data/get.rs
@@ -1,5 +1,5 @@
-use crate::storage::messages::momento_store_request::MomentoStorageRequest;
-use crate::storage::messages::store_value::StoreValue;
+use crate::storage::messages::momento_storage_request::MomentoStorageRequest;
+use crate::storage::messages::storage_value::StorageValue;
 use crate::storage::PreviewStorageClient;
 use crate::{utils, MomentoErrorCode};
 use crate::{MomentoError, MomentoResult};
@@ -123,7 +123,7 @@ impl MomentoStorageRequest for GetRequest {
 #[derive(Debug, PartialEq, Clone)]
 pub struct GetResponse {
     /// The value of the item.
-    pub value: Option<StoreValue>,
+    pub value: Option<StorageValue>,
 }
 
 fn not_found_error() -> MomentoError {
@@ -135,7 +135,7 @@ fn not_found_error() -> MomentoError {
     }
 }
 
-impl<I: Into<StoreValue>> From<I> for GetResponse {
+impl<I: Into<StorageValue>> From<I> for GetResponse {
     fn from(value: I) -> Self {
         GetResponse {
             value: Some(value.into()),

--- a/sdk/src/storage/messages/data/mod.rs
+++ b/sdk/src/storage/messages/data/mod.rs
@@ -1,3 +1,6 @@
+/// Contains the request and response types for deleting an item from a store.
 pub mod delete;
+/// Contains the request and response types for getting an item from a store.
 pub mod get;
+/// Contains the request and response types for putting an item in a store.
 pub mod put;

--- a/sdk/src/storage/messages/data/put.rs
+++ b/sdk/src/storage/messages/data/put.rs
@@ -1,5 +1,5 @@
-use crate::storage::messages::momento_store_request::MomentoStorageRequest;
-use crate::storage::messages::store_value::StoreValue;
+use crate::storage::messages::momento_storage_request::MomentoStorageRequest;
+use crate::storage::messages::storage_value::StorageValue;
 use crate::storage::PreviewStorageClient;
 use crate::utils::prep_storage_request_with_timeout;
 use crate::MomentoResult;
@@ -45,7 +45,7 @@ use crate::MomentoResult;
 pub struct PutRequest {
     store_name: String,
     key: String,
-    value: StoreValue,
+    value: StorageValue,
 }
 
 impl PutRequest {
@@ -53,7 +53,7 @@ impl PutRequest {
     pub fn new(
         store_name: impl Into<String>,
         key: impl Into<String>,
-        value: impl Into<StoreValue>,
+        value: impl Into<StorageValue>,
     ) -> Self {
         Self {
             store_name: store_name.into(),

--- a/sdk/src/storage/messages/mod.rs
+++ b/sdk/src/storage/messages/mod.rs
@@ -1,7 +1,7 @@
-/// Control messages for storage
+/// Control plane messages for storage
 pub mod control;
 
-/// Data messages for storage
+/// Data plane messages for storage
 pub mod data;
 mod momento_storage_request;
 pub use momento_storage_request::MomentoStorageRequest;

--- a/sdk/src/storage/messages/mod.rs
+++ b/sdk/src/storage/messages/mod.rs
@@ -1,5 +1,9 @@
+/// Control messages for storage
 pub mod control;
 
+/// Data messages for storage
 pub mod data;
-pub mod momento_store_request;
-pub mod store_value;
+mod momento_storage_request;
+pub use momento_storage_request::MomentoStorageRequest;
+mod storage_value;
+pub use storage_value::StorageValue;

--- a/sdk/src/storage/messages/momento_storage_request.rs
+++ b/sdk/src/storage/messages/momento_storage_request.rs
@@ -1,12 +1,12 @@
 use crate::storage::PreviewStorageClient;
 use crate::MomentoResult;
 
-/// A trait that allows Momento request types to define their interaction with the gRPC client.
+/// A trait that allows Momento storage request types to define their interaction with the gRPC client.
 pub trait MomentoStorageRequest {
     #[allow(missing_docs)]
     type Response;
 
-    /// An internal fn that allows Momento request types to define their interaction with
+    /// An internal fn that allows Momento storage request types to define their interaction with
     /// the gRPC client. You can impl this fn for your own types if you'd like to hand them
     /// to the Momento client directly, but that is not an explicitly supported scenario and
     /// this signature may change a little over time. If that's okay with you, impl away!

--- a/sdk/src/storage/messages/storage_value.rs
+++ b/sdk/src/storage/messages/storage_value.rs
@@ -1,126 +1,131 @@
 use std::convert::{TryFrom, TryInto};
 
-use momento_protos::store;
 use momento_protos::store::store_value::Value;
+use momento_protos::store::StoreValue;
 
 use crate::{MomentoError, MomentoErrorCode};
 
+/// An enum representing an item in a Momento store.
 #[derive(Debug, Clone, PartialEq)]
-pub enum StoreValue {
+pub enum StorageValue {
+    /// A storage value containing a byte array.
     Bytes(Vec<u8>),
+    /// A storage value containing a string.
     String(String),
+    /// A storage value containing a 64-bit integer.
     Integer(i64),
+    /// A storage value containing a double.
     Double(f64),
 }
 
-impl From<Vec<u8>> for StoreValue {
+impl From<Vec<u8>> for StorageValue {
     fn from(bytes: Vec<u8>) -> Self {
-        StoreValue::Bytes(bytes)
+        StorageValue::Bytes(bytes)
     }
 }
 
-impl From<&[u8]> for StoreValue {
+impl From<&[u8]> for StorageValue {
     fn from(bytes: &[u8]) -> Self {
-        StoreValue::Bytes(bytes.to_vec())
+        StorageValue::Bytes(bytes.to_vec())
     }
 }
 
-impl From<String> for StoreValue {
+impl From<String> for StorageValue {
     fn from(string: String) -> Self {
-        StoreValue::String(string)
+        StorageValue::String(string)
     }
 }
 
-impl From<&str> for StoreValue {
+impl From<&str> for StorageValue {
     fn from(string: &str) -> Self {
-        StoreValue::String(string.to_string())
+        StorageValue::String(string.to_string())
     }
 }
 
-impl From<&String> for StoreValue {
+impl From<&String> for StorageValue {
     fn from(string: &String) -> Self {
-        StoreValue::String(string.clone())
+        StorageValue::String(string.clone())
     }
 }
 
-impl From<i64> for StoreValue {
+impl From<i64> for StorageValue {
     fn from(integer: i64) -> Self {
-        StoreValue::Integer(integer)
+        StorageValue::Integer(integer)
     }
 }
 
-impl From<&i64> for StoreValue {
+impl From<&i64> for StorageValue {
     fn from(integer: &i64) -> Self {
-        StoreValue::Integer(*integer)
+        StorageValue::Integer(*integer)
     }
 }
 
-impl From<i32> for StoreValue {
+impl From<i32> for StorageValue {
     fn from(integer: i32) -> Self {
-        StoreValue::Integer(integer as i64)
+        StorageValue::Integer(integer as i64)
     }
 }
 
-impl From<&i32> for StoreValue {
+impl From<&i32> for StorageValue {
     fn from(integer: &i32) -> Self {
-        StoreValue::Integer(*integer as i64)
+        StorageValue::Integer(*integer as i64)
     }
 }
 
-impl From<f64> for StoreValue {
+impl From<f64> for StorageValue {
     fn from(double: f64) -> Self {
-        StoreValue::Double(double)
+        StorageValue::Double(double)
     }
 }
 
-impl From<&f64> for StoreValue {
+impl From<&f64> for StorageValue {
     fn from(double: &f64) -> Self {
-        StoreValue::Double(*double)
+        StorageValue::Double(*double)
     }
 }
 
-impl From<Value> for StoreValue {
+impl From<Value> for StorageValue {
     fn from(value: Value) -> Self {
         match value {
-            Value::BytesValue(bytes) => StoreValue::Bytes(bytes),
-            Value::StringValue(string) => StoreValue::String(string),
-            Value::IntegerValue(integer) => StoreValue::Integer(integer),
-            Value::DoubleValue(double) => StoreValue::Double(double),
+            Value::BytesValue(bytes) => StorageValue::Bytes(bytes),
+            Value::StringValue(string) => StorageValue::String(string),
+            Value::IntegerValue(integer) => StorageValue::Integer(integer),
+            Value::DoubleValue(double) => StorageValue::Double(double),
         }
     }
 }
 
-impl From<StoreValue> for store::StoreValue {
-    fn from(value: StoreValue) -> store::StoreValue {
+impl From<StorageValue> for StoreValue {
+    fn from(value: StorageValue) -> StoreValue {
         match value {
-            StoreValue::Bytes(bytes) => store::StoreValue {
+            StorageValue::Bytes(bytes) => StoreValue {
                 value: Some(Value::BytesValue(bytes)),
             },
-            StoreValue::String(string) => store::StoreValue {
+            StorageValue::String(string) => StoreValue {
                 value: Some(Value::StringValue(string)),
             },
-            StoreValue::Integer(integer) => store::StoreValue {
+            StorageValue::Integer(integer) => StoreValue {
                 value: Some(Value::IntegerValue(integer)),
             },
-            StoreValue::Double(double) => store::StoreValue {
+            StorageValue::Double(double) => StoreValue {
                 value: Some(Value::DoubleValue(double)),
             },
         }
     }
 }
 
-impl std::fmt::Display for StoreValue {
+impl std::fmt::Display for StorageValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
     }
 }
 
-impl TryFrom<StoreValue> for Vec<u8> {
+impl TryFrom<StorageValue> for Vec<u8> {
     type Error = MomentoError;
 
-    fn try_from(value: StoreValue) -> Result<Self, Self::Error> {
+    fn try_from(value: StorageValue) -> Result<Self, Self::Error> {
         match value {
-            StoreValue::Bytes(s) => Ok(s),
+            StorageValue::Bytes(s) => Ok(s),
             _ => Err(MomentoError {
                 message: "item is not a byte array".to_string(),
                 error_code: MomentoErrorCode::TypeError,
@@ -131,12 +136,12 @@ impl TryFrom<StoreValue> for Vec<u8> {
     }
 }
 
-impl TryFrom<StoreValue> for String {
+impl TryFrom<StorageValue> for String {
     type Error = MomentoError;
 
-    fn try_from(value: StoreValue) -> Result<Self, Self::Error> {
+    fn try_from(value: StorageValue) -> Result<Self, Self::Error> {
         match value {
-            StoreValue::String(s) => Ok(s),
+            StorageValue::String(s) => Ok(s),
             _ => Err(MomentoError {
                 message: "item is not a utf-8 string".to_string(),
                 error_code: MomentoErrorCode::TypeError,
@@ -147,12 +152,12 @@ impl TryFrom<StoreValue> for String {
     }
 }
 
-impl TryFrom<StoreValue> for i64 {
+impl TryFrom<StorageValue> for i64 {
     type Error = MomentoError;
 
-    fn try_from(value: StoreValue) -> Result<Self, Self::Error> {
+    fn try_from(value: StorageValue) -> Result<Self, Self::Error> {
         match value {
-            StoreValue::Integer(s) => Ok(s),
+            StorageValue::Integer(s) => Ok(s),
             _ => Err(MomentoError {
                 message: "item is not an i64".to_string(),
                 error_code: MomentoErrorCode::TypeError,
@@ -163,12 +168,12 @@ impl TryFrom<StoreValue> for i64 {
     }
 }
 
-impl TryFrom<StoreValue> for i32 {
+impl TryFrom<StorageValue> for i32 {
     type Error = MomentoError;
 
-    fn try_from(value: StoreValue) -> Result<Self, Self::Error> {
+    fn try_from(value: StorageValue) -> Result<Self, Self::Error> {
         match value {
-            StoreValue::Integer(s) => match s.try_into() {
+            StorageValue::Integer(s) => match s.try_into() {
                 Ok(converted) => Ok(converted),
                 Err(_) => Err(MomentoError {
                     message: "item is out of range for i32".to_string(),
@@ -187,12 +192,12 @@ impl TryFrom<StoreValue> for i32 {
     }
 }
 
-impl TryFrom<StoreValue> for f64 {
+impl TryFrom<StorageValue> for f64 {
     type Error = MomentoError;
 
-    fn try_from(value: StoreValue) -> Result<Self, Self::Error> {
+    fn try_from(value: StorageValue) -> Result<Self, Self::Error> {
         match value {
-            StoreValue::Double(s) => Ok(s),
+            StorageValue::Double(s) => Ok(s),
             _ => Err(MomentoError {
                 message: "item is not an f64".to_string(),
                 error_code: MomentoErrorCode::TypeError,
@@ -203,12 +208,12 @@ impl TryFrom<StoreValue> for f64 {
     }
 }
 
-impl TryFrom<StoreValue> for f32 {
+impl TryFrom<StorageValue> for f32 {
     type Error = MomentoError;
 
-    fn try_from(value: StoreValue) -> Result<Self, Self::Error> {
+    fn try_from(value: StorageValue) -> Result<Self, Self::Error> {
         match value {
-            StoreValue::Double(s) => {
+            StorageValue::Double(s) => {
                 let converted: f32 = s as f32;
                 if converted.is_infinite() && s.is_finite() {
                     Err(MomentoError {

--- a/sdk/src/storage/mod.rs
+++ b/sdk/src/storage/mod.rs
@@ -1,15 +1,26 @@
-pub use config::configuration::Configuration;
-pub use config::configurations;
+/// Contains the request and response types for storage operations.
+pub mod messages;
+
+pub use messages::MomentoStorageRequest;
+pub use messages::StorageValue;
+
 pub use messages::control::create_store::{CreateStoreRequest, CreateStoreResponse};
 pub use messages::control::delete_store::{DeleteStoreRequest, DeleteStoreResponse};
 pub use messages::control::list_stores::{ListStoresRequest, ListStoresResponse, StoreInfo};
+
 pub use messages::data::delete::{DeleteRequest, DeleteResponse};
 pub use messages::data::get::{GetRequest, GetResponse};
 pub use messages::data::put::{PutRequest, PutResponse};
-pub use preview_storage_client::PreviewStorageClient;
 
+// Similar re-exporting with config::configuration and config::configurations
+// so import paths can be simplified to "momento::storage::Configuration" and
+// "use momento::storage::configurations::laptop"
 mod config;
+
+pub use config::configuration::Configuration;
+pub use config::configurations;
+
 mod preview_storage_client;
 mod preview_storage_client_builder;
 
-mod messages;
+pub use preview_storage_client::PreviewStorageClient;

--- a/sdk/src/storage/preview_storage_client.rs
+++ b/sdk/src/storage/preview_storage_client.rs
@@ -4,16 +4,14 @@ use tonic::codegen::InterceptedService;
 use tonic::transport::Channel;
 
 use crate::grpc::header_interceptor::HeaderInterceptor;
-use crate::storage::messages::control::create_store::{CreateStoreRequest, CreateStoreResponse};
-use crate::storage::messages::control::delete_store::{DeleteStoreRequest, DeleteStoreResponse};
-use crate::storage::messages::control::list_stores::{ListStoresRequest, ListStoresResponse};
-use crate::storage::messages::data::get::{GetRequest, GetResponse};
-use crate::storage::messages::momento_store_request::MomentoStorageRequest;
-use crate::storage::messages::store_value::StoreValue;
 use crate::storage::preview_storage_client_builder::{
     NeedsConfiguration, PreviewStorageClientBuilder,
 };
-use crate::storage::{Configuration, DeleteRequest, DeleteResponse, PutRequest, PutResponse};
+use crate::storage::{
+    Configuration, CreateStoreRequest, CreateStoreResponse, DeleteRequest, DeleteResponse,
+    DeleteStoreRequest, DeleteStoreResponse, GetRequest, GetResponse, ListStoresRequest,
+    ListStoresResponse, MomentoStorageRequest, PutRequest, PutResponse, StorageValue,
+};
 use crate::MomentoResult;
 
 /// Preview client to work with Momento Storage.
@@ -212,7 +210,7 @@ impl PreviewStorageClient {
         &self,
         store_name: impl Into<String>,
         key: impl Into<String>,
-        value: impl Into<StoreValue>,
+        value: impl Into<StorageValue>,
     ) -> MomentoResult<PutResponse> {
         let request = PutRequest::new(store_name, key, value);
         request.send(self).await


### PR DESCRIPTION
Rename StoreValue to StorageValue.

Export StorageValue so it can be matched on.

Bring the storage client exports in line with the cache client exports.

Match on item_not_found instead of element_not_found.

Add doc strings for the now public modules and files.