### PR TITLE
chore: update vscode workspace to match directory structure

### DIFF
--- a/.vscode/client-sdk-rust.code-workspace
+++ b/.vscode/client-sdk-rust.code-workspace
@@ -5,15 +5,11 @@
 		"path": ".."
 	},
 	{
-		"name": "sdk",
-		"path": "../sdk"
-	},
-	{
 		"name": "example/rust",
 		"path": "../example/rust"
 	}
 ],
   "settings": {
-    "rust-analyzer.linkedProjects": ["./example/rust/Cargo.toml", "./sdk/Cargo.toml"]
+    "rust-analyzer.linkedProjects": ["./example/rust/Cargo.toml", "./Cargo.toml"]
   }
 }


### PR DESCRIPTION
We pulled up the sdk code from the `sdk` folder into the top-level and should update the paths in the VSCode workspaces settings accordingly.