### PR TITLE
refactor: lazily initialize control client

### DIFF
--- a/sdk/src/cache/cache_client.rs
+++ b/sdk/src/cache/cache_client.rs
@@ -47,6 +47,9 @@ use crate::cache::messages::data::sorted_set::sorted_set_increment_score::{
 use crate::utils::IntoBytesIterable;
 use crate::{utils, CredentialProvider, IntoBytes, MomentoResult};
 
+type ControlClient =
+    Arc<Mutex<Option<ScsControlClient<InterceptedService<Channel, HeaderInterceptor>>>>>;
+
 /// Client to work with Momento Cache, the serverless caching service.
 ///
 /// # Example
@@ -78,8 +81,7 @@ use crate::{utils, CredentialProvider, IntoBytes, MomentoResult};
 #[derive(Clone, Debug)]
 pub struct CacheClient {
     pub(crate) data_client: ScsClient<InterceptedService<Channel, HeaderInterceptor>>,
-    pub(crate) control_client:
-        Arc<Mutex<Option<ScsControlClient<InterceptedService<Channel, HeaderInterceptor>>>>>,
+    pub(crate) control_client: ControlClient,
     pub(crate) credential_provider: CredentialProvider,
     pub(crate) configuration: Configuration,
     pub(crate) item_default_ttl: Duration,

--- a/sdk/src/cache/messages/control/create_cache.rs
+++ b/sdk/src/cache/messages/control/create_cache.rs
@@ -54,8 +54,7 @@ impl MomentoRequest for CreateCacheRequest {
         });
 
         let result = cache_client
-            .control_client
-            .clone()
+            .get_control_client()?
             .create_cache(request)
             .await;
         match result {

--- a/sdk/src/cache/messages/control/delete_cache.rs
+++ b/sdk/src/cache/messages/control/delete_cache.rs
@@ -60,8 +60,7 @@ impl MomentoRequest for DeleteCacheRequest {
         });
 
         let _ = cache_client
-            .control_client
-            .clone()
+            .get_control_client()?
             .delete_cache(request)
             .await?;
         Ok(DeleteCacheResponse {})

--- a/sdk/src/cache/messages/control/flush_cache.rs
+++ b/sdk/src/cache/messages/control/flush_cache.rs
@@ -62,8 +62,7 @@ impl MomentoRequest for FlushCacheRequest {
         });
 
         let _ = cache_client
-            .control_client
-            .clone()
+            .get_control_client()?
             .flush_cache(request)
             .await?;
         Ok(FlushCacheResponse {})

--- a/sdk/src/cache/messages/control/list_caches.rs
+++ b/sdk/src/cache/messages/control/list_caches.rs
@@ -36,8 +36,7 @@ impl MomentoRequest for ListCachesRequest {
         });
 
         let response = cache_client
-            .control_client
-            .clone()
+            .get_control_client()?
             .list_caches(request)
             .await?
             .into_inner();


### PR DESCRIPTION
# Overview

Demonstrates how to lazily initialize the control client. Stores the
control client as an `Arc<Mutex<Option<ScsControlClient<>>>>`:

- Since the cache client is cloneable, Arc allows it to be cloned
- Mutex for exclusive access to lazily initialize only once
- Option to track the state from uninitialized to initialized

A helper function `get_control_client` does
get-or-lazily-initialize. Uses another helper `create_control_client`
to instantiate it.

In this PR we've refactored the control requests to use this. The data
client refactor would be nearly identical but would take changes to
many request files. So we exclude that from this spike.

We could refactor this into its own component for re-use. It would parallel
the `once_cell::sync::Lazy` struct (see below).

# Alternatives considered

There is a rust library called `once_cell` which has a `Lazy` type that takes an
initializer function. This has to be a pure function and cannot capture variables
from the outer scope (which we would need for the credential provider), so
we could not get that to work.