### PR TITLE
chore: improve resource exhausted message

### DIFF
--- a/sdk/src/errors.rs
+++ b/sdk/src/errors.rs
@@ -323,27 +323,38 @@ pub(crate) fn status_to_error(status: tonic::Status) -> MomentoError {
     }
 }
 
-
 enum LimitExceededMessageWrapper {
-    TopicSubscriptionsLimitExceeded,
-    OperationsRateLimitExceeded,
-    ThroughputRateLimitExceeded,
-    RequestSizeLimitExceeded,
-    ItemSizeLimitExceeded,
-    ElementSizeLimitExceeded,
-    UnknownLimitExceeded,
+    TopicSubscriptions,
+    OperationsRate,
+    ThroughputRate,
+    RequestSize,
+    ItemSize,
+    ElementSize,
+    Unknown,
 }
 
 impl LimitExceededMessageWrapper {
     pub fn value(&self) -> String {
         match self {
-            LimitExceededMessageWrapper::TopicSubscriptionsLimitExceeded => "Topic subscriptions limit exceeded for this account".to_string(),
-            LimitExceededMessageWrapper::OperationsRateLimitExceeded => "Request rate limit exceeded for this account".to_string(),
-            LimitExceededMessageWrapper::ThroughputRateLimitExceeded => "Bandwidth limit exceeded for this account".to_string(),
-            LimitExceededMessageWrapper::RequestSizeLimitExceeded => "Request size limit exceeded for this account".to_string(),
-            LimitExceededMessageWrapper::ItemSizeLimitExceeded => "Item size limit exceeded for this account".to_string(),
-            LimitExceededMessageWrapper::ElementSizeLimitExceeded => "Element size limit exceeded for this account".to_string(),
-            LimitExceededMessageWrapper::UnknownLimitExceeded => "Limit exceeded for this account".to_string(),
+            LimitExceededMessageWrapper::TopicSubscriptions => {
+                "Topic subscriptions limit exceeded for this account".to_string()
+            }
+            LimitExceededMessageWrapper::OperationsRate => {
+                "Request rate limit exceeded for this account".to_string()
+            }
+            LimitExceededMessageWrapper::ThroughputRate => {
+                "Bandwidth limit exceeded for this account".to_string()
+            }
+            LimitExceededMessageWrapper::RequestSize => {
+                "Request size limit exceeded for this account".to_string()
+            }
+            LimitExceededMessageWrapper::ItemSize => {
+                "Item size limit exceeded for this account".to_string()
+            }
+            LimitExceededMessageWrapper::ElementSize => {
+                "Element size limit exceeded for this account".to_string()
+            }
+            LimitExceededMessageWrapper::Unknown => "Limit exceeded for this account".to_string(),
         }
     }
 }
@@ -354,14 +365,20 @@ fn determine_limit_exceeded_message_wrapper(metadata: &MetadataMap, message: &st
     if let Some(err_cause) = metadata.get("err") {
         if let Ok(err_str) = err_cause.to_str() {
             return match err_str {
-                "topic_subscriptions_limit_exceeded" => LimitExceededMessageWrapper::TopicSubscriptionsLimitExceeded.value(),
-                "operations_rate_limit_exceeded" => LimitExceededMessageWrapper::OperationsRateLimitExceeded.value(),
-                "throughput_rate_limit_exceeded" => LimitExceededMessageWrapper::ThroughputRateLimitExceeded.value(),
-                "request_size_limit_exceeded" => LimitExceededMessageWrapper::RequestSizeLimitExceeded.value(),
-                "item_size_limit_exceeded" => LimitExceededMessageWrapper::ItemSizeLimitExceeded.value(),
-                "element_size_limit_exceeded" => LimitExceededMessageWrapper::ElementSizeLimitExceeded.value(),
-                _ => LimitExceededMessageWrapper::UnknownLimitExceeded.value(),
-            }
+                "topic_subscriptions_limit_exceeded" => {
+                    LimitExceededMessageWrapper::TopicSubscriptions.value()
+                }
+                "operations_rate_limit_exceeded" => {
+                    LimitExceededMessageWrapper::OperationsRate.value()
+                }
+                "throughput_rate_limit_exceeded" => {
+                    LimitExceededMessageWrapper::ThroughputRate.value()
+                }
+                "request_size_limit_exceeded" => LimitExceededMessageWrapper::RequestSize.value(),
+                "item_size_limit_exceeded" => LimitExceededMessageWrapper::ItemSize.value(),
+                "element_size_limit_exceeded" => LimitExceededMessageWrapper::ElementSize.value(),
+                _ => LimitExceededMessageWrapper::Unknown.value(),
+            };
         }
     }
 
