### PR TITLE
chore: fix failing test for StoreNotFound

### DIFF
--- a/sdk/tests/storage/control.rs
+++ b/sdk/tests/storage/control.rs
@@ -12,7 +12,7 @@ mod create_delete_list_store {
         let client = &CACHE_TEST_STATE.storage_client;
         let store_name = unique_store_name();
         let result = client.delete_store(store_name).await.unwrap_err();
-        assert_eq!(result.error_code, MomentoErrorCode::CacheNotFoundError);
+        assert_eq!(result.error_code, MomentoErrorCode::StoreNotFoundError);
         Ok(())
     }
 


### PR DESCRIPTION
I think this test behavior might have changed when the error metadata on the server changed.