### PR TITLE
chore: sdk/Cargo.lock should use correct version of momento packages

### DIFF
--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.43.1"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "momento-test-util"
-version = "0.43.1"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "momento",


### PR DESCRIPTION
My local build automatically updates this in the lock file. I suspect
this wasn't committed previously. We will have to monitor after the
next release.
