### PR TITLE
chore: remove deprecated crates extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
     "recommendations": [
         "rust-lang.rust-analyzer",
-        "serayuzgur.crates",
+        "fill-labs.dependi",
         "vadimcn.vscode-lldb",
         "tamasfe.even-better-toml"
     ]


### PR DESCRIPTION
Replaces deprecated crates extension and applies recommended dependi
extension.
