### PR TITLE
ci: allow dirty git tree on publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,5 +93,6 @@ help:
 publish:
 	cd sdk && \
  	cp ../README.md . && \
- 	cargo publish
+ 	cargo publish --allow-dirty
+
 

--- a/sdk/Cargo.lock
+++ b/sdk/Cargo.lock
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "momento-test-util"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "momento",


### PR DESCRIPTION
In order to unblock the release, we adjust cargo publish to allow
publish on a dirty git tree.

We are actively root causing why the `Cargo.lock` file has not been
committed.