@@ -369,18 +386,18 @@ fn determine_limit_exceeded_message_wrapper(metadata: &MetadataMap, message: &st
     // to return an appropriate error message.
     let lower_cased_message = message.to_lowercase();
     if lower_cased_message.contains("subscribers") {
-        return LimitExceededMessageWrapper::TopicSubscriptionsLimitExceeded.value();
+        LimitExceededMessageWrapper::TopicSubscriptions.value()
     } else if lower_cased_message.contains("operations") {
-        return LimitExceededMessageWrapper::OperationsRateLimitExceeded.value();
+        LimitExceededMessageWrapper::OperationsRate.value()
     } else if lower_cased_message.contains("throughput") {
-        return LimitExceededMessageWrapper::ThroughputRateLimitExceeded.value();
+        LimitExceededMessageWrapper::ThroughputRate.value()
     } else if lower_cased_message.contains("request limit") {
-        return LimitExceededMessageWrapper::RequestSizeLimitExceeded.value();
+        LimitExceededMessageWrapper::RequestSize.value()
     } else if lower_cased_message.contains("item size") {
-        return LimitExceededMessageWrapper::ItemSizeLimitExceeded.value();
+        LimitExceededMessageWrapper::ItemSize.value()
     } else if lower_cased_message.contains("element size") {
-        return LimitExceededMessageWrapper::ElementSizeLimitExceeded.value();
+        LimitExceededMessageWrapper::ElementSize.value()
     } else {
-        return LimitExceededMessageWrapper::UnknownLimitExceeded.value();
+        LimitExceededMessageWrapper::Unknown.value()
     }
 }

