### PR TITLE
chore: adjust agent header value per spec

### DIFF
--- a/sdk/src/cache/cache_client_builder.rs
+++ b/sdk/src/cache/cache_client_builder.rs
@@ -59,7 +59,7 @@ impl CacheClientBuilder<NeedsCredentialProvider> {
 
 impl CacheClientBuilder<ReadyToBuild> {
     pub fn build(self) -> MomentoResult<CacheClient> {
-        let agent_value = &utils::user_agent("sdk");
+        let agent_value = &utils::user_agent("cache");
 
         let data_channel = utils::connect_channel_lazily_configurable(
             &self.0.credential_provider.cache_endpoint,

--- a/sdk/src/storage/preview_storage_client_builder.rs
+++ b/sdk/src/storage/preview_storage_client_builder.rs
@@ -44,7 +44,7 @@ impl PreviewStorageClientBuilder<NeedsCredentialProvider> {
 
 impl PreviewStorageClientBuilder<ReadyToBuild> {
     pub fn build(self) -> MomentoResult<PreviewStorageClient> {
-        let agent_value = &utils::user_agent("sdk");
+        let agent_value = &utils::user_agent("store");
 
         let data_channel = utils::connect_channel_lazily_configurable(
             &self.0.credential_provider.storage_endpoint,

--- a/sdk/src/topics/topic_client_builder.rs
+++ b/sdk/src/topics/topic_client_builder.rs
@@ -46,7 +46,7 @@ impl TopicClientBuilder<NeedsCredentialProvider> {
 
 impl TopicClientBuilder<ReadyToBuild> {
     pub fn build(self) -> MomentoResult<TopicClient> {
-        let agent_value = &utils::user_agent("sdk");
+        let agent_value = &utils::user_agent("topic");
         let channel = connect_channel_lazily(&self.0.credential_provider.cache_endpoint)?;
         let authorized_channel = InterceptedService::new(
             channel,

--- a/sdk/src/utils.rs
+++ b/sdk/src/utils.rs
@@ -170,7 +170,7 @@ pub(crate) fn connect_channel_lazily_configurable(
 }
 
 pub(crate) fn user_agent(user_agent_name: &str) -> String {
-    format!("rust-{user_agent_name}:{VERSION}")
+    format!("rust:{user_agent_name}:{VERSION}")
 }
 
 pub(crate) fn parse_string(raw: Vec<u8>) -> MomentoResult<String> {
@@ -352,8 +352,8 @@ mod tests {
 
     #[test]
     fn test_user_agent() {
-        let user_agent_name = "my_app";
-        let expected_user_agent = format!("rust-{user_agent_name}:{VERSION}");
+        let user_agent_name = "cache";
+        let expected_user_agent = format!("rust:{user_agent_name}:{VERSION}");
         let result = user_agent(user_agent_name);
         assert_eq!(result, expected_user_agent);
     }


### PR DESCRIPTION
Adjust agent header value to be colon delimited and to supply the
service name. Verified the header is sent only once.

As far as the `runtime-version` header goes, this does not make as
much sense for rust. Rust is a compiled language and does not have
an associated runtime (as in `golang`). If we do we want to include
something here, we could include the rust compiler version, though
we believe that would be uncommon.