### PR TITLE
chore: fix broken links in readmes

### DIFF
--- a/example/rust/README.ja.md
+++ b/example/rust/README.ja.md
@@ -10,13 +10,11 @@ _他言語バージョンもあります_：[English](README.md)
 - Momento オーストークンが必要です。トークン発行は[Momento CLI](https://github.com/momentohq/momento-cli)から行えます。
 
 ```bash
-cargo build
-
 # SDKコード例を実行する
-MOMENTO_AUTH_TOKEN=<YOUR AUTH TOKEN> ./target/debug/rust
+MOMENTO_API_KEY=<YOUR API KEY> cargo run --bin=cache
 ```
 
-SDK コード例: [main.rs](src/main.rs)
+SDK コード例: [cache.rs](src/bin/cache.rs)
 
 ## SDK を自身のプロジェクトで使用する
 

--- a/example/rust/README.template.md
+++ b/example/rust/README.template.md
@@ -22,7 +22,7 @@ This example demonstrates a basic set and get from a cache.
 MOMENTO_API_KEY=<YOUR API KEY> cargo run --bin=cache
 ```
 
-Example Code: [cache.rs](src/cache.rs)
+Example Code: [cache.rs](src/bin/cache.rs)
 
 ## Running the Topics Example
 
@@ -33,6 +33,6 @@ This example demonstrates subscribing to and publishing to a Topic.
 MOMENTO_API_KEY=<YOUR API KEY> cargo run --bin=topics
 ```
 
-Example Code: [topics.rs](src/topics.rs)
+Example Code: [topics.rs](src/bin/topics.rs)
 
 {{ ossFooter }}


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1056

Fixes broken links in the `example/rust` README. 
Also updates the Japanese `example/rust` README to use `MOMENTO_API_KEY` instead of `AUTH_TOKEN` and fixes a broken link there too.