--- a/sdk/src/errors.rs
+++ b/sdk/src/errors.rs
@@ -334,70 +334,68 @@ enum LimitExceededMessageWrapper {
 }
 
 impl LimitExceededMessageWrapper {
-    pub fn value(&self) -> String {
+    pub fn value(&self) -> &str {
         match self {
             LimitExceededMessageWrapper::TopicSubscriptions => {
-                "Topic subscriptions limit exceeded for this account".to_string()
+                "Topic subscriptions limit exceeded for this account"
             }
             LimitExceededMessageWrapper::OperationsRate => {
-                "Request rate limit exceeded for this account".to_string()
+                "Request rate limit exceeded for this account"
             }
             LimitExceededMessageWrapper::ThroughputRate => {
-                "Bandwidth limit exceeded for this account".to_string()
+                "Bandwidth limit exceeded for this account"
             }
             LimitExceededMessageWrapper::RequestSize => {
-                "Request size limit exceeded for this account".to_string()
+                "Request size limit exceeded for this account"
             }
-            LimitExceededMessageWrapper::ItemSize => {
-                "Item size limit exceeded for this account".to_string()
-            }
+            LimitExceededMessageWrapper::ItemSize => "Item size limit exceeded for this account",
             LimitExceededMessageWrapper::ElementSize => {
-                "Element size limit exceeded for this account".to_string()
+                "Element size limit exceeded for this account"
             }
-            LimitExceededMessageWrapper::Unknown => "Limit exceeded for this account".to_string(),
+            LimitExceededMessageWrapper::Unknown => "Limit exceeded for this account",
         }
     }
 }
 
 fn determine_limit_exceeded_message_wrapper(metadata: &MetadataMap, message: &str) -> String {
+    let wrapper;
+
     // If provided, we use the `err` metadata value to determine the most
     // appropriate error message to return.
     if let Some(err_cause) = metadata.get("err") {
         if let Ok(err_str) = err_cause.to_str() {
-            return match err_str {
+            wrapper = match err_str {
                 "topic_subscriptions_limit_exceeded" => {
-                    LimitExceededMessageWrapper::TopicSubscriptions.value()
+                    LimitExceededMessageWrapper::TopicSubscriptions
                 }
-                "operations_rate_limit_exceeded" => {
-                    LimitExceededMessageWrapper::OperationsRate.value()
-                }
-                "throughput_rate_limit_exceeded" => {
-                    LimitExceededMessageWrapper::ThroughputRate.value()
-                }
-                "request_size_limit_exceeded" => LimitExceededMessageWrapper::RequestSize.value(),
-                "item_size_limit_exceeded" => LimitExceededMessageWrapper::ItemSize.value(),
-                "element_size_limit_exceeded" => LimitExceededMessageWrapper::ElementSize.value(),
-                _ => LimitExceededMessageWrapper::Unknown.value(),
+                "operations_rate_limit_exceeded" => LimitExceededMessageWrapper::OperationsRate,
+                "throughput_rate_limit_exceeded" => LimitExceededMessageWrapper::ThroughputRate,
+                "request_size_limit_exceeded" => LimitExceededMessageWrapper::RequestSize,
+                "item_size_limit_exceeded" => LimitExceededMessageWrapper::ItemSize,
+                "element_size_limit_exceeded" => LimitExceededMessageWrapper::ElementSize,
+                _ => LimitExceededMessageWrapper::Unknown,
             };
+            return wrapper.value().to_string();
         }
     }
 
     // If `err` metadata is unavailable, try to use the error details field
     // to return an appropriate error message.
     let lower_cased_message = message.to_lowercase();
-    if lower_cased_message.contains("subscribers") {
-        LimitExceededMessageWrapper::TopicSubscriptions.value()
+    wrapper = if lower_cased_message.contains("subscribers") {
+        LimitExceededMessageWrapper::TopicSubscriptions
     } else if lower_cased_message.contains("operations") {
-        LimitExceededMessageWrapper::OperationsRate.value()
+        LimitExceededMessageWrapper::OperationsRate
     } else if lower_cased_message.contains("throughput") {
-        LimitExceededMessageWrapper::ThroughputRate.value()
+        LimitExceededMessageWrapper::ThroughputRate
     } else if lower_cased_message.contains("request limit") {
-        LimitExceededMessageWrapper::RequestSize.value()
+        LimitExceededMessageWrapper::RequestSize
     } else if lower_cased_message.contains("item size") {
-        LimitExceededMessageWrapper::ItemSize.value()
+        LimitExceededMessageWrapper::ItemSize
     } else if lower_cased_message.contains("element size") {
-        LimitExceededMessageWrapper::ElementSize.value()
+        LimitExceededMessageWrapper::ElementSize
     } else {
-        LimitExceededMessageWrapper::Unknown.value()
-    }
+        LimitExceededMessageWrapper::Unknown
+    };
+    wrapper.value().to_string()
 }

--- a/sdk/src/errors.rs
+++ b/sdk/src/errors.rs
@@ -2,6 +2,7 @@ use std::{error::Error, fmt::Debug, str::from_utf8};
 
 use tonic::codegen::http;
 use tonic::metadata::errors::ToStrError;
+use tonic::metadata::MetadataMap;
 
 /// Error codes to indicate the type of error that occurred
 #[derive(Debug, Clone, PartialEq)]
@@ -197,7 +198,7 @@ pub(crate) fn status_to_error(status: tonic::Status) -> MomentoError {
             details: Some(status.into())
         },
         tonic::Code::ResourceExhausted => MomentoError {
-            message: "Request rate, bandwidth, or object size exceeded the limits for this account.  To resolve this error, reduce your usage as appropriate or contact us at support@momentohq.com to request a limit increase".into(),
+            message: determine_limit_exceeded_message_wrapper(status.metadata(), status.message()),
             error_code: MomentoErrorCode::LimitExceededError,
             inner_error: Some(status.clone().into()),
             details: Some(status.into())
@@ -319,5 +320,67 @@ pub(crate) fn status_to_error(status: tonic::Status) -> MomentoError {
             inner_error: Some(status.clone().into()),
             details: Some(status.into())
         },
+    }
+}
+
+
+enum LimitExceededMessageWrapper {
+    TopicSubscriptionsLimitExceeded,
+    OperationsRateLimitExceeded,
+    ThroughputRateLimitExceeded,
+    RequestSizeLimitExceeded,
+    ItemSizeLimitExceeded,
+    ElementSizeLimitExceeded,
+    UnknownLimitExceeded,
+}
+
+impl LimitExceededMessageWrapper {
+    pub fn value(&self) -> String {
+        match self {
+            LimitExceededMessageWrapper::TopicSubscriptionsLimitExceeded => "Topic subscriptions limit exceeded for this account".to_string(),
+            LimitExceededMessageWrapper::OperationsRateLimitExceeded => "Request rate limit exceeded for this account".to_string(),
+            LimitExceededMessageWrapper::ThroughputRateLimitExceeded => "Bandwidth limit exceeded for this account".to_string(),
+            LimitExceededMessageWrapper::RequestSizeLimitExceeded => "Request size limit exceeded for this account".to_string(),
+            LimitExceededMessageWrapper::ItemSizeLimitExceeded => "Item size limit exceeded for this account".to_string(),
+            LimitExceededMessageWrapper::ElementSizeLimitExceeded => "Element size limit exceeded for this account".to_string(),
+            LimitExceededMessageWrapper::UnknownLimitExceeded => "Limit exceeded for this account".to_string(),
+        }
+    }
+}
+
+fn determine_limit_exceeded_message_wrapper(metadata: &MetadataMap, message: &str) -> String {
+    // If provided, we use the `err` metadata value to determine the most
+    // appropriate error message to return.
+    if let Some(err_cause) = metadata.get("err") {
+        if let Ok(err_str) = err_cause.to_str() {
+            return match err_str {
+                "topic_subscriptions_limit_exceeded" => LimitExceededMessageWrapper::TopicSubscriptionsLimitExceeded.value(),
+                "operations_rate_limit_exceeded" => LimitExceededMessageWrapper::OperationsRateLimitExceeded.value(),
+                "throughput_rate_limit_exceeded" => LimitExceededMessageWrapper::ThroughputRateLimitExceeded.value(),
+                "request_size_limit_exceeded" => LimitExceededMessageWrapper::RequestSizeLimitExceeded.value(),
+                "item_size_limit_exceeded" => LimitExceededMessageWrapper::ItemSizeLimitExceeded.value(),
+                "element_size_limit_exceeded" => LimitExceededMessageWrapper::ElementSizeLimitExceeded.value(),
+                _ => LimitExceededMessageWrapper::UnknownLimitExceeded.value(),
+            }
+        }
+    }
+
+    // If `err` metadata is unavailable, try to use the error details field
+    // to return an appropriate error message.
+    let lower_cased_message = message.to_lowercase();
+    if lower_cased_message.contains("subscribers") {
+        return LimitExceededMessageWrapper::TopicSubscriptionsLimitExceeded.value();
+    } else if lower_cased_message.contains("operations") {
+        return LimitExceededMessageWrapper::OperationsRateLimitExceeded.value();
+    } else if lower_cased_message.contains("throughput") {
+        return LimitExceededMessageWrapper::ThroughputRateLimitExceeded.value();
+    } else if lower_cased_message.contains("request limit") {
+        return LimitExceededMessageWrapper::RequestSizeLimitExceeded.value();
+    } else if lower_cased_message.contains("item size") {
+        return LimitExceededMessageWrapper::ItemSizeLimitExceeded.value();
+    } else if lower_cased_message.contains("element size") {
+        return LimitExceededMessageWrapper::ElementSizeLimitExceeded.value();
+    } else {
+        return LimitExceededMessageWrapper::UnknownLimitExceeded.value();
     }
 }


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1040

When a RESOURCE_EXHAUSTED error is received, we now parse the err metadata in order to report the cause in the message wrapper. If the metadata is not available, we try to use string matching on the error details.