### PR TITLE
chore: send sentinel value for `runtime-version` header

### DIFF
--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.41.1"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "momento-test-util"
-version = "0.41.1"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "momento",

--- a/sdk/src/grpc/header_interceptor.rs
+++ b/sdk/src/grpc/header_interceptor.rs
@@ -1,4 +1,5 @@
 use std::convert::TryFrom;
+use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 #[derive(Clone)]
@@ -23,41 +24,54 @@ impl tonic::service::Interceptor for HeaderInterceptor {
     ) -> Result<tonic::Request<()>, tonic::Status> {
         static ARE_ONLY_ONCE_HEADER_SENT: AtomicBool = AtomicBool::new(false);
 
-        let auth_token =
-            tonic::metadata::AsciiMetadataValue::try_from(&self.auth_token).map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::InvalidArgument,
-                    format!("Couldn't parse auth token for auth header: {}", e),
-                )
-            })?;
-
-        request.metadata_mut().insert(
-            tonic::metadata::AsciiMetadataKey::from_static("authorization"),
-            auth_token,
-        );
-
-        let sdk_agent =
-            tonic::metadata::AsciiMetadataValue::try_from(&self.sdk_agent).map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::InvalidArgument,
-                    format!("Couldn't parse sdk agent for agent header: {}", e),
-                )
-            })?;
+        let (auth_header_name, auth_header_value) =
+            create_header_from_string("authorization", &self.auth_token)?;
+        request
+            .metadata_mut()
+            .insert(auth_header_name, auth_header_value);
 
         if !ARE_ONLY_ONCE_HEADER_SENT.load(Ordering::Relaxed) {
-            request.metadata_mut().insert(
-                tonic::metadata::AsciiMetadataKey::from_static("agent"),
-                sdk_agent,
-            );
+            let (agent_header_name, agent_header_value) =
+                create_header_from_string("agent", &self.sdk_agent)?;
+            request
+                .metadata_mut()
+                .insert(agent_header_name, agent_header_value);
+
             // Because the `runtime-version` header makes more sense for interpreted languages,
             // we send this sentinel value to ensure we report *some* value for this sdk.
-            request.metadata_mut().insert(
-                tonic::metadata::AsciiMetadataKey::from_static("runtime-version"),
-                "rust".parse().unwrap(),
-            );
+            let (runtime_version_header_name, runtime_version_header_value) =
+                create_header_from_string("runtime-version", "rust")?;
+            request
+                .metadata_mut()
+                .insert(runtime_version_header_name, runtime_version_header_value);
             ARE_ONLY_ONCE_HEADER_SENT.store(true, Ordering::Relaxed);
         }
 
         Ok(request)
     }
+}
+
+fn create_header_from_string(
+    name: &str,
+    value: &str,
+) -> Result<
+    (
+        tonic::metadata::AsciiMetadataKey,
+        tonic::metadata::AsciiMetadataValue,
+    ),
+    tonic::Status,
+> {
+    let header_name = tonic::metadata::AsciiMetadataKey::from_str(name).map_err(|e| {
+        tonic::Status::new(
+            tonic::Code::InvalidArgument,
+            format!("Couldn't parse header name {}: {}", name, e),
+        )
+    })?;
+    let header_value = tonic::metadata::AsciiMetadataValue::try_from(value).map_err(|e| {
+        tonic::Status::new(
+            tonic::Code::InvalidArgument,
+            format!("Couldn't parse header value for {}: {}", name, e),
+        )
+    })?;
+    Ok((header_name, header_value))
 }

--- a/sdk/src/grpc/header_interceptor.rs
+++ b/sdk/src/grpc/header_interceptor.rs
@@ -49,6 +49,12 @@ impl tonic::service::Interceptor for HeaderInterceptor {
                 tonic::metadata::AsciiMetadataKey::from_static("agent"),
                 sdk_agent,
             );
+            // Because the `runtime-version` header makes more sense for interpreted languages,
+            // we send this sentinel value to ensure we report *some* value for this sdk.
+            request.metadata_mut().insert(
+                tonic::metadata::AsciiMetadataKey::from_static("runtime-version"),
+                "rust".parse().unwrap(),
+            );
             ARE_ONLY_ONCE_HEADER_SENT.store(true, Ordering::Relaxed);
         }
 


### PR DESCRIPTION
Because rust does not have a runtime, we send a sentinel value `rust`
for the header so that the server metrics at least have a stub value.

Also simplifies header creation and insertion with utility functions. This 
reduces code duplication.