### PR TITLE
ci: exclude component from tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "packages": {
     ".": {
       "release-type": "rust",
+      "include-component-in-tag": false,
       "changelog-sections": [
         {
           "type": "feat",


### PR DESCRIPTION
Previously release-please was expecting the component in the tag name:

> ⚠ Expected 1 releases, only found 0
❯ looking for tagName: momento-v0.46.0

But we were not using this. As a result the latest release changelog
went back to the beginning. With this change it should only include up
until the previous release.
