### PR TITLE
chore: showcase publisher_id in topics example

### DIFF
--- a/example/rust/Cargo.lock
+++ b/example/rust/Cargo.lock
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.44.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b17859dc0a6c5c0f227f98054723ec32a07f00d6851663ddd9a4d1f00d87b1"
+checksum = "fc7de71fc41987b56bda2a3f97f31e701431d63ad29a01ba5fe0b4f78cb01d01"
 dependencies = [
  "base64",
  "derive_more",

--- a/example/rust/Cargo.toml
+++ b/example/rust/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/docs_examples/docs_examples.rs"
 
 [dependencies]
 futures = "0.3.30"
-momento = { version = "0.44.0" }
+momento = { version = "0.47.0" }
 tokio = { version = "1.37.0", features = ["full"] }
 uuid = { version = "1.8.0", features = ["v4"] }
 anyhow = "1"

--- a/example/rust/README.template.md
+++ b/example/rust/README.template.md
@@ -35,6 +35,6 @@ MOMENTO_API_KEY=<YOUR API KEY> cargo run --bin=topics
 
 Example Code: [topics.rs](src/bin/topics.rs)
 
-Note: to see a non-null `publisher_id` on a received [`SubscriptionValue`](https://docs.rs/momento/0.46.1/momento/topics/struct.SubscriptionValue.html), you'll need to set the optional `token_id` argument when programmatically creating a [disposable token](https://docs.momentohq.com/cache/develop/api-reference/auth#generatedisposabletoken). 
+Note: to see a non-null `publisher_id` on a received [`SubscriptionValue`](https://docs.rs/momento/0.46.1/momento/topics/struct.SubscriptionValue.html), you'll need to set the optional `token_id` argument when programmatically creating a [disposable token](https://docs.momentohq.com/cache/develop/api-reference/auth#generatedisposabletoken). An example of this is provided in [topics.rs](src/bin/topics.rs).
 
 {{ ossFooter }}

--- a/example/rust/README.template.md
+++ b/example/rust/README.template.md
@@ -35,4 +35,6 @@ MOMENTO_API_KEY=<YOUR API KEY> cargo run --bin=topics
 
 Example Code: [topics.rs](src/bin/topics.rs)
 
+Note: to see a non-null `publisher_id` on a received [`SubscriptionValue`](https://docs.rs/momento/0.46.1/momento/topics/struct.SubscriptionValue.html), you'll need to set the optional `token_id` argument when programmatically creating a [disposable token](https://docs.momentohq.com/cache/develop/api-reference/auth#generatedisposabletoken). 
+
 {{ ossFooter }}

--- a/example/rust/src/bin/topics.rs
+++ b/example/rust/src/bin/topics.rs
@@ -16,9 +16,15 @@ async fn main() -> MomentoResult<()> {
     // call `abort()` on the task handle after messages are published.
     let mut subscription1 = topic_client.subscribe("cache", "my-topic").await?;
     let subscriber_handle1 = tokio::spawn(async move {
-        println!("Subscriber should keep receiving until task is aborted");
+        println!("\n Subscriber [1] should keep receiving until task is aborted");
         while let Some(message) = subscription1.next().await {
-            println!("[1] Received message: {:?}", message);
+            println!(
+                "[1] Received message: \n\tKind: {:?} \n\tSequence number: {:?} \n\tSequence page: {:?} \n\tPublisher ID: {:?}", 
+                message.kind,
+                message.topic_sequence_number,
+                message.topic_sequence_page,
+                message.publisher_id
+            );
         }
     });
 
@@ -38,10 +44,24 @@ async fn main() -> MomentoResult<()> {
     // let the task end after receiving 10 messages.
     let mut subscription2 = topic_client.subscribe("cache", "my-topic").await?;
     tokio::spawn(async move {
-        println!("Subscriber should receive 10 messages then exit");
+        println!("\nSubscriber [2] should receive 10 messages then exit");
         for _ in 0..10 {
             let message = subscription2.next().await;
-            println!("[2] Received message: {:?}", message);
+            // println!("[2] Received message: {:?}", message);
+            match message {
+                Some(message) => {
+                    println!(
+                        "[2] Received message: \n\tKind: {:?} \n\tSequence number: {:?} \n\tSequence page: {:?} \n\tPublisher ID: {:?}", 
+                        message.kind,
+                        message.topic_sequence_number,
+                        message.topic_sequence_page,
+                        message.publisher_id
+                    );
+                }
+                None => {
+                    println!("[2] Received None item from subscription");
+                }
+            }
         }
     });
 

--- a/example/rust/src/bin/topics.rs
+++ b/example/rust/src/bin/topics.rs
@@ -52,7 +52,6 @@ async fn main() -> MomentoResult<()> {
         println!("\nSubscriber [2] should receive 10 messages then exit");
         for _ in 0..10 {
             let message = subscription2.next().await;
-            // println!("[2] Received message: {:?}", message);
             match message {
                 Some(message) => {
                     println!(


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/951

Now that generate_disposable_token is implemented, I updated this example to include that as well.