### PR TITLE
feat: add auth client and generate_disposable_token api

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -9,6 +9,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   TEST_CACHE_NAME: rust-integration-test-ci-cache-${{ github.sha }}
   TEST_STORE_NAME: rust-integration-test-ci-store-${{ github.sha }}
+  TEST_AUTH_CACHE_NAME: rust-integration-test-ci-cache-auth-${{ github.sha }}
 
 jobs:
   rustfmt:

--- a/src/auth/auth_client.rs
+++ b/src/auth/auth_client.rs
@@ -85,7 +85,7 @@ impl AuthClient {
     /// # Arguments
     ///
     /// * `scope` - The permission scope that the token will have.
-    /// * `expires_in` - The duration for which the token will be valid.
+    /// * `expires_in` - The duration for which the token will be valid. Note: disposable tokens must expire within 1 hour.
     ///
     /// # Optional Arguments
     /// If you use [send_request](AuthClient::send_request) to generate a token using a
@@ -100,7 +100,7 @@ impl AuthClient {
     /// # use momento_test_util::create_doctest_auth_client;
     /// # tokio_test::block_on(async {
     /// # let auth_client = create_doctest_auth_client();
-    /// use momento::auth::{GenerateDisposableTokenResponse, ExpiresIn, DisposableTokenScopes};
+    /// use momento::auth::{ExpiresIn, DisposableTokenScopes};
     ///
     /// let expiry = ExpiresIn::minutes(5);
     /// let permission_scope = DisposableTokenScopes::cache_key_read_write("cache", "key");

--- a/src/auth/auth_client.rs
+++ b/src/auth/auth_client.rs
@@ -1,0 +1,61 @@
+use momento_protos::token::token_client::TokenClient;
+use tonic::{codegen::InterceptedService, transport::Channel};
+
+use crate::auth::auth_client_builder::{AuthClientBuilder, NeedsCredentialProvider};
+use crate::grpc::header_interceptor::HeaderInterceptor;
+
+use crate::auth::messages::MomentoRequest;
+use crate::{utils, CredentialProvider, IntoBytes, MomentoResult};
+
+use crate::auth::expiration::ExpiresIn;
+
+use crate::auth::messages::generate_disposable_token::{
+    GenerateDisposableTokenRequest, GenerateDisposableTokenResponse,
+};
+
+use super::permissions::disposable_token_scope::DisposableTokenScope;
+
+type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
+
+/// TODO
+#[derive(Clone, Debug)]
+pub struct AuthClient {
+    pub(crate) token_client: TokenClient<ChannelType>,
+    pub(crate) credential_provider: CredentialProvider,
+}
+
+impl AuthClient {
+    /// Creates a new instance of the AuthClient.
+    ///
+    /// Note: AuthClient does not take a configuration but this is subject to change.
+    pub fn builder() -> AuthClientBuilder<NeedsCredentialProvider> {
+        AuthClientBuilder(NeedsCredentialProvider(()))
+    }
+
+    pub async fn generate_disposable_token(
+        &self,
+        scope: DisposableTokenScope<impl IntoBytes>,
+        expires_in: ExpiresIn,
+    ) -> MomentoResult<GenerateDisposableTokenResponse> {
+        utils::is_disposable_token_expiry_valid(expires_in.clone())?;
+        let request = GenerateDisposableTokenRequest::new(scope, expires_in);
+        request.send(self).await
+    }
+
+    /// Lower-level API to send any type of MomentoRequest to the server. This is used for cases when
+    /// you want to set optional fields on a request that are not supported by the short-hand API for
+    /// that request type.
+    ///
+    /// See [GenerateDisposableTokenRequest] for an example of creating a request with optional fields.
+    pub async fn send_request<R: MomentoRequest>(&self, request: R) -> MomentoResult<R::Response> {
+        request.send(self).await
+    }
+
+    pub(crate) fn token_client(&self) -> TokenClient<ChannelType> {
+        self.token_client.clone()
+    }
+
+    pub(crate) fn credentials(&self) -> CredentialProvider {
+        self.credential_provider.clone()
+    }
+}

--- a/src/auth/auth_client_builder.rs
+++ b/src/auth/auth_client_builder.rs
@@ -1,0 +1,42 @@
+use momento_protos::token::token_client::TokenClient;
+use tonic::service::interceptor::InterceptedService;
+
+use crate::{
+    grpc::header_interceptor::HeaderInterceptor,
+    utils::{self, connect_channel_lazily},
+    AuthClient, CredentialProvider, MomentoResult,
+};
+
+pub struct AuthClientBuilder<State>(pub State);
+
+pub struct NeedsCredentialProvider(pub ());
+
+pub struct ReadyToBuild {
+    credential_provider: CredentialProvider,
+}
+
+impl AuthClientBuilder<NeedsCredentialProvider> {
+    pub fn credential_provider(
+        self,
+        credential_provider: CredentialProvider,
+    ) -> AuthClientBuilder<ReadyToBuild> {
+        AuthClientBuilder(ReadyToBuild {
+            credential_provider,
+        })
+    }
+}
+
+impl AuthClientBuilder<ReadyToBuild> {
+    pub fn build(self) -> MomentoResult<AuthClient> {
+        let agent_value = &utils::user_agent("auth");
+        let channel = connect_channel_lazily(&self.0.credential_provider.token_endpoint)?;
+        let authorized_channel = InterceptedService::new(
+            channel,
+            HeaderInterceptor::new(&self.0.credential_provider.auth_token, agent_value),
+        );
+        Ok(AuthClient {
+            token_client: TokenClient::new(authorized_channel),
+            credential_provider: self.0.credential_provider,
+        })
+    }
+}

--- a/src/auth/expiration.rs
+++ b/src/auth/expiration.rs
@@ -1,0 +1,105 @@
+use crate::{MomentoError, MomentoErrorCode, MomentoResult};
+use derive_more::Display;
+
+pub trait Expiration {
+    fn does_expire(&self) -> bool;
+}
+
+#[derive(Debug, Display, PartialEq, Eq, Clone)]
+pub struct ExpiresIn {
+    // u64::MAX means it never expires
+    valid_for_seconds: u64,
+}
+
+impl Expiration for ExpiresIn {
+    fn does_expire(&self) -> bool {
+        self.valid_for_seconds != u64::MAX
+    }
+}
+
+impl ExpiresIn {
+    pub fn to_seconds(&self) -> u64 {
+        self.valid_for_seconds
+    }
+
+    pub fn never() -> Self {
+        Self {
+            valid_for_seconds: u64::MAX,
+        }
+    }
+
+    pub fn seconds(valid_for_seconds: u64) -> Self {
+        Self { valid_for_seconds }
+    }
+
+    pub fn minutes(valid_for_minutes: u64) -> Self {
+        Self {
+            valid_for_seconds: valid_for_minutes * 60,
+        }
+    }
+
+    pub fn hours(valid_for_hours: u64) -> Self {
+        Self {
+            valid_for_seconds: valid_for_hours * 3600,
+        }
+    }
+
+    pub fn days(valid_for_days: u64) -> Self {
+        Self {
+            valid_for_seconds: valid_for_days * 86400,
+        }
+    }
+
+    pub fn epoch(expires_by: u64) -> MomentoResult<Self> {
+        match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+            Ok(duration) => {
+                let current_epoch = duration.as_secs();
+                let seconds_until_epoch = expires_by - current_epoch;
+                Ok(Self {
+                    valid_for_seconds: seconds_until_epoch,
+                })
+            }
+            Err(_) => Err(MomentoError {
+                message: "Unable to convert epoch timestamp into valid expiry".into(),
+                error_code: MomentoErrorCode::InvalidArgumentError,
+                inner_error: None,
+                details: None,
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Display, PartialEq, Eq, Clone)]
+pub struct ExpiresAt {
+    // u64::MAX means it never expires
+    valid_until: u64,
+}
+
+impl Expiration for ExpiresAt {
+    fn does_expire(&self) -> bool {
+        self.valid_until != u64::MAX
+    }
+}
+
+impl ExpiresAt {
+    pub fn new(epoch_timestamp: Option<u64>) -> Self {
+        match epoch_timestamp {
+            Some(epoch_timestamp) => Self {
+                valid_until: epoch_timestamp,
+            },
+            None => Self {
+                valid_until: u64::MAX,
+            },
+        }
+    }
+
+    pub fn from_epoch(epoch_timestamp: u64) -> Self {
+        Self {
+            valid_until: epoch_timestamp,
+        }
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.valid_until
+    }
+}

--- a/src/auth/expiration.rs
+++ b/src/auth/expiration.rs
@@ -1,10 +1,13 @@
 use crate::{MomentoError, MomentoErrorCode, MomentoResult};
 use derive_more::Display;
 
+/// Trait for determining if an object expires.
 pub trait Expiration {
+    /// Returns true if the object expires.
     fn does_expire(&self) -> bool;
 }
 
+/// Represents the time remaining before an object expires.
 #[derive(Debug, Display, PartialEq, Eq, Clone)]
 pub struct ExpiresIn {
     // u64::MAX means it never expires
@@ -18,38 +21,46 @@ impl Expiration for ExpiresIn {
 }
 
 impl ExpiresIn {
+    /// Returns the number of seconds until the object expires.
+    /// If the object never expires, it will return u64::MAX.
     pub fn to_seconds(&self) -> u64 {
         self.valid_for_seconds
     }
 
+    /// Creates a new instance of ExpiresIn that never expires.
     pub fn never() -> Self {
         Self {
             valid_for_seconds: u64::MAX,
         }
     }
 
+    /// Creates a new instance of ExpiresIn from a number of seconds.
     pub fn seconds(valid_for_seconds: u64) -> Self {
         Self { valid_for_seconds }
     }
 
+    /// Creates a new instance of ExpiresIn from a number of minutes.
     pub fn minutes(valid_for_minutes: u64) -> Self {
         Self {
             valid_for_seconds: valid_for_minutes * 60,
         }
     }
 
+    /// Creates a new instance of ExpiresIn from a number of hours.
     pub fn hours(valid_for_hours: u64) -> Self {
         Self {
             valid_for_seconds: valid_for_hours * 3600,
         }
     }
 
+    /// Creates a new instance of ExpiresIn from a number of days.
     pub fn days(valid_for_days: u64) -> Self {
         Self {
             valid_for_seconds: valid_for_days * 86400,
         }
     }
 
+    /// Creates a new instance of ExpiresIn from an epoch timestamp.
     pub fn epoch(expires_by: u64) -> MomentoResult<Self> {
         match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
             Ok(duration) => {
@@ -69,6 +80,7 @@ impl ExpiresIn {
     }
 }
 
+/// Represents an expiration time for an object.
 #[derive(Debug, Display, PartialEq, Eq, Clone)]
 pub struct ExpiresAt {
     // u64::MAX means it never expires
@@ -82,6 +94,8 @@ impl Expiration for ExpiresAt {
 }
 
 impl ExpiresAt {
+    /// Creates a new instance of ExpiresAt.
+    /// If no epoch timestamp is provided, the object will never expire.
     pub fn new(epoch_timestamp: Option<u64>) -> Self {
         match epoch_timestamp {
             Some(epoch_timestamp) => Self {
@@ -93,12 +107,14 @@ impl ExpiresAt {
         }
     }
 
+    /// Creates a new instance of ExpiresAt from an epoch timestamp.
     pub fn from_epoch(epoch_timestamp: u64) -> Self {
         Self {
             valid_until: epoch_timestamp,
         }
     }
 
+    /// Returns the epoch timestamp of when the object expires.
     pub fn epoch(&self) -> u64 {
         self.valid_until
     }

--- a/src/auth/messages/generate_disposable_token.rs
+++ b/src/auth/messages/generate_disposable_token.rs
@@ -14,7 +14,7 @@ use momento_protos::token::generate_disposable_token_request::Expires;
 /// Optional arguments for generating a disposable token.
 /// Currently, the only optional argument is the `token_id`,
 /// which can be used to identify which token was used for
-/// publishing messages on Momento Topics.
+/// messages published on Momento Topics.
 pub struct DisposableTokenProps {
     pub token_id: Option<String>,
 }

--- a/src/auth/messages/generate_disposable_token.rs
+++ b/src/auth/messages/generate_disposable_token.rs
@@ -1,0 +1,129 @@
+use crate::{
+    auth::{
+        expiration::{ExpiresAt, ExpiresIn},
+        permissions::disposable_token_scope::DisposableTokenScope,
+    },
+    utils::is_disposable_token_id_valid,
+    AuthClient, IntoBytes, MomentoResult,
+};
+
+use super::{permissions_conversions::permissions_from_disposable_token_scope, MomentoRequest};
+use base64::{engine::general_purpose, Engine as _};
+use momento_protos::token::generate_disposable_token_request::Expires;
+
+/// Optional arguments for generating a disposable token.
+/// Currently, the only optional argument is the `token_id`,
+/// which can be used to identify which token was used for
+/// publishing messages on Momento Topics.
+pub struct DisposableTokenProps {
+    pub token_id: Option<String>,
+}
+
+pub struct GenerateDisposableTokenRequest<K: IntoBytes> {
+    scope: DisposableTokenScope<K>,
+    expires_in: ExpiresIn,
+    props: Option<DisposableTokenProps>,
+}
+
+impl<K: IntoBytes> GenerateDisposableTokenRequest<K> {
+    pub fn new(scope: DisposableTokenScope<K>, expires_in: ExpiresIn) -> Self {
+        Self {
+            scope,
+            expires_in,
+            props: None,
+        }
+    }
+
+    /// Set the optional DisposableTokenProps for the request.
+    pub fn props(mut self, props: DisposableTokenProps) -> Self {
+        self.props = Some(props);
+        self
+    }
+
+    /// Set the optional `token_id`` field of the optional DisposableTokenProps for the request.
+    pub fn token_id(mut self, token_id: String) -> Self {
+        self.props = Some(DisposableTokenProps {
+            token_id: Some(token_id),
+        });
+        self
+    }
+}
+
+impl<K: IntoBytes> MomentoRequest for GenerateDisposableTokenRequest<K> {
+    type Response = GenerateDisposableTokenResponse;
+
+    async fn send(self, client: &AuthClient) -> MomentoResult<Self::Response> {
+        let request = momento_protos::token::GenerateDisposableTokenRequest {
+            expires: Some(Expires {
+                valid_for_seconds: self.expires_in.to_seconds() as u32,
+            }),
+            auth_token: client.credentials().auth_token,
+            permissions: Some(permissions_from_disposable_token_scope(self.scope)),
+            token_id: match self.props {
+                Some(props) => match props.token_id {
+                    Some(token_id) => {
+                        is_disposable_token_id_valid(&token_id)?;
+                        token_id
+                    }
+                    None => "".to_string(),
+                },
+                None => "".to_string(),
+            },
+        };
+        let response = client
+            .token_client()
+            .generate_disposable_token(request)
+            .await?
+            .into_inner();
+
+        // We must b64 encode {endpoint: endpoint, api_key: apiKey} to return a valid
+        // auth token that can be accepted by a CredentialProvider.
+        let auth_token = general_purpose::STANDARD.encode(format!(
+            "{{\"endpoint\": \"{}\", \"api_key\": \"{}\"}}",
+            response.endpoint, response.api_key
+        ));
+
+        Ok(GenerateDisposableTokenResponse {
+            auth_token,
+            endpoint: response.endpoint,
+            expires_at: ExpiresAt::from_epoch(response.valid_until),
+        })
+    }
+}
+
+/// Response for a generate disposable token operation.
+///
+/// TODO: examples
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct GenerateDisposableTokenResponse {
+    auth_token: String,
+    endpoint: String,
+    expires_at: ExpiresAt,
+}
+
+impl std::fmt::Display for GenerateDisposableTokenResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "GenerateDisposableTokenResponse {{ auth_token beginning with: {}, endpoint: {}, expires_at epoch: {} }}",
+            &self.auth_token[..5], self.endpoint, self.expires_at.epoch()
+        )
+    }
+}
+
+impl GenerateDisposableTokenResponse {
+    /// Returns the generated disposable token.
+    pub fn auth_token(self) -> String {
+        self.auth_token
+    }
+
+    /// Returns the endpoint to connect to.
+    pub fn endpoint(self) -> String {
+        self.endpoint
+    }
+
+    /// Returns when the token expires.
+    pub fn expires_at(self) -> ExpiresAt {
+        self.expires_at
+    }
+}

--- a/src/auth/messages/generate_disposable_token.rs
+++ b/src/auth/messages/generate_disposable_token.rs
@@ -49,7 +49,6 @@ pub struct DisposableTokenProps {
 /// # })
 /// # }
 /// ```
-/// ```
 pub struct GenerateDisposableTokenRequest<K: IntoBytes> {
     scope: DisposableTokenScope<K>,
     expires_in: ExpiresIn,

--- a/src/auth/messages/mod.rs
+++ b/src/auth/messages/mod.rs
@@ -1,0 +1,5 @@
+pub mod generate_disposable_token;
+mod permissions_conversions;
+
+mod momento_request;
+pub use momento_request::MomentoRequest;

--- a/src/auth/messages/mod.rs
+++ b/src/auth/messages/mod.rs
@@ -1,4 +1,6 @@
+/// Generate disposable token messages
 pub mod generate_disposable_token;
+
 mod permissions_conversions;
 
 mod momento_request;

--- a/src/auth/messages/momento_request.rs
+++ b/src/auth/messages/momento_request.rs
@@ -1,0 +1,18 @@
+use crate::AuthClient;
+use crate::MomentoResult;
+
+/// A trait that allows Momento request types to define their interaction with the gRPC client.
+pub trait MomentoRequest {
+    /// The response type expected from the AuthClient
+    type Response;
+
+    /// An internal fn that allows Momento request types to define their interaction with
+    /// the gRPC client. You can impl this fn for your own types if you'd like to hand them
+    /// to the Momento client directly, but that is not an explicitly supported scenario and
+    /// this signature may change a little over time. If that's okay with you, impl away!
+    #[doc(hidden)]
+    fn send(
+        self,
+        auth_client: &AuthClient,
+    ) -> impl std::future::Future<Output = MomentoResult<Self::Response>> + Send;
+}

--- a/src/auth/messages/permissions_conversions.rs
+++ b/src/auth/messages/permissions_conversions.rs
@@ -1,0 +1,166 @@
+use momento_protos::permission_messages::{
+    self, permissions,
+    permissions_type::{
+        self, cache_item_selector, cache_permissions, cache_selector,
+        topic_permissions::{self},
+        topic_selector, All,
+    },
+    ExplicitPermissions, PermissionsType,
+};
+
+use crate::{
+    auth::permissions::{
+        disposable_token_scope::{
+            CacheItemKey, CacheItemKeyPrefix, CacheItemSelector, DisposableTokenCachePermission,
+            DisposableTokenScope,
+        },
+        permission_scope::{
+            CachePermission, CacheRole, CacheSelector, Permission, TopicPermission, TopicRole,
+            TopicSelector,
+        },
+    },
+    IntoBytes,
+};
+
+// Create protobuf Permissions from DisposableTokenScope
+pub(crate) fn permissions_from_disposable_token_scope(
+    scope: DisposableTokenScope<impl IntoBytes>,
+) -> permission_messages::Permissions {
+    match scope {
+        DisposableTokenScope::Permissions(permissions) => permission_messages::Permissions {
+            kind: Some(permissions::Kind::Explicit(ExplicitPermissions {
+                permissions: permissions
+                    .permissions
+                    .into_iter()
+                    .map(token_permission_to_grpc_permission)
+                    .collect(),
+            })),
+        },
+        DisposableTokenScope::DisposableTokenPermissions(permissions) => {
+            permission_messages::Permissions {
+                kind: Some(permissions::Kind::Explicit(ExplicitPermissions {
+                    permissions: permissions
+                        .permissions
+                        .into_iter()
+                        .map(disposable_token_permission_to_grpc_permission)
+                        .collect(),
+                })),
+            }
+        }
+    }
+}
+
+fn token_permission_to_grpc_permission(permission: Permission) -> PermissionsType {
+    match permission {
+        Permission::CachePermission(cache_perm) => cache_permission_to_grpc_permission(cache_perm),
+        Permission::TopicPermission(topic_perm) => topic_permission_to_grpc_permission(topic_perm),
+    }
+}
+
+fn cache_permission_to_grpc_permission(permission: CachePermission) -> PermissionsType {
+    let grpc_cache_perm = permissions_type::CachePermissions {
+        role: assign_cache_role(permission.role).into(),
+        cache: Some(assign_cache_selector_for_cache_permission(permission.cache)),
+        cache_item: None,
+    };
+    permission_messages::PermissionsType {
+        kind: Some(permissions_type::Kind::CachePermissions(grpc_cache_perm)),
+    }
+}
+
+fn assign_cache_role(role: CacheRole) -> permission_messages::CacheRole {
+    match role {
+        CacheRole::ReadWrite => permission_messages::CacheRole::CacheReadWrite,
+        CacheRole::ReadOnly => permission_messages::CacheRole::CacheReadOnly,
+        CacheRole::WriteOnly => permission_messages::CacheRole::CacheWriteOnly,
+    }
+}
+
+fn assign_cache_selector_for_cache_permission(
+    cache_selector: CacheSelector,
+) -> cache_permissions::Cache {
+    match cache_selector {
+        CacheSelector::AllCaches => cache_permissions::Cache::AllCaches(All {}),
+        CacheSelector::CacheName { name } => {
+            cache_permissions::Cache::CacheSelector(permissions_type::CacheSelector {
+                kind: Some(cache_selector::Kind::CacheName(name)),
+            })
+        }
+    }
+}
+
+fn assign_cache_selector_for_topic_permission(
+    cache_selector: CacheSelector,
+) -> topic_permissions::Cache {
+    match cache_selector {
+        CacheSelector::AllCaches => topic_permissions::Cache::AllCaches(All {}),
+        CacheSelector::CacheName { name } => {
+            topic_permissions::Cache::CacheSelector(permissions_type::CacheSelector {
+                kind: Some(cache_selector::Kind::CacheName(name)),
+            })
+        }
+    }
+}
+
+fn assign_topic_role(role: TopicRole) -> permission_messages::TopicRole {
+    match role {
+        TopicRole::PublishSubscribe => permission_messages::TopicRole::TopicReadWrite,
+        TopicRole::SubscribeOnly => permission_messages::TopicRole::TopicReadOnly,
+        TopicRole::PublishOnly => permission_messages::TopicRole::TopicWriteOnly,
+    }
+}
+
+fn assign_topic_selector(topic_selector: TopicSelector) -> topic_permissions::Topic {
+    match topic_selector {
+        TopicSelector::AllTopics => topic_permissions::Topic::AllTopics(All {}),
+        TopicSelector::TopicName { name } => {
+            topic_permissions::Topic::TopicSelector(permissions_type::TopicSelector {
+                kind: Some(topic_selector::Kind::TopicName(name)),
+            })
+        }
+    }
+}
+
+fn topic_permission_to_grpc_permission(permission: TopicPermission) -> PermissionsType {
+    let grpc_topics_perm = permissions_type::TopicPermissions {
+        role: assign_topic_role(permission.role).into(),
+        cache: Some(assign_cache_selector_for_topic_permission(permission.cache)),
+        topic: Some(assign_topic_selector(permission.topic)),
+    };
+    permission_messages::PermissionsType {
+        kind: Some(permissions_type::Kind::TopicPermissions(grpc_topics_perm)),
+    }
+}
+
+fn assign_cache_item_selector(
+    item_selector: CacheItemSelector<impl IntoBytes>,
+) -> cache_permissions::CacheItem {
+    match item_selector {
+        CacheItemSelector::AllCacheItems => cache_permissions::CacheItem::AllItems(All {}),
+        CacheItemSelector::CacheItemKey(CacheItemKey { key }) => {
+            cache_permissions::CacheItem::ItemSelector(permissions_type::CacheItemSelector {
+                kind: Some(cache_item_selector::Kind::Key(key.into_bytes())),
+            })
+        }
+        CacheItemSelector::CacheItemKeyPrefix(CacheItemKeyPrefix { key_prefix }) => {
+            cache_permissions::CacheItem::ItemSelector(permissions_type::CacheItemSelector {
+                kind: Some(cache_item_selector::Kind::KeyPrefix(
+                    key_prefix.into_bytes(),
+                )),
+            })
+        }
+    }
+}
+
+fn disposable_token_permission_to_grpc_permission(
+    permission: DisposableTokenCachePermission<impl IntoBytes>,
+) -> PermissionsType {
+    let grpc_perm = permissions_type::CachePermissions {
+        role: assign_cache_role(permission.role).into(),
+        cache: Some(assign_cache_selector_for_cache_permission(permission.cache)),
+        cache_item: Some(assign_cache_item_selector(permission.item_selector)),
+    };
+    permission_messages::PermissionsType {
+        kind: Some(permissions_type::Kind::CachePermissions(grpc_perm)),
+    }
+}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,12 +1,15 @@
+/// Objects for representing expiry times.
 pub mod expiration;
 pub use expiration::{Expiration, ExpiresAt, ExpiresIn};
 
+/// Permissions structure for creating API keys and disposable tokens
 pub mod permissions;
 pub use permissions::disposable_token_scope::*;
 pub use permissions::disposable_token_scopes::DisposableTokenScopes;
 pub use permissions::permission_scope::*;
 pub use permissions::permission_scopes::PermissionScopes;
 
+/// Auth API requests and responses
 pub mod messages;
 pub use messages::generate_disposable_token::{
     GenerateDisposableTokenRequest, GenerateDisposableTokenResponse,

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -2,6 +2,10 @@ pub mod expiration;
 pub use expiration::{Expiration, ExpiresAt, ExpiresIn};
 
 pub mod permissions;
+pub use permissions::disposable_token_scope::*;
+pub use permissions::disposable_token_scopes::DisposableTokenScopes;
+pub use permissions::permission_scope::*;
+pub use permissions::permission_scopes::PermissionScopes;
 
 pub mod messages;
 pub use messages::generate_disposable_token::{

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,0 +1,14 @@
+pub mod expiration;
+pub use expiration::{Expiration, ExpiresAt, ExpiresIn};
+
+pub mod permissions;
+
+pub mod messages;
+pub use messages::generate_disposable_token::{
+    GenerateDisposableTokenRequest, GenerateDisposableTokenResponse,
+};
+pub use messages::MomentoRequest;
+
+mod auth_client;
+mod auth_client_builder;
+pub use auth_client::AuthClient;

--- a/src/auth/permissions/disposable_token_scope.rs
+++ b/src/auth/permissions/disposable_token_scope.rs
@@ -2,45 +2,63 @@ use crate::IntoBytes;
 
 use super::permission_scope::{CacheRole, CacheSelector, Permissions};
 
+/// A key for a specific item in a cache.
 pub struct CacheItemKey<K: IntoBytes> {
+    /// The cache item key
     pub key: K,
 }
 
-// Can accept a String or &str or bytes as CacheItemKey
-// rather than constructing CacheItemKey manually
+// An [IntoBytes] type can be passed in as a CacheItemKey.
 impl<K: IntoBytes> From<K> for CacheItemKey<K> {
     fn from(key: K) -> Self {
         CacheItemKey { key }
     }
 }
 
+/// A key prefix for items in a cache.
 pub struct CacheItemKeyPrefix<K: IntoBytes> {
+    /// The key prefix
     pub key_prefix: K,
 }
 
+/// An [IntoBytes] type can be passed in as a CacheItemKeyPrefix.
 impl<K: IntoBytes> From<K> for CacheItemKeyPrefix<K> {
     fn from(key_prefix: K) -> Self {
         CacheItemKeyPrefix { key_prefix }
     }
 }
 
+/// A component of a [DisposableTokenCachePermission].
+/// Specifies the cache item(s) to which the permission applies.
 pub enum CacheItemSelector<K: IntoBytes> {
+    /// Access to all cache items
     AllCacheItems,
+    /// Access to a specific cache item
     CacheItemKey(CacheItemKey<K>),
+    /// Access to all cache items with a specific key prefix
     CacheItemKeyPrefix(CacheItemKeyPrefix<K>),
 }
 
+/// A permission to be granted to a new disposable access token, specifying
+/// access to specific cache items.
 pub struct DisposableTokenCachePermission<K: IntoBytes> {
+    /// The type of access granted by the permission.
     pub role: CacheRole,
+    /// The cache(s) to which the permission applies.
     pub cache: CacheSelector,
+    /// The cache item(s) to which the permission applies.
     pub item_selector: CacheItemSelector<K>,
 }
 
+/// A set of permissions to be granted to a new disposable access token.
 pub struct DisposableTokenCachePermissions<K: IntoBytes> {
     pub(crate) permissions: Vec<DisposableTokenCachePermission<K>>,
 }
+
+/// The permission scope for creating a new disposable access token.
 pub enum DisposableTokenScope<K: IntoBytes> {
+    /// Set of permissions to be granted to a new token on the level of a cache or topic
     Permissions(Permissions),
-    // PredefinedScope, // does this need to exist?
+    /// Set of permissions to be granted to a new token on the level of a cache item (key or key prefix)
     DisposableTokenPermissions(DisposableTokenCachePermissions<K>),
 }

--- a/src/auth/permissions/disposable_token_scope.rs
+++ b/src/auth/permissions/disposable_token_scope.rs
@@ -1,0 +1,46 @@
+use crate::IntoBytes;
+
+use super::permission_scope::{CacheRole, CacheSelector, Permissions};
+
+pub struct CacheItemKey<K: IntoBytes> {
+    pub key: K,
+}
+
+// Can accept a String or &str or bytes as CacheItemKey
+// rather than constructing CacheItemKey manually
+impl<K: IntoBytes> From<K> for CacheItemKey<K> {
+    fn from(key: K) -> Self {
+        CacheItemKey { key }
+    }
+}
+
+pub struct CacheItemKeyPrefix<K: IntoBytes> {
+    pub key_prefix: K,
+}
+
+impl<K: IntoBytes> From<K> for CacheItemKeyPrefix<K> {
+    fn from(key_prefix: K) -> Self {
+        CacheItemKeyPrefix { key_prefix }
+    }
+}
+
+pub enum CacheItemSelector<K: IntoBytes> {
+    AllCacheItems,
+    CacheItemKey(CacheItemKey<K>),
+    CacheItemKeyPrefix(CacheItemKeyPrefix<K>),
+}
+
+pub struct DisposableTokenCachePermission<K: IntoBytes> {
+    pub role: CacheRole,
+    pub cache: CacheSelector,
+    pub item_selector: CacheItemSelector<K>,
+}
+
+pub struct DisposableTokenCachePermissions<K: IntoBytes> {
+    pub(crate) permissions: Vec<DisposableTokenCachePermission<K>>,
+}
+pub enum DisposableTokenScope<K: IntoBytes> {
+    Permissions(Permissions),
+    // PredefinedScope, // does this need to exist?
+    DisposableTokenPermissions(DisposableTokenCachePermissions<K>),
+}

--- a/src/auth/permissions/disposable_token_scopes.rs
+++ b/src/auth/permissions/disposable_token_scopes.rs
@@ -8,9 +8,11 @@ use super::{
     permission_scope::{CacheRole, CacheSelector},
 };
 
+/// A collection of convenience methods for creating disposable token permission scopes.
 pub struct DisposableTokenScopes {}
 
 impl DisposableTokenScopes {
+    /// Create a ReadWrite permission scope for a specific key in a specific cache.
     pub fn cache_key_read_write(
         cache_selector: impl Into<CacheSelector>,
         key: impl IntoBytes,
@@ -24,6 +26,7 @@ impl DisposableTokenScopes {
         })
     }
 
+    /// Create a ReadWrite permission scope for all keys matching the key prefix in a specific cache.
     pub fn cache_key_prefix_read_write(
         cache_selector: impl Into<CacheSelector>,
         key_prefix: impl IntoBytes,
@@ -39,6 +42,7 @@ impl DisposableTokenScopes {
         })
     }
 
+    /// Create a ReadOnly permission scope for a specific key in a specific cache.
     pub fn cache_key_read_only(
         cache_selector: impl Into<CacheSelector>,
         key: impl IntoBytes,
@@ -52,6 +56,7 @@ impl DisposableTokenScopes {
         })
     }
 
+    /// Create a ReadOnly permission scope for all keys matching the key prefix in a specific cache.
     pub fn cache_key_prefix_read_only(
         cache_selector: impl Into<CacheSelector>,
         key_prefix: impl IntoBytes,
@@ -67,6 +72,7 @@ impl DisposableTokenScopes {
         })
     }
 
+    /// Create a WriteOnly permission scope for a specific key in a specific cache.
     pub fn cache_key_write_only(
         cache_selector: impl Into<CacheSelector>,
         key: impl IntoBytes,
@@ -80,6 +86,7 @@ impl DisposableTokenScopes {
         })
     }
 
+    /// Create a WriteOnly permission scope for all keys matching the key prefix in a specific cache.
     pub fn cache_key_prefix_write_only(
         cache_selector: impl Into<CacheSelector>,
         key_prefix: impl IntoBytes,

--- a/src/auth/permissions/disposable_token_scopes.rs
+++ b/src/auth/permissions/disposable_token_scopes.rs
@@ -1,0 +1,97 @@
+use crate::IntoBytes;
+
+use super::{
+    disposable_token_scope::{
+        CacheItemKey, CacheItemKeyPrefix, CacheItemSelector, DisposableTokenCachePermission,
+        DisposableTokenCachePermissions, DisposableTokenScope,
+    },
+    permission_scope::{CacheRole, CacheSelector},
+};
+
+pub struct DisposableTokenScopes {}
+
+impl DisposableTokenScopes {
+    pub fn cache_key_read_write(
+        cache_selector: impl Into<CacheSelector>,
+        key: impl IntoBytes,
+    ) -> DisposableTokenScope<impl IntoBytes> {
+        DisposableTokenScope::DisposableTokenPermissions(DisposableTokenCachePermissions {
+            permissions: vec![DisposableTokenCachePermission {
+                role: CacheRole::ReadWrite,
+                cache: cache_selector.into(),
+                item_selector: CacheItemSelector::CacheItemKey(CacheItemKey { key }),
+            }],
+        })
+    }
+
+    pub fn cache_key_prefix_read_write(
+        cache_selector: impl Into<CacheSelector>,
+        key_prefix: impl IntoBytes,
+    ) -> DisposableTokenScope<impl IntoBytes> {
+        DisposableTokenScope::DisposableTokenPermissions(DisposableTokenCachePermissions {
+            permissions: vec![DisposableTokenCachePermission {
+                role: CacheRole::ReadWrite,
+                cache: cache_selector.into(),
+                item_selector: CacheItemSelector::CacheItemKeyPrefix(CacheItemKeyPrefix {
+                    key_prefix,
+                }),
+            }],
+        })
+    }
+
+    pub fn cache_key_read_only(
+        cache_selector: impl Into<CacheSelector>,
+        key: impl IntoBytes,
+    ) -> DisposableTokenScope<impl IntoBytes> {
+        DisposableTokenScope::DisposableTokenPermissions(DisposableTokenCachePermissions {
+            permissions: vec![DisposableTokenCachePermission {
+                role: CacheRole::ReadOnly,
+                cache: cache_selector.into(),
+                item_selector: CacheItemSelector::CacheItemKey(CacheItemKey { key }),
+            }],
+        })
+    }
+
+    pub fn cache_key_prefix_read_only(
+        cache_selector: impl Into<CacheSelector>,
+        key_prefix: impl IntoBytes,
+    ) -> DisposableTokenScope<impl IntoBytes> {
+        DisposableTokenScope::DisposableTokenPermissions(DisposableTokenCachePermissions {
+            permissions: vec![DisposableTokenCachePermission {
+                role: CacheRole::ReadOnly,
+                cache: cache_selector.into(),
+                item_selector: CacheItemSelector::CacheItemKeyPrefix(CacheItemKeyPrefix {
+                    key_prefix,
+                }),
+            }],
+        })
+    }
+
+    pub fn cache_key_write_only(
+        cache_selector: impl Into<CacheSelector>,
+        key: impl IntoBytes,
+    ) -> DisposableTokenScope<impl IntoBytes> {
+        DisposableTokenScope::DisposableTokenPermissions(DisposableTokenCachePermissions {
+            permissions: vec![DisposableTokenCachePermission {
+                role: CacheRole::WriteOnly,
+                cache: cache_selector.into(),
+                item_selector: CacheItemSelector::CacheItemKey(CacheItemKey { key }),
+            }],
+        })
+    }
+
+    pub fn cache_key_prefix_write_only(
+        cache_selector: impl Into<CacheSelector>,
+        key_prefix: impl IntoBytes,
+    ) -> DisposableTokenScope<impl IntoBytes> {
+        DisposableTokenScope::DisposableTokenPermissions(DisposableTokenCachePermissions {
+            permissions: vec![DisposableTokenCachePermission {
+                role: CacheRole::WriteOnly,
+                cache: cache_selector.into(),
+                item_selector: CacheItemSelector::CacheItemKeyPrefix(CacheItemKeyPrefix {
+                    key_prefix,
+                }),
+            }],
+        })
+    }
+}

--- a/src/auth/permissions/mod.rs
+++ b/src/auth/permissions/mod.rs
@@ -1,0 +1,5 @@
+pub mod disposable_token_scope;
+pub mod disposable_token_scopes;
+
+pub mod permission_scope;
+pub mod permission_scopes;

--- a/src/auth/permissions/mod.rs
+++ b/src/auth/permissions/mod.rs
@@ -1,5 +1,11 @@
+/// DisposableTokenScope struct and related enums.
 pub mod disposable_token_scope;
+
+/// Convenience methods for creating DisposableTokenScope objects.
 pub mod disposable_token_scopes;
 
+/// PermissionScope struct and related enums.
 pub mod permission_scope;
+
+/// Convenience methods for creating PermissionScope objects.
 pub mod permission_scopes;

--- a/src/auth/permissions/permission_scope.rs
+++ b/src/auth/permissions/permission_scope.rs
@@ -1,20 +1,34 @@
+/// A component of a [CachePermission].
+/// Type of access granted by the permission.
 pub enum CacheRole {
+    /// Allows read-write access to a cache
     ReadWrite,
+    /// Allows read-only access to a cache
     ReadOnly,
+    /// Allows write-only access to a cache
     WriteOnly,
 }
 
+/// A component of a [CachePermission].
+/// A permission can be restricted to a specific cache or to all caches.
 pub enum CacheSelector {
+    /// Apply permission to all caches
     AllCaches,
-    CacheName { name: String },
+    /// Apply permission to a specific cache
+    CacheName {
+        /// The name of the cache
+        name: String,
+    },
 }
 
+/// A String can be passed in as a CacheSelector::CacheName
 impl From<String> for CacheSelector {
     fn from(name: String) -> Self {
         CacheSelector::CacheName { name }
     }
 }
 
+/// A string literal can be passed in as a CacheSelector::CacheName
 impl From<&str> for CacheSelector {
     fn from(name: &str) -> Self {
         CacheSelector::CacheName {
@@ -23,28 +37,45 @@ impl From<&str> for CacheSelector {
     }
 }
 
+/// Defines access permissions for a cache.
 pub struct CachePermission {
+    /// The type of access granted by the permission.
     pub role: CacheRole,
+    /// The cache(s) to which the permission applies.
     pub cache: CacheSelector,
 }
 
+/// A component of a [TopicPermission].
+/// Type of access granted by the permission.
 pub enum TopicRole {
+    /// Allows both publishing and subscribing to a topic
     PublishSubscribe,
+    /// Allows only subscribing to a topic
     SubscribeOnly,
+    /// Allows only publishing to a topic
     PublishOnly,
 }
 
+/// A component of a [TopicPermission].
+/// A permission can be restricted to a specific topic or to all topics in a cache.
 pub enum TopicSelector {
+    /// Apply permission to all topics
     AllTopics,
-    TopicName { name: String },
+    /// Apply permission to a specific topic
+    TopicName {
+        /// The name of the topic
+        name: String,
+    },
 }
 
+// A String can be passed in as a TopicSelector::TopicName
 impl From<String> for TopicSelector {
     fn from(name: String) -> Self {
         TopicSelector::TopicName { name }
     }
 }
 
+/// A string literal can be passed in as a TopicSelector::TopicName
 impl From<&str> for TopicSelector {
     fn from(name: &str) -> Self {
         TopicSelector::TopicName {
@@ -53,22 +84,32 @@ impl From<&str> for TopicSelector {
     }
 }
 
+/// Defines access permissions for a topic in a cache.
 pub struct TopicPermission {
+    /// The type of access granted by the permission.
     pub role: TopicRole,
+    /// The cache(s) to which the permission applies.
     pub cache: CacheSelector,
+    /// The topic(s) to which the permission applies.
     pub topic: TopicSelector,
 }
 
+/// A component of a [PermissionScope].
 pub enum Permission {
+    /// Defines the permissions for a cache.
     CachePermission(CachePermission),
+    /// Defines the permissions for a topic in a cache.
     TopicPermission(TopicPermission),
 }
 
+/// Permissions object contains the set of permissions to be granted to a new API key.
 pub struct Permissions {
+    /// The set of permissions to be granted to a new API key.
     pub permissions: Vec<Permission>,
 }
 
 impl Permissions {
+    /// Create a permission scope allowing read-write access to all caches and topics.
     pub fn all_data_read_write() -> Permissions {
         Permissions {
             permissions: vec![
@@ -86,7 +127,10 @@ impl Permissions {
     }
 }
 
+/// The permission scope for creating a new API key.
 pub enum PermissionScope {
+    /// Set of permissions to be granted to a new API key
     Permissions(Permissions),
+    /// PredefinedScope for internal use
     PredefinedScope,
 }

--- a/src/auth/permissions/permission_scope.rs
+++ b/src/auth/permissions/permission_scope.rs
@@ -1,0 +1,92 @@
+pub enum CacheRole {
+    ReadWrite,
+    ReadOnly,
+    WriteOnly,
+}
+
+pub enum CacheSelector {
+    AllCaches,
+    CacheName { name: String },
+}
+
+impl From<String> for CacheSelector {
+    fn from(name: String) -> Self {
+        CacheSelector::CacheName { name }
+    }
+}
+
+impl From<&str> for CacheSelector {
+    fn from(name: &str) -> Self {
+        CacheSelector::CacheName {
+            name: name.to_string(),
+        }
+    }
+}
+
+pub struct CachePermission {
+    pub role: CacheRole,
+    pub cache: CacheSelector,
+}
+
+pub enum TopicRole {
+    PublishSubscribe,
+    SubscribeOnly,
+    PublishOnly,
+}
+
+pub enum TopicSelector {
+    AllTopics,
+    TopicName { name: String },
+}
+
+impl From<String> for TopicSelector {
+    fn from(name: String) -> Self {
+        TopicSelector::TopicName { name }
+    }
+}
+
+impl From<&str> for TopicSelector {
+    fn from(name: &str) -> Self {
+        TopicSelector::TopicName {
+            name: name.to_string(),
+        }
+    }
+}
+
+pub struct TopicPermission {
+    pub role: TopicRole,
+    pub cache: CacheSelector,
+    pub topic: TopicSelector,
+}
+
+pub enum Permission {
+    CachePermission(CachePermission),
+    TopicPermission(TopicPermission),
+}
+
+pub struct Permissions {
+    pub permissions: Vec<Permission>,
+}
+
+impl Permissions {
+    pub fn all_data_read_write() -> Permissions {
+        Permissions {
+            permissions: vec![
+                Permission::CachePermission(CachePermission {
+                    role: CacheRole::ReadWrite,
+                    cache: CacheSelector::AllCaches,
+                }),
+                Permission::TopicPermission(TopicPermission {
+                    role: TopicRole::PublishSubscribe,
+                    cache: CacheSelector::AllCaches,
+                    topic: TopicSelector::AllTopics,
+                }),
+            ],
+        }
+    }
+}
+
+pub enum PermissionScope {
+    Permissions(Permissions),
+    PredefinedScope,
+}

--- a/src/auth/permissions/permission_scopes.rs
+++ b/src/auth/permissions/permission_scopes.rs
@@ -3,9 +3,12 @@ use super::permission_scope::{
     TopicPermission, TopicRole, TopicSelector,
 };
 
+/// A collection of convenience methods for creating permission scopes.
+/// These can be used to create both longer-lived API keys and disposable tokens.
 pub struct PermissionScopes {}
 
 impl PermissionScopes {
+    /// Create a ReadWrite permission scope for a specific cache.
     pub fn cache_read_write(cache_selector: impl Into<CacheSelector>) -> PermissionScope {
         PermissionScope::Permissions(Permissions {
             permissions: vec![Permission::CachePermission(CachePermission {
@@ -15,6 +18,7 @@ impl PermissionScopes {
         })
     }
 
+    /// Create a ReadOnly permission scope for a specific cache.
     pub fn cache_read_only(cache_selector: impl Into<CacheSelector>) -> PermissionScope {
         PermissionScope::Permissions(Permissions {
             permissions: vec![Permission::CachePermission(CachePermission {
@@ -24,6 +28,7 @@ impl PermissionScopes {
         })
     }
 
+    /// Create a WriteOnly permission scope for a specific cache.
     pub fn cache_write_only(cache_selector: impl Into<CacheSelector>) -> PermissionScope {
         PermissionScope::Permissions(Permissions {
             permissions: vec![Permission::CachePermission(CachePermission {
@@ -33,6 +38,7 @@ impl PermissionScopes {
         })
     }
 
+    /// Create a PublishSubscribe permission scope for a specific topic in a specific cache.
     pub fn topic_publish_subscribe(
         cache_selector: impl Into<CacheSelector>,
         topic_selector: impl Into<TopicSelector>,
@@ -46,6 +52,7 @@ impl PermissionScopes {
         })
     }
 
+    /// Create a SubscribeOnly permission scope for a specific topic in a specific cache.
     pub fn topic_subscribe_only(
         cache_selector: impl Into<CacheSelector>,
         topic_selector: impl Into<TopicSelector>,
@@ -59,6 +66,7 @@ impl PermissionScopes {
         })
     }
 
+    /// Create a PublishOnly permission scope for a specific topic in a specific cache.
     pub fn topic_publish_only(
         cache_selector: impl Into<CacheSelector>,
         topic_selector: impl Into<TopicSelector>,

--- a/src/auth/permissions/permission_scopes.rs
+++ b/src/auth/permissions/permission_scopes.rs
@@ -1,0 +1,74 @@
+use super::permission_scope::{
+    CachePermission, CacheRole, CacheSelector, Permission, PermissionScope, Permissions,
+    TopicPermission, TopicRole, TopicSelector,
+};
+
+pub struct PermissionScopes {}
+
+impl PermissionScopes {
+    pub fn cache_read_write(cache_selector: impl Into<CacheSelector>) -> PermissionScope {
+        PermissionScope::Permissions(Permissions {
+            permissions: vec![Permission::CachePermission(CachePermission {
+                role: CacheRole::ReadWrite,
+                cache: cache_selector.into(),
+            })],
+        })
+    }
+
+    pub fn cache_read_only(cache_selector: impl Into<CacheSelector>) -> PermissionScope {
+        PermissionScope::Permissions(Permissions {
+            permissions: vec![Permission::CachePermission(CachePermission {
+                role: CacheRole::ReadOnly,
+                cache: cache_selector.into(),
+            })],
+        })
+    }
+
+    pub fn cache_write_only(cache_selector: impl Into<CacheSelector>) -> PermissionScope {
+        PermissionScope::Permissions(Permissions {
+            permissions: vec![Permission::CachePermission(CachePermission {
+                role: CacheRole::WriteOnly,
+                cache: cache_selector.into(),
+            })],
+        })
+    }
+
+    pub fn topic_publish_subscribe(
+        cache_selector: impl Into<CacheSelector>,
+        topic_selector: impl Into<TopicSelector>,
+    ) -> PermissionScope {
+        PermissionScope::Permissions(Permissions {
+            permissions: vec![Permission::TopicPermission(TopicPermission {
+                role: TopicRole::PublishSubscribe,
+                cache: cache_selector.into(),
+                topic: topic_selector.into(),
+            })],
+        })
+    }
+
+    pub fn topic_subscribe_only(
+        cache_selector: impl Into<CacheSelector>,
+        topic_selector: impl Into<TopicSelector>,
+    ) -> PermissionScope {
+        PermissionScope::Permissions(Permissions {
+            permissions: vec![Permission::TopicPermission(TopicPermission {
+                role: TopicRole::SubscribeOnly,
+                cache: cache_selector.into(),
+                topic: topic_selector.into(),
+            })],
+        })
+    }
+
+    pub fn topic_publish_only(
+        cache_selector: impl Into<CacheSelector>,
+        topic_selector: impl Into<TopicSelector>,
+    ) -> PermissionScope {
+        PermissionScope::Permissions(Permissions {
+            permissions: vec![Permission::TopicPermission(TopicPermission {
+                role: TopicRole::PublishOnly,
+                cache: cache_selector.into(),
+                topic: topic_selector.into(),
+            })],
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,3 +142,7 @@ pub use crate::utils::{IntoBytes, IntoBytesIterable};
 
 /// Represents the result of a Momento operation.
 pub type MomentoResult<T> = Result<T, MomentoError>;
+
+/// Contains the [AuthClient] for calling Momento Auth APIs.
+pub mod auth;
+pub use auth::AuthClient;

--- a/test-util/src/lib.rs
+++ b/test-util/src/lib.rs
@@ -8,6 +8,7 @@ pub use crate::test_data::{
     unique_value, TestDictionary, TestList, TestScalar, TestSet, TestSortedSet,
 };
 pub use crate::test_utils::{
-    create_doctest_cache_client, create_doctest_storage_client, create_doctest_topic_client,
-    doctest, get_test_cache_name, get_test_credential_provider, get_test_store_name, DoctestResult,
+    create_doctest_auth_client, create_doctest_cache_client, create_doctest_storage_client,
+    create_doctest_topic_client, doctest, get_test_cache_name, get_test_credential_provider,
+    get_test_store_name, DoctestResult,
 };

--- a/test-util/src/test_utils.rs
+++ b/test-util/src/test_utils.rs
@@ -79,6 +79,10 @@ pub fn get_test_store_name() -> String {
     env::var("TEST_STORE_NAME").unwrap_or("rust-sdk-test-store".to_string())
 }
 
+pub fn get_test_auth_cache_name() -> String {
+    env::var("TEST_CACHE_NAME").unwrap_or("rust-sdk-test-cache-auth".to_string())
+}
+
 #[allow(clippy::expect_used)] // we want to panic if the env var is not set
 pub fn get_test_credential_provider() -> CredentialProvider {
     CredentialProvider::from_env_var("MOMENTO_API_KEY".to_string())

--- a/test-util/src/test_utils.rs
+++ b/test-util/src/test_utils.rs
@@ -80,7 +80,7 @@ pub fn get_test_store_name() -> String {
 }
 
 pub fn get_test_auth_cache_name() -> String {
-    env::var("TEST_CACHE_NAME").unwrap_or("rust-sdk-test-cache-auth".to_string())
+    env::var("TEST_AUTH_CACHE_NAME").unwrap_or("rust-sdk-test-cache-auth".to_string())
 }
 
 #[allow(clippy::expect_used)] // we want to panic if the env var is not set

--- a/test-util/src/test_utils.rs
+++ b/test-util/src/test_utils.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use momento::cache::configurations;
 use momento::storage::PreviewStorageClient;
+use momento::AuthClient;
 use momento::CacheClient;
 use momento::CredentialProvider;
 use momento::TopicClient;
@@ -31,7 +32,7 @@ where
     let _guard = runtime.enter();
 
     let cache_name = unique_cache_name();
-    let (client, _, _, credential_provider) = build_clients_and_credential_provider();
+    let (client, _, _, _, credential_provider) = build_clients_and_credential_provider();
     runtime.block_on(client.create_cache(&cache_name))?;
 
     let runtime = scopeguard::guard(runtime, {
@@ -49,20 +50,25 @@ where
 
 pub fn create_doctest_cache_client() -> (CacheClient, String) {
     let cache_name = get_test_cache_name();
-    let (cache_client, _, _, _) = build_clients_and_credential_provider();
+    let (cache_client, _, _, _, _) = build_clients_and_credential_provider();
     (cache_client, cache_name)
 }
 
 pub fn create_doctest_storage_client() -> (PreviewStorageClient, String) {
     let store_name = get_test_store_name();
-    let (_, _, storage_client, _) = build_clients_and_credential_provider();
+    let (_, _, storage_client, _, _) = build_clients_and_credential_provider();
     (storage_client, store_name)
 }
 
 pub fn create_doctest_topic_client() -> (TopicClient, String) {
     let cache_name = get_test_cache_name();
-    let (_, topic_client, _, _) = build_clients_and_credential_provider();
+    let (_, topic_client, _, _, _) = build_clients_and_credential_provider();
     (topic_client, cache_name)
+}
+
+pub fn create_doctest_auth_client() -> AuthClient {
+    let (_, _, _, auth_client, _) = build_clients_and_credential_provider();
+    auth_client
 }
 
 pub fn get_test_cache_name() -> String {
@@ -83,6 +89,7 @@ pub fn build_clients_and_credential_provider() -> (
     CacheClient,
     TopicClient,
     PreviewStorageClient,
+    AuthClient,
     CredentialProvider,
 ) {
     let credential_provider = get_test_credential_provider();
@@ -102,11 +109,16 @@ pub fn build_clients_and_credential_provider() -> (
         .credential_provider(credential_provider.clone())
         .build()
         .expect("storage client should be created");
+    let auth_client = momento::AuthClient::builder()
+        .credential_provider(credential_provider.clone())
+        .build()
+        .expect("auth client should be created");
 
     (
         cache_client,
         topic_client,
         storage_client,
+        auth_client,
         credential_provider,
     )
 }

--- a/tests/auth/disposable_tokens.rs
+++ b/tests/auth/disposable_tokens.rs
@@ -48,10 +48,10 @@ fn new_topic_client(credential_provider: CredentialProvider) -> TopicClient {
 
 async fn assert_get_success(
     cache_client: &CacheClient,
-    cache_name: String,
-    key: String,
+    cache_name: &str,
+    key: &str,
 ) -> MomentoResult<()> {
-    match cache_client.get(cache_name.clone(), key.clone()).await {
+    match cache_client.get(cache_name, key).await {
         Ok(_) => Ok(()),
         Err(e) => {
             eprintln!(
@@ -65,10 +65,10 @@ async fn assert_get_success(
 
 async fn assert_get_failure(
     cache_client: &CacheClient,
-    cache_name: String,
-    key: String,
+    cache_name: &str,
+    key: &str,
 ) -> MomentoResult<()> {
-    match cache_client.get(cache_name.clone(), key.clone()).await {
+    match cache_client.get(cache_name, key).await {
         Ok(_) => Err(MomentoError {
             message: format!(
                 "Expected getting key '{}' from cache '{}' to fail",
@@ -87,14 +87,11 @@ async fn assert_get_failure(
 
 async fn assert_set_success(
     cache_client: &CacheClient,
-    cache_name: String,
-    key: String,
-    value: String,
+    cache_name: &str,
+    key: &str,
+    value: &str,
 ) -> MomentoResult<()> {
-    match cache_client
-        .set(cache_name.clone(), key.clone(), value.clone())
-        .await
-    {
+    match cache_client.set(cache_name, key, value).await {
         Ok(_) => Ok(()),
         Err(e) => {
             eprintln!(
@@ -108,14 +105,11 @@ async fn assert_set_success(
 
 async fn assert_set_failure(
     cache_client: &CacheClient,
-    cache_name: String,
-    key: String,
-    value: String,
+    cache_name: &str,
+    key: &str,
+    value: &str,
 ) -> MomentoResult<()> {
-    match cache_client
-        .set(cache_name.clone(), key.clone(), value.clone())
-        .await
-    {
+    match cache_client.set(cache_name, key, value).await {
         Ok(_) => Err(MomentoError {
             message: format!(
                 "Expected setting value '{}' for key '{}' from cache '{}' to fail",
@@ -134,14 +128,11 @@ async fn assert_set_failure(
 
 async fn assert_publish_success(
     topic_client: &TopicClient,
-    cache_name: String,
-    topic_name: String,
-    value: String,
+    cache_name: &str,
+    topic_name: &str,
+    value: &str,
 ) -> MomentoResult<()> {
-    match topic_client
-        .publish(cache_name.clone(), topic_name.clone(), value.clone())
-        .await
-    {
+    match topic_client.publish(cache_name, topic_name, value).await {
         Ok(_) => Ok(()),
         Err(e) => {
             eprintln!(
@@ -155,14 +146,11 @@ async fn assert_publish_success(
 
 async fn assert_publish_failure(
     topic_client: &TopicClient,
-    cache_name: String,
-    topic_name: String,
-    value: String,
+    cache_name: &str,
+    topic_name: &str,
+    value: &str,
 ) -> MomentoResult<()> {
-    match topic_client
-        .publish(cache_name.clone(), topic_name.clone(), value.clone())
-        .await
-    {
+    match topic_client.publish(cache_name, topic_name, value).await {
         Ok(_) => Err(MomentoError {
             message: format!(
                 "Expected publishing value '{}' for topic '{}' in cache '{}' to fail",
@@ -181,13 +169,10 @@ async fn assert_publish_failure(
 
 async fn assert_subscribe_success(
     topic_client: &TopicClient,
-    cache_name: String,
-    topic_name: String,
+    cache_name: &str,
+    topic_name: &str,
 ) -> MomentoResult<()> {
-    match topic_client
-        .subscribe(cache_name.clone(), topic_name.clone())
-        .await
-    {
+    match topic_client.subscribe(cache_name, topic_name).await {
         Ok(_) => Ok(()),
         Err(e) => {
             eprintln!(
@@ -201,13 +186,10 @@ async fn assert_subscribe_success(
 
 async fn assert_subscribe_failure(
     topic_client: &TopicClient,
-    cache_name: String,
-    topic_name: String,
+    cache_name: &str,
+    topic_name: &str,
 ) -> MomentoResult<()> {
-    match topic_client
-        .subscribe(cache_name.clone(), topic_name.clone())
-        .await
-    {
+    match topic_client.subscribe(cache_name, topic_name).await {
         Ok(_) => Err(MomentoError {
             message: format!(
                 "Expected subscribe to topic '{}' in cache '{}' to fail",
@@ -241,68 +223,36 @@ mod disposable_tokens_cache_key {
         let topic_client = new_topic_client(creds);
 
         // should be able to read this key in both caches
-        assert_get_success(
-            &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_success(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
+        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_success(&cache_client, second_cache, test_item.key()).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
-        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+        assert_get_failure(&cache_client, first_cache, &other_key).await?;
+        assert_get_failure(&cache_client, second_cache, &other_key).await?;
 
         // should not be able to write the key in either cache
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -321,68 +271,36 @@ mod disposable_tokens_cache_key {
         let topic_client = new_topic_client(creds);
 
         // should be able to read this key in only first cache
-        assert_get_success(
-            &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
+        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
-        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+        assert_get_failure(&cache_client, first_cache, &other_key).await?;
+        assert_get_failure(&cache_client, second_cache, &other_key).await?;
 
         // should not be able to write the key in either cache
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -401,68 +319,36 @@ mod disposable_tokens_cache_key {
         let topic_client = new_topic_client(creds);
 
         // should not be able to read this key in either cache
-        assert_get_failure(
-            &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
-        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+        assert_get_failure(&cache_client, first_cache, &other_key).await?;
+        assert_get_failure(&cache_client, second_cache, &other_key).await?;
 
         // should be able to write the key in both caches
         assert_set_success(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_success(
             &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -481,68 +367,36 @@ mod disposable_tokens_cache_key {
         let topic_client = new_topic_client(creds);
 
         // should not be able to read this key in either cache
-        assert_get_failure(
-            &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
-        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+        assert_get_failure(&cache_client, first_cache, &other_key).await?;
+        assert_get_failure(&cache_client, second_cache, &other_key).await?;
 
         // should be able to write the key in only first cache
         assert_set_success(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -561,68 +415,36 @@ mod disposable_tokens_cache_key {
         let topic_client = new_topic_client(creds);
 
         // should be able to read this key in both caches
-        assert_get_success(
-            &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_success(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
+        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_success(&cache_client, second_cache, test_item.key()).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
-        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+        assert_get_failure(&cache_client, first_cache, &other_key).await?;
+        assert_get_failure(&cache_client, second_cache, &other_key).await?;
 
         // should be able to write the key in both caches
         assert_set_success(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_success(
             &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -641,68 +463,36 @@ mod disposable_tokens_cache_key {
         let topic_client = new_topic_client(creds);
 
         // should be able to read this key in only first cache
-        assert_get_success(
-            &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
+        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
-        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+        assert_get_failure(&cache_client, first_cache, &other_key).await?;
+        assert_get_failure(&cache_client, second_cache, &other_key).await?;
 
         // should be able to write the key in only first cache
         assert_set_success(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -725,78 +515,41 @@ mod disposable_tokens_cache_key_prefix {
         let topic_client = new_topic_client(creds);
 
         // should be able to read this key in only first cache
-        assert_get_success(
-            &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
+        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
 
         // should be able to read a prefixed key in only first cache
         let prefixed_key = format!("{}-smth-else", test_item.key());
-        assert_get_success(&cache_client, first_cache.to_string(), prefixed_key.clone()).await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            prefixed_key.clone(),
-        )
-        .await?;
+        assert_get_success(&cache_client, first_cache, &prefixed_key).await?;
+        assert_get_failure(&cache_client, second_cache, &prefixed_key).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
-        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+        assert_get_failure(&cache_client, first_cache, &other_key).await?;
+        assert_get_failure(&cache_client, second_cache, &other_key).await?;
 
         // should not be able to write the key in either cache
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -817,78 +570,41 @@ mod disposable_tokens_cache_key_prefix {
         let topic_client = new_topic_client(creds);
 
         // should be able to read this key in both caches
-        assert_get_success(
-            &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_success(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
+        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_success(&cache_client, second_cache, test_item.key()).await?;
 
         // should be able to read a prefixed key in both caches
         let prefixed_key = format!("{}-smth-else", test_item.key());
-        assert_get_success(&cache_client, first_cache.to_string(), prefixed_key.clone()).await?;
-        assert_get_success(
-            &cache_client,
-            second_cache.to_string(),
-            prefixed_key.clone(),
-        )
-        .await?;
+        assert_get_success(&cache_client, first_cache, &prefixed_key).await?;
+        assert_get_success(&cache_client, second_cache, &prefixed_key).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
-        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+        assert_get_failure(&cache_client, first_cache, &other_key).await?;
+        assert_get_failure(&cache_client, second_cache, &other_key).await?;
 
         // should not be able to write the key in either cache
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -909,78 +625,41 @@ mod disposable_tokens_cache_key_prefix {
         let topic_client = new_topic_client(creds);
 
         // should not be able to read this key in either cache
-        assert_get_failure(
-            &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
 
         // should not be able to read a prefixed key in either cache
         let prefixed_key = format!("{}-smth-else", test_item.key());
-        assert_get_failure(&cache_client, first_cache.to_string(), prefixed_key.clone()).await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            prefixed_key.clone(),
-        )
-        .await?;
+        assert_get_failure(&cache_client, first_cache, &prefixed_key).await?;
+        assert_get_failure(&cache_client, second_cache, &prefixed_key).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
-        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+        assert_get_failure(&cache_client, first_cache, &other_key).await?;
+        assert_get_failure(&cache_client, second_cache, &other_key).await?;
 
         // should be able to write the key in only first cache
         assert_set_success(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -1001,78 +680,41 @@ mod disposable_tokens_cache_key_prefix {
         let topic_client = new_topic_client(creds);
 
         // should not be able to read this key in either cache
-        assert_get_failure(
-            &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
 
         // should not be able to read a prefixed key in either cache
         let prefixed_key = format!("{}-smth-else", test_item.key());
-        assert_get_failure(&cache_client, first_cache.to_string(), prefixed_key.clone()).await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            prefixed_key.clone(),
-        )
-        .await?;
+        assert_get_failure(&cache_client, first_cache, &prefixed_key).await?;
+        assert_get_failure(&cache_client, second_cache, &prefixed_key).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
-        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+        assert_get_failure(&cache_client, first_cache, &other_key).await?;
+        assert_get_failure(&cache_client, second_cache, &other_key).await?;
 
         // should be able to write the key in both caches
         assert_set_success(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_success(
             &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -1093,78 +735,41 @@ mod disposable_tokens_cache_key_prefix {
         let topic_client = new_topic_client(creds);
 
         // should be able to read this key in only first cache
-        assert_get_success(
-            &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
+        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
 
         // should be able to read a prefixed key in only first cache
         let prefixed_key = format!("{}-smth-else", test_item.key());
-        assert_get_success(&cache_client, first_cache.to_string(), prefixed_key.clone()).await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            prefixed_key.clone(),
-        )
-        .await?;
+        assert_get_success(&cache_client, first_cache, &prefixed_key).await?;
+        assert_get_failure(&cache_client, second_cache, &prefixed_key).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
-        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+        assert_get_failure(&cache_client, first_cache, &other_key).await?;
+        assert_get_failure(&cache_client, second_cache, &other_key).await?;
 
         // should be able to write the key in only first cache
         assert_set_success(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -1185,78 +790,41 @@ mod disposable_tokens_cache_key_prefix {
         let topic_client = new_topic_client(creds);
 
         // should be able to read this key in both caches
-        assert_get_success(
-            &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_success(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
+        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_success(&cache_client, second_cache, test_item.key()).await?;
 
         // should be able to read a prefixed key in both caches
         let prefixed_key = format!("{}-smth-else", test_item.key());
-        assert_get_success(&cache_client, first_cache.to_string(), prefixed_key.clone()).await?;
-        assert_get_success(
-            &cache_client,
-            second_cache.to_string(),
-            prefixed_key.clone(),
-        )
-        .await?;
+        assert_get_success(&cache_client, first_cache, &prefixed_key).await?;
+        assert_get_success(&cache_client, second_cache, &prefixed_key).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
-        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+        assert_get_failure(&cache_client, first_cache, &other_key).await?;
+        assert_get_failure(&cache_client, second_cache, &other_key).await?;
 
         // should be able to write the key in both caches
         assert_set_success(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_success(
             &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -1272,7 +840,7 @@ mod disposable_tokens_cache {
         let response = generate_disposable_token_success(
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::CachePermission(CachePermission {
-                    cache: first_cache.to_string().into(),
+                    cache: (*first_cache).clone().into(),
                     role: CacheRole::ReadWrite,
                 })],
             }),
@@ -1284,61 +852,29 @@ mod disposable_tokens_cache {
 
         // should be able to read and write in only first cache
         let test_item = TestScalar::new();
-        assert_get_success(
-            &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
+        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
         assert_set_success(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -1362,61 +898,29 @@ mod disposable_tokens_cache {
 
         // should be able to read and write in both caches
         let test_item = TestScalar::new();
-        assert_get_success(
+        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_success(&cache_client, second_cache, test_item.key()).await?;
+        assert_set_success(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_success(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_success(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
-        )
-        .await?;
-        assert_set_success(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -1428,7 +932,7 @@ mod disposable_tokens_cache {
         let response = generate_disposable_token_success(
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::CachePermission(CachePermission {
-                    cache: first_cache.to_string().into(),
+                    cache: (*first_cache).clone().into(),
                     role: CacheRole::ReadOnly,
                 })],
             }),
@@ -1440,63 +944,31 @@ mod disposable_tokens_cache {
 
         // should be able to read in only first cache
         let test_item = TestScalar::new();
-        assert_get_success(
-            &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
+        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
 
         // should not be able to write in either cache
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -1520,63 +992,31 @@ mod disposable_tokens_cache {
 
         // should be able to read in both caches
         let test_item = TestScalar::new();
-        assert_get_success(
-            &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_success(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
+        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_success(&cache_client, second_cache, test_item.key()).await?;
 
         // should not be able to write in either cache
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -1588,7 +1028,7 @@ mod disposable_tokens_cache {
         let response = generate_disposable_token_success(
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::CachePermission(CachePermission {
-                    cache: first_cache.to_string().into(),
+                    cache: (*first_cache).clone().into(),
                     role: CacheRole::WriteOnly,
                 })],
             }),
@@ -1600,63 +1040,31 @@ mod disposable_tokens_cache {
 
         // should not be able to read in either cache
         let test_item = TestScalar::new();
-        assert_get_failure(
-            &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
 
         // should be able to write in only first cache
         assert_set_success(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -1680,63 +1088,31 @@ mod disposable_tokens_cache {
 
         // should not be able to read in either cache
         let test_item = TestScalar::new();
-        assert_get_failure(
-            &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
 
         // should be able to write in both caches
         assert_set_success(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_success(
             &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-            topic.value().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            topic.key().to_string(),
-        )
-        .await?;
+        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -1755,8 +1131,8 @@ mod disposable_tokens_topics {
         let response = generate_disposable_token_success(
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: first_cache.to_string().into(),
-                    topic: test_topic.key().to_string().into(),
+                    cache: (*first_cache).clone().into(),
+                    topic: test_topic.key().into(),
                     role: TopicRole::PublishSubscribe,
                 })],
             }),
@@ -1768,60 +1144,40 @@ mod disposable_tokens_topics {
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should be able to publish and subscribe in only first cache on only the specific topic
         assert_publish_success(
             &topic_client,
-            first_cache.to_string(),
-            test_topic.key().to_string(),
-            test_topic.value().to_string(),
+            first_cache,
+            test_topic.key(),
+            test_topic.value(),
         )
         .await?;
-        assert_subscribe_success(
-            &topic_client,
-            first_cache.to_string(),
-            test_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_success(&topic_client, first_cache, test_topic.key()).await?;
         assert_publish_failure(
             &topic_client,
-            second_cache.to_string(),
-            test_topic.key().to_string(),
-            test_topic.value().to_string(),
+            second_cache,
+            test_topic.key(),
+            test_topic.value(),
         )
         .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            test_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_failure(&topic_client, second_cache, test_topic.key()).await?;
 
         Ok(())
     }
@@ -1835,7 +1191,7 @@ mod disposable_tokens_topics {
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::TopicPermission(TopicPermission {
                     cache: CacheSelector::AllCaches,
-                    topic: test_topic.key().to_string().into(),
+                    topic: test_topic.key().into(),
                     role: TopicRole::PublishSubscribe,
                 })],
             }),
@@ -1847,60 +1203,40 @@ mod disposable_tokens_topics {
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should be able to publish and subscribe in both caches on only the specific topic
         assert_publish_success(
             &topic_client,
-            first_cache.to_string(),
-            test_topic.key().to_string(),
-            test_topic.value().to_string(),
+            first_cache,
+            test_topic.key(),
+            test_topic.value(),
         )
         .await?;
-        assert_subscribe_success(
-            &topic_client,
-            first_cache.to_string(),
-            test_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_success(&topic_client, first_cache, test_topic.key()).await?;
         assert_publish_success(
             &topic_client,
-            second_cache.to_string(),
-            test_topic.key().to_string(),
-            test_topic.value().to_string(),
+            second_cache,
+            test_topic.key(),
+            test_topic.value(),
         )
         .await?;
-        assert_subscribe_success(
-            &topic_client,
-            second_cache.to_string(),
-            test_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_success(&topic_client, second_cache, test_topic.key()).await?;
 
         Ok(())
     }
@@ -1914,7 +1250,7 @@ mod disposable_tokens_topics {
         let response = generate_disposable_token_success(
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: first_cache.to_string().into(),
+                    cache: (*first_cache).clone().into(),
                     topic: TopicSelector::AllTopics,
                     role: TopicRole::PublishSubscribe,
                 })],
@@ -1927,86 +1263,56 @@ mod disposable_tokens_topics {
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should be able to publish and subscribe in only first cache on all topics
         assert_publish_success(
             &topic_client,
-            first_cache.to_string(),
-            first_topic.key().to_string(),
-            first_topic.value().to_string(),
+            first_cache,
+            first_topic.key(),
+            first_topic.value(),
         )
         .await?;
-        assert_subscribe_success(
-            &topic_client,
-            first_cache.to_string(),
-            first_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_success(&topic_client, first_cache, first_topic.key()).await?;
         assert_publish_failure(
             &topic_client,
-            second_cache.to_string(),
-            first_topic.key().to_string(),
-            first_topic.value().to_string(),
+            second_cache,
+            first_topic.key(),
+            first_topic.value(),
         )
         .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            first_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_failure(&topic_client, second_cache, first_topic.key()).await?;
         assert_publish_success(
             &topic_client,
-            first_cache.to_string(),
-            second_topic.key().to_string(),
-            second_topic.value().to_string(),
+            first_cache,
+            second_topic.key(),
+            second_topic.value(),
         )
         .await?;
-        assert_subscribe_success(
-            &topic_client,
-            first_cache.to_string(),
-            second_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_success(&topic_client, first_cache, second_topic.key()).await?;
         assert_publish_failure(
             &topic_client,
-            second_cache.to_string(),
-            second_topic.key().to_string(),
-            second_topic.value().to_string(),
+            second_cache,
+            second_topic.key(),
+            second_topic.value(),
         )
         .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            second_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_failure(&topic_client, second_cache, second_topic.key()).await?;
 
         Ok(())
     }
@@ -2033,86 +1339,56 @@ mod disposable_tokens_topics {
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should be able to publish and subscribe in both caches on all topics
         assert_publish_success(
             &topic_client,
-            first_cache.to_string(),
-            first_topic.key().to_string(),
-            first_topic.value().to_string(),
+            first_cache,
+            first_topic.key(),
+            first_topic.value(),
         )
         .await?;
-        assert_subscribe_success(
-            &topic_client,
-            first_cache.to_string(),
-            first_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_success(&topic_client, first_cache, first_topic.key()).await?;
         assert_publish_success(
             &topic_client,
-            second_cache.to_string(),
-            first_topic.key().to_string(),
-            first_topic.value().to_string(),
+            second_cache,
+            first_topic.key(),
+            first_topic.value(),
         )
         .await?;
-        assert_subscribe_success(
-            &topic_client,
-            second_cache.to_string(),
-            first_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_success(&topic_client, second_cache, first_topic.key()).await?;
         assert_publish_success(
             &topic_client,
-            first_cache.to_string(),
-            second_topic.key().to_string(),
-            second_topic.value().to_string(),
+            first_cache,
+            second_topic.key(),
+            second_topic.value(),
         )
         .await?;
-        assert_subscribe_success(
-            &topic_client,
-            first_cache.to_string(),
-            second_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_success(&topic_client, first_cache, second_topic.key()).await?;
         assert_publish_success(
             &topic_client,
-            second_cache.to_string(),
-            second_topic.key().to_string(),
-            second_topic.value().to_string(),
+            second_cache,
+            second_topic.key(),
+            second_topic.value(),
         )
         .await?;
-        assert_subscribe_success(
-            &topic_client,
-            second_cache.to_string(),
-            second_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_success(&topic_client, second_cache, second_topic.key()).await?;
 
         Ok(())
     }
@@ -2125,8 +1401,8 @@ mod disposable_tokens_topics {
         let response = generate_disposable_token_success(
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: first_cache.to_string().into(),
-                    topic: test_topic.key().to_string().into(),
+                    cache: (*first_cache).clone().into(),
+                    topic: test_topic.key().into(),
                     role: TopicRole::SubscribeOnly,
                 })],
             }),
@@ -2138,62 +1414,42 @@ mod disposable_tokens_topics {
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to publish in either cache on only the specific topic
         assert_publish_failure(
             &topic_client,
-            first_cache.to_string(),
-            test_topic.key().to_string(),
-            test_topic.value().to_string(),
+            first_cache,
+            test_topic.key(),
+            test_topic.value(),
         )
         .await?;
         assert_publish_failure(
             &topic_client,
-            second_cache.to_string(),
-            test_topic.key().to_string(),
-            test_topic.value().to_string(),
+            second_cache,
+            test_topic.key(),
+            test_topic.value(),
         )
         .await?;
 
         // should be able to subscribe in only first cache on only the specific topic
-        assert_subscribe_success(
-            &topic_client,
-            first_cache.to_string(),
-            test_topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            test_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_success(&topic_client, first_cache, test_topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, test_topic.key()).await?;
 
         Ok(())
     }
@@ -2207,7 +1463,7 @@ mod disposable_tokens_topics {
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::TopicPermission(TopicPermission {
                     cache: CacheSelector::AllCaches,
-                    topic: test_topic.key().to_string().into(),
+                    topic: test_topic.key().into(),
                     role: TopicRole::SubscribeOnly,
                 })],
             }),
@@ -2219,62 +1475,42 @@ mod disposable_tokens_topics {
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to publish in either cache
         assert_publish_failure(
             &topic_client,
-            first_cache.to_string(),
-            test_topic.key().to_string(),
-            test_topic.value().to_string(),
+            first_cache,
+            test_topic.key(),
+            test_topic.value(),
         )
         .await?;
         assert_publish_failure(
             &topic_client,
-            second_cache.to_string(),
-            test_topic.key().to_string(),
-            test_topic.value().to_string(),
+            second_cache,
+            test_topic.key(),
+            test_topic.value(),
         )
         .await?;
 
         // should be able to subscribe in both caches
-        assert_subscribe_success(
-            &topic_client,
-            first_cache.to_string(),
-            test_topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_success(
-            &topic_client,
-            second_cache.to_string(),
-            test_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_success(&topic_client, first_cache, test_topic.key()).await?;
+        assert_subscribe_success(&topic_client, second_cache, test_topic.key()).await?;
 
         Ok(())
     }
@@ -2288,7 +1524,7 @@ mod disposable_tokens_topics {
         let response = generate_disposable_token_success(
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: first_cache.to_string().into(),
+                    cache: (*first_cache).clone().into(),
                     topic: TopicSelector::AllTopics,
                     role: TopicRole::SubscribeOnly,
                 })],
@@ -2301,76 +1537,56 @@ mod disposable_tokens_topics {
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to publish in either cache on all topics
         assert_publish_failure(
             &topic_client,
-            first_cache.to_string(),
-            first_topic.key().to_string(),
-            first_topic.value().to_string(),
+            first_cache,
+            first_topic.key(),
+            first_topic.value(),
         )
         .await?;
         assert_publish_failure(
             &topic_client,
-            second_cache.to_string(),
-            first_topic.key().to_string(),
-            first_topic.value().to_string(),
+            second_cache,
+            first_topic.key(),
+            first_topic.value(),
         )
         .await?;
         assert_publish_failure(
             &topic_client,
-            first_cache.to_string(),
-            second_topic.key().to_string(),
-            second_topic.value().to_string(),
+            first_cache,
+            second_topic.key(),
+            second_topic.value(),
         )
         .await?;
         assert_publish_failure(
             &topic_client,
-            second_cache.to_string(),
-            second_topic.key().to_string(),
-            second_topic.value().to_string(),
+            second_cache,
+            second_topic.key(),
+            second_topic.value(),
         )
         .await?;
 
         // should be able to subscribe in only first cache on all topics
-        assert_subscribe_success(
-            &topic_client,
-            first_cache.to_string(),
-            first_topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            first_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_success(&topic_client, first_cache, first_topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, first_topic.key()).await?;
 
         Ok(())
     }
@@ -2397,88 +1613,58 @@ mod disposable_tokens_topics {
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should not be able to publish in either cache on all topics
         assert_publish_failure(
             &topic_client,
-            first_cache.to_string(),
-            first_topic.key().to_string(),
-            first_topic.value().to_string(),
+            first_cache,
+            first_topic.key(),
+            first_topic.value(),
         )
         .await?;
         assert_publish_failure(
             &topic_client,
-            second_cache.to_string(),
-            first_topic.key().to_string(),
-            first_topic.value().to_string(),
+            second_cache,
+            first_topic.key(),
+            first_topic.value(),
         )
         .await?;
         assert_publish_failure(
             &topic_client,
-            first_cache.to_string(),
-            second_topic.key().to_string(),
-            second_topic.value().to_string(),
+            first_cache,
+            second_topic.key(),
+            second_topic.value(),
         )
         .await?;
         assert_publish_failure(
             &topic_client,
-            second_cache.to_string(),
-            second_topic.key().to_string(),
-            second_topic.value().to_string(),
+            second_cache,
+            second_topic.key(),
+            second_topic.value(),
         )
         .await?;
 
         // should be able to subscribe in both caches on all topics
-        assert_subscribe_success(
-            &topic_client,
-            first_cache.to_string(),
-            first_topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_success(
-            &topic_client,
-            second_cache.to_string(),
-            first_topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_success(
-            &topic_client,
-            first_cache.to_string(),
-            second_topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_success(
-            &topic_client,
-            second_cache.to_string(),
-            second_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_success(&topic_client, first_cache, first_topic.key()).await?;
+        assert_subscribe_success(&topic_client, second_cache, first_topic.key()).await?;
+        assert_subscribe_success(&topic_client, first_cache, second_topic.key()).await?;
+        assert_subscribe_success(&topic_client, second_cache, second_topic.key()).await?;
 
         Ok(())
     }
@@ -2491,8 +1677,8 @@ mod disposable_tokens_topics {
         let response = generate_disposable_token_success(
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: first_cache.to_string().into(),
-                    topic: test_topic.key().to_string().into(),
+                    cache: (*first_cache).clone().into(),
+                    topic: test_topic.key().into(),
                     role: TopicRole::PublishOnly,
                 })],
             }),
@@ -2504,62 +1690,42 @@ mod disposable_tokens_topics {
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should be able to publish in only first cache on only the specific topic
         assert_publish_success(
             &topic_client,
-            first_cache.to_string(),
-            test_topic.key().to_string(),
-            test_topic.value().to_string(),
+            first_cache,
+            test_topic.key(),
+            test_topic.value(),
         )
         .await?;
         assert_publish_failure(
             &topic_client,
-            second_cache.to_string(),
-            test_topic.key().to_string(),
-            test_topic.value().to_string(),
+            second_cache,
+            test_topic.key(),
+            test_topic.value(),
         )
         .await?;
 
         // should not be able to subscribe in either cache on only the specific topic
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            test_topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            test_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_failure(&topic_client, first_cache, test_topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, test_topic.key()).await?;
 
         Ok(())
     }
@@ -2573,7 +1739,7 @@ mod disposable_tokens_topics {
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::TopicPermission(TopicPermission {
                     cache: CacheSelector::AllCaches,
-                    topic: test_topic.key().to_string().into(),
+                    topic: test_topic.key().into(),
                     role: TopicRole::PublishOnly,
                 })],
             }),
@@ -2585,62 +1751,42 @@ mod disposable_tokens_topics {
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should be able to publish in both caches on only the specific topic
         assert_publish_success(
             &topic_client,
-            first_cache.to_string(),
-            test_topic.key().to_string(),
-            test_topic.value().to_string(),
+            first_cache,
+            test_topic.key(),
+            test_topic.value(),
         )
         .await?;
         assert_publish_success(
             &topic_client,
-            second_cache.to_string(),
-            test_topic.key().to_string(),
-            test_topic.value().to_string(),
+            second_cache,
+            test_topic.key(),
+            test_topic.value(),
         )
         .await?;
 
         // should not be able to subscribe in either cache on only the specific topic
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            test_topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            test_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_failure(&topic_client, first_cache, test_topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, test_topic.key()).await?;
 
         Ok(())
     }
@@ -2654,7 +1800,7 @@ mod disposable_tokens_topics {
         let response = generate_disposable_token_success(
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: first_cache.to_string().into(),
+                    cache: (*first_cache).clone().into(),
                     topic: TopicSelector::AllTopics,
                     role: TopicRole::PublishOnly,
                 })],
@@ -2667,88 +1813,58 @@ mod disposable_tokens_topics {
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should be able to publish in only first cache on all topics
         assert_publish_success(
             &topic_client,
-            first_cache.to_string(),
-            first_topic.key().to_string(),
-            first_topic.value().to_string(),
+            first_cache,
+            first_topic.key(),
+            first_topic.value(),
         )
         .await?;
         assert_publish_failure(
             &topic_client,
-            second_cache.to_string(),
-            first_topic.key().to_string(),
-            first_topic.value().to_string(),
+            second_cache,
+            first_topic.key(),
+            first_topic.value(),
         )
         .await?;
         assert_publish_success(
             &topic_client,
-            first_cache.to_string(),
-            second_topic.key().to_string(),
-            second_topic.value().to_string(),
+            first_cache,
+            second_topic.key(),
+            second_topic.value(),
         )
         .await?;
         assert_publish_failure(
             &topic_client,
-            second_cache.to_string(),
-            second_topic.key().to_string(),
-            second_topic.value().to_string(),
+            second_cache,
+            second_topic.key(),
+            second_topic.value(),
         )
         .await?;
 
         // should not be able to subscribe in either cache on all topics
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            first_topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            first_topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            second_topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            second_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_failure(&topic_client, first_cache, first_topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, first_topic.key()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, second_topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, second_topic.key()).await?;
 
         Ok(())
     }
@@ -2775,88 +1891,58 @@ mod disposable_tokens_topics {
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(
+        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_failure(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should be able to publish in both caches on all topics
         assert_publish_success(
             &topic_client,
-            first_cache.to_string(),
-            first_topic.key().to_string(),
-            first_topic.value().to_string(),
+            first_cache,
+            first_topic.key(),
+            first_topic.value(),
         )
         .await?;
         assert_publish_success(
             &topic_client,
-            second_cache.to_string(),
-            first_topic.key().to_string(),
-            first_topic.value().to_string(),
+            second_cache,
+            first_topic.key(),
+            first_topic.value(),
         )
         .await?;
         assert_publish_success(
             &topic_client,
-            first_cache.to_string(),
-            second_topic.key().to_string(),
-            second_topic.value().to_string(),
+            first_cache,
+            second_topic.key(),
+            second_topic.value(),
         )
         .await?;
         assert_publish_success(
             &topic_client,
-            second_cache.to_string(),
-            second_topic.key().to_string(),
-            second_topic.value().to_string(),
+            second_cache,
+            second_topic.key(),
+            second_topic.value(),
         )
         .await?;
 
         // should not be able to subscribe in either cache on all topics
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            first_topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            first_topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            first_cache.to_string(),
-            second_topic.key().to_string(),
-        )
-        .await?;
-        assert_subscribe_failure(
-            &topic_client,
-            second_cache.to_string(),
-            second_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_failure(&topic_client, first_cache, first_topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, first_topic.key()).await?;
+        assert_subscribe_failure(&topic_client, first_cache, second_topic.key()).await?;
+        assert_subscribe_failure(&topic_client, second_cache, second_topic.key()).await?;
 
         Ok(())
     }
@@ -2881,87 +1967,57 @@ mod disposable_tokens_all_data {
 
         // should be able to read and write in both caches
         let test_item = TestScalar::new();
-        assert_get_success(
+        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
+        assert_get_success(&cache_client, second_cache, test_item.key()).await?;
+        assert_set_success(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-        )
-        .await?;
-        assert_get_success(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
+            first_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
         assert_set_success(
             &cache_client,
-            first_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
-        )
-        .await?;
-        assert_set_success(
-            &cache_client,
-            second_cache.to_string(),
-            test_item.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            test_item.key(),
+            test_item.value(),
         )
         .await?;
 
         // should be able to publish and subscribe in both caches on both topics
         assert_publish_success(
             &topic_client,
-            first_cache.to_string(),
-            first_topic.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            first_topic.key(),
+            test_item.value(),
         )
         .await?;
-        assert_subscribe_success(
-            &topic_client,
-            first_cache.to_string(),
-            first_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_success(&topic_client, first_cache, first_topic.key()).await?;
         assert_publish_success(
             &topic_client,
-            second_cache.to_string(),
-            first_topic.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            first_topic.key(),
+            test_item.value(),
         )
         .await?;
-        assert_subscribe_success(
-            &topic_client,
-            second_cache.to_string(),
-            first_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_success(&topic_client, second_cache, first_topic.key()).await?;
 
         assert_publish_success(
             &topic_client,
-            first_cache.to_string(),
-            second_topic.key().to_string(),
-            test_item.value().to_string(),
+            first_cache,
+            second_topic.key(),
+            test_item.value(),
         )
         .await?;
-        assert_subscribe_success(
-            &topic_client,
-            first_cache.to_string(),
-            second_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_success(&topic_client, first_cache, second_topic.key()).await?;
         assert_publish_success(
             &topic_client,
-            second_cache.to_string(),
-            second_topic.key().to_string(),
-            test_item.value().to_string(),
+            second_cache,
+            second_topic.key(),
+            test_item.value(),
         )
         .await?;
-        assert_subscribe_success(
-            &topic_client,
-            second_cache.to_string(),
-            second_topic.key().to_string(),
-        )
-        .await?;
+        assert_subscribe_success(&topic_client, second_cache, second_topic.key()).await?;
 
         Ok(())
     }

--- a/tests/auth/disposable_tokens.rs
+++ b/tests/auth/disposable_tokens.rs
@@ -219,40 +219,32 @@ mod disposable_tokens_cache_key {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should be able to read this key in both caches
-        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_success(&cache_client, second_cache, test_item.key()).await?;
+        assert_get_success(&cc, first_cache, test_item.key()).await?;
+        assert_get_success(&cc, second_cache, test_item.key()).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache, &other_key).await?;
-        assert_get_failure(&cache_client, second_cache, &other_key).await?;
+        assert_get_failure(&cc, first_cache, &other_key).await?;
+        assert_get_failure(&cc, second_cache, &other_key).await?;
 
         // should not be able to write the key in either cache
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
+
+        // should not be able to write another key in either cache
+        assert_set_failure(&cc, first_cache, &other_key, test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, &other_key, test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -267,40 +259,32 @@ mod disposable_tokens_cache_key {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should be able to read this key in only first cache
-        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_get_success(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache, &other_key).await?;
-        assert_get_failure(&cache_client, second_cache, &other_key).await?;
+        assert_get_failure(&cc, first_cache, &other_key).await?;
+        assert_get_failure(&cc, second_cache, &other_key).await?;
 
         // should not be able to write the key in either cache
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
+
+        // should not be able to write another key in either cache
+        assert_set_failure(&cc, first_cache, &other_key, test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, &other_key, test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -315,40 +299,32 @@ mod disposable_tokens_cache_key {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should not be able to read this key in either cache
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache, &other_key).await?;
-        assert_get_failure(&cache_client, second_cache, &other_key).await?;
+        assert_get_failure(&cc, first_cache, &other_key).await?;
+        assert_get_failure(&cc, second_cache, &other_key).await?;
 
         // should be able to write the key in both caches
-        assert_set_success(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_success(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_set_success(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_success(&cc, second_cache, test_item.key(), test_item.value()).await?;
+
+        // should not be able to write another key in either cache
+        assert_set_failure(&cc, first_cache, &other_key, test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, &other_key, test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -363,40 +339,32 @@ mod disposable_tokens_cache_key {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should not be able to read this key in either cache
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache, &other_key).await?;
-        assert_get_failure(&cache_client, second_cache, &other_key).await?;
+        assert_get_failure(&cc, first_cache, &other_key).await?;
+        assert_get_failure(&cc, second_cache, &other_key).await?;
 
         // should be able to write the key in only first cache
-        assert_set_success(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_set_success(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
+
+        // should not be able to write another key in either cache
+        assert_set_failure(&cc, first_cache, &other_key, test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, &other_key, test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -411,40 +379,32 @@ mod disposable_tokens_cache_key {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should be able to read this key in both caches
-        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_success(&cache_client, second_cache, test_item.key()).await?;
+        assert_get_success(&cc, first_cache, test_item.key()).await?;
+        assert_get_success(&cc, second_cache, test_item.key()).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache, &other_key).await?;
-        assert_get_failure(&cache_client, second_cache, &other_key).await?;
+        assert_get_failure(&cc, first_cache, &other_key).await?;
+        assert_get_failure(&cc, second_cache, &other_key).await?;
 
         // should be able to write the key in both caches
-        assert_set_success(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_success(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_set_success(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_success(&cc, second_cache, test_item.key(), test_item.value()).await?;
+
+        // should not be able to write another key in both caches
+        assert_set_failure(&cc, first_cache, &other_key, test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, &other_key, test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -459,40 +419,32 @@ mod disposable_tokens_cache_key {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should be able to read this key in only first cache
-        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_get_success(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache, &other_key).await?;
-        assert_get_failure(&cache_client, second_cache, &other_key).await?;
+        assert_get_failure(&cc, first_cache, &other_key).await?;
+        assert_get_failure(&cc, second_cache, &other_key).await?;
 
         // should be able to write the key in only first cache
-        assert_set_success(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_set_success(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
+
+        // should not be able to write another key in either cache
+        assert_set_failure(&cc, first_cache, &other_key, test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, &other_key, test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -511,45 +463,37 @@ mod disposable_tokens_cache_key_prefix {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should be able to read this key in only first cache
-        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_get_success(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
 
         // should be able to read a prefixed key in only first cache
         let prefixed_key = format!("{}-smth-else", test_item.key());
-        assert_get_success(&cache_client, first_cache, &prefixed_key).await?;
-        assert_get_failure(&cache_client, second_cache, &prefixed_key).await?;
+        assert_get_success(&cc, first_cache, &prefixed_key).await?;
+        assert_get_failure(&cc, second_cache, &prefixed_key).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache, &other_key).await?;
-        assert_get_failure(&cache_client, second_cache, &other_key).await?;
+        assert_get_failure(&cc, first_cache, &other_key).await?;
+        assert_get_failure(&cc, second_cache, &other_key).await?;
 
         // should not be able to write the key in either cache
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
+
+        // should not be able to write another key in either cache
+        assert_set_failure(&cc, first_cache, &other_key, test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, &other_key, test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -566,45 +510,37 @@ mod disposable_tokens_cache_key_prefix {
             ))
             .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should be able to read this key in both caches
-        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_success(&cache_client, second_cache, test_item.key()).await?;
+        assert_get_success(&cc, first_cache, test_item.key()).await?;
+        assert_get_success(&cc, second_cache, test_item.key()).await?;
 
         // should be able to read a prefixed key in both caches
         let prefixed_key = format!("{}-smth-else", test_item.key());
-        assert_get_success(&cache_client, first_cache, &prefixed_key).await?;
-        assert_get_success(&cache_client, second_cache, &prefixed_key).await?;
+        assert_get_success(&cc, first_cache, &prefixed_key).await?;
+        assert_get_success(&cc, second_cache, &prefixed_key).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache, &other_key).await?;
-        assert_get_failure(&cache_client, second_cache, &other_key).await?;
+        assert_get_failure(&cc, first_cache, &other_key).await?;
+        assert_get_failure(&cc, second_cache, &other_key).await?;
 
         // should not be able to write the key in either cache
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
+
+        // should not be able to write another key in either cache
+        assert_set_failure(&cc, first_cache, &other_key, test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, &other_key, test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -621,45 +557,37 @@ mod disposable_tokens_cache_key_prefix {
             ))
             .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should not be able to read this key in either cache
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
 
         // should not be able to read a prefixed key in either cache
         let prefixed_key = format!("{}-smth-else", test_item.key());
-        assert_get_failure(&cache_client, first_cache, &prefixed_key).await?;
-        assert_get_failure(&cache_client, second_cache, &prefixed_key).await?;
+        assert_get_failure(&cc, first_cache, &prefixed_key).await?;
+        assert_get_failure(&cc, second_cache, &prefixed_key).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache, &other_key).await?;
-        assert_get_failure(&cache_client, second_cache, &other_key).await?;
+        assert_get_failure(&cc, first_cache, &other_key).await?;
+        assert_get_failure(&cc, second_cache, &other_key).await?;
 
         // should be able to write the key in only first cache
-        assert_set_success(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_set_success(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
+
+        // should not be able to write another key in either cache
+        assert_set_failure(&cc, first_cache, &other_key, test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, &other_key, test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -676,45 +604,37 @@ mod disposable_tokens_cache_key_prefix {
             ))
             .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should not be able to read this key in either cache
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
 
         // should not be able to read a prefixed key in either cache
         let prefixed_key = format!("{}-smth-else", test_item.key());
-        assert_get_failure(&cache_client, first_cache, &prefixed_key).await?;
-        assert_get_failure(&cache_client, second_cache, &prefixed_key).await?;
+        assert_get_failure(&cc, first_cache, &prefixed_key).await?;
+        assert_get_failure(&cc, second_cache, &prefixed_key).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache, &other_key).await?;
-        assert_get_failure(&cache_client, second_cache, &other_key).await?;
+        assert_get_failure(&cc, first_cache, &other_key).await?;
+        assert_get_failure(&cc, second_cache, &other_key).await?;
 
         // should be able to write the key in both caches
-        assert_set_success(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_success(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_set_success(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_success(&cc, second_cache, test_item.key(), test_item.value()).await?;
+
+        // should be able to write another key in either cache
+        assert_set_failure(&cc, first_cache, &other_key, test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, &other_key, test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -731,45 +651,37 @@ mod disposable_tokens_cache_key_prefix {
             ))
             .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should be able to read this key in only first cache
-        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_get_success(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
 
         // should be able to read a prefixed key in only first cache
         let prefixed_key = format!("{}-smth-else", test_item.key());
-        assert_get_success(&cache_client, first_cache, &prefixed_key).await?;
-        assert_get_failure(&cache_client, second_cache, &prefixed_key).await?;
+        assert_get_success(&cc, first_cache, &prefixed_key).await?;
+        assert_get_failure(&cc, second_cache, &prefixed_key).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache, &other_key).await?;
-        assert_get_failure(&cache_client, second_cache, &other_key).await?;
+        assert_get_failure(&cc, first_cache, &other_key).await?;
+        assert_get_failure(&cc, second_cache, &other_key).await?;
 
         // should be able to write the key in only first cache
-        assert_set_success(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_set_success(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
+
+        // should not be able to write another key in either cache
+        assert_set_failure(&cc, first_cache, &other_key, test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, &other_key, test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -786,45 +698,37 @@ mod disposable_tokens_cache_key_prefix {
             ))
             .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should be able to read this key in both caches
-        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_success(&cache_client, second_cache, test_item.key()).await?;
+        assert_get_success(&cc, first_cache, test_item.key()).await?;
+        assert_get_success(&cc, second_cache, test_item.key()).await?;
 
         // should be able to read a prefixed key in both caches
         let prefixed_key = format!("{}-smth-else", test_item.key());
-        assert_get_success(&cache_client, first_cache, &prefixed_key).await?;
-        assert_get_success(&cache_client, second_cache, &prefixed_key).await?;
+        assert_get_success(&cc, first_cache, &prefixed_key).await?;
+        assert_get_success(&cc, second_cache, &prefixed_key).await?;
 
         // should not be able to read another key in either cache
         let other_key = unique_key();
-        assert_get_failure(&cache_client, first_cache, &other_key).await?;
-        assert_get_failure(&cache_client, second_cache, &other_key).await?;
+        assert_get_failure(&cc, first_cache, &other_key).await?;
+        assert_get_failure(&cc, second_cache, &other_key).await?;
 
         // should be able to write the key in both caches
-        assert_set_success(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_success(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_set_success(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_success(&cc, second_cache, test_item.key(), test_item.value()).await?;
+
+        // should not be able to write another key in either cache
+        assert_set_failure(&cc, first_cache, &other_key, test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, &other_key, test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -847,34 +751,22 @@ mod disposable_tokens_cache {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should be able to read and write in only first cache
         let test_item = TestScalar::new();
-        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
-        assert_set_success(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_get_success(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
+        assert_set_success(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -893,34 +785,22 @@ mod disposable_tokens_cache {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should be able to read and write in both caches
         let test_item = TestScalar::new();
-        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_success(&cache_client, second_cache, test_item.key()).await?;
-        assert_set_success(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_success(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_get_success(&cc, first_cache, test_item.key()).await?;
+        assert_get_success(&cc, second_cache, test_item.key()).await?;
+        assert_set_success(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_success(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -939,36 +819,24 @@ mod disposable_tokens_cache {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should be able to read in only first cache
         let test_item = TestScalar::new();
-        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_get_success(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
 
         // should not be able to write in either cache
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -987,36 +855,24 @@ mod disposable_tokens_cache {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should be able to read in both caches
         let test_item = TestScalar::new();
-        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_success(&cache_client, second_cache, test_item.key()).await?;
+        assert_get_success(&cc, first_cache, test_item.key()).await?;
+        assert_get_success(&cc, second_cache, test_item.key()).await?;
 
         // should not be able to write in either cache
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -1035,36 +891,24 @@ mod disposable_tokens_cache {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should not be able to read in either cache
         let test_item = TestScalar::new();
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
 
         // should be able to write in only first cache
-        assert_set_success(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_set_success(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -1083,36 +927,24 @@ mod disposable_tokens_cache {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should not be able to read in either cache
         let test_item = TestScalar::new();
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
 
         // should be able to write in both caches
-        assert_set_success(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_success(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_set_success(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_success(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
         // should not be able to use topics
         let topic = TestScalar::new();
-        assert_publish_failure(&topic_client, first_cache, topic.key(), topic.value()).await?;
-        assert_publish_failure(&topic_client, second_cache, topic.key(), topic.value()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, topic.key(), topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, topic.key(), topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, topic.key()).await?;
 
         Ok(())
     }
@@ -1127,57 +959,36 @@ mod disposable_tokens_topics {
     async fn test_topics_publish_subscribe_specific_topic_specific_cache() -> MomentoResult<()> {
         let first_cache = &CACHE_TEST_STATE.cache_name;
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
-        let test_topic = TestScalar::new();
+        let first_topic = TestScalar::new();
+        let second_topic = TestScalar::new();
         let response = generate_disposable_token_success(
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::TopicPermission(TopicPermission {
                     cache: (*first_cache).clone().into(),
-                    topic: test_topic.key().into(),
+                    topic: first_topic.key().into(),
                     role: TopicRole::PublishSubscribe,
                 })],
             }),
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let topic_client = new_topic_client(creds.clone());
-        let cache_client = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds.clone());
+        let cc = new_cache_client(creds.clone());
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
         // should be able to publish and subscribe in only first cache on only the specific topic
-        assert_publish_success(
-            &topic_client,
-            first_cache,
-            test_topic.key(),
-            test_topic.value(),
-        )
-        .await?;
-        assert_subscribe_success(&topic_client, first_cache, test_topic.key()).await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache,
-            test_topic.key(),
-            test_topic.value(),
-        )
-        .await?;
-        assert_subscribe_failure(&topic_client, second_cache, test_topic.key()).await?;
+        assert_publish_success(&tc, first_cache, first_topic.key(), first_topic.value()).await?;
+        assert_subscribe_success(&tc, first_cache, first_topic.key()).await?;
+        assert_publish_failure(&tc, second_cache, first_topic.key(), first_topic.value()).await?;
+        assert_subscribe_failure(&tc, second_cache, first_topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, second_topic.key(), second_topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, second_topic.key()).await?;
 
         Ok(())
     }
@@ -1186,57 +997,36 @@ mod disposable_tokens_topics {
     async fn test_topics_publish_subscribe_specific_topic_all_caches() -> MomentoResult<()> {
         let first_cache = &CACHE_TEST_STATE.cache_name;
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
-        let test_topic = TestScalar::new();
+        let first_topic = TestScalar::new();
+        let second_topic = TestScalar::new();
         let response = generate_disposable_token_success(
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::TopicPermission(TopicPermission {
                     cache: CacheSelector::AllCaches,
-                    topic: test_topic.key().into(),
+                    topic: first_topic.key().into(),
                     role: TopicRole::PublishSubscribe,
                 })],
             }),
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let topic_client = new_topic_client(creds.clone());
-        let cache_client = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds.clone());
+        let cc = new_cache_client(creds.clone());
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
         // should be able to publish and subscribe in both caches on only the specific topic
-        assert_publish_success(
-            &topic_client,
-            first_cache,
-            test_topic.key(),
-            test_topic.value(),
-        )
-        .await?;
-        assert_subscribe_success(&topic_client, first_cache, test_topic.key()).await?;
-        assert_publish_success(
-            &topic_client,
-            second_cache,
-            test_topic.key(),
-            test_topic.value(),
-        )
-        .await?;
-        assert_subscribe_success(&topic_client, second_cache, test_topic.key()).await?;
+        assert_publish_success(&tc, first_cache, first_topic.key(), first_topic.value()).await?;
+        assert_subscribe_success(&tc, first_cache, first_topic.key()).await?;
+        assert_publish_success(&tc, second_cache, first_topic.key(), first_topic.value()).await?;
+        assert_subscribe_success(&tc, second_cache, first_topic.key()).await?;
+        assert_publish_failure(&tc, first_cache, second_topic.key(), second_topic.value()).await?;
+        assert_subscribe_failure(&tc, first_cache, second_topic.key()).await?;
 
         Ok(())
     }
@@ -1258,61 +1048,25 @@ mod disposable_tokens_topics {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let topic_client = new_topic_client(creds.clone());
-        let cache_client = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds.clone());
+        let cc = new_cache_client(creds.clone());
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
         // should be able to publish and subscribe in only first cache on all topics
-        assert_publish_success(
-            &topic_client,
-            first_cache,
-            first_topic.key(),
-            first_topic.value(),
-        )
-        .await?;
-        assert_subscribe_success(&topic_client, first_cache, first_topic.key()).await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache,
-            first_topic.key(),
-            first_topic.value(),
-        )
-        .await?;
-        assert_subscribe_failure(&topic_client, second_cache, first_topic.key()).await?;
-        assert_publish_success(
-            &topic_client,
-            first_cache,
-            second_topic.key(),
-            second_topic.value(),
-        )
-        .await?;
-        assert_subscribe_success(&topic_client, first_cache, second_topic.key()).await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache,
-            second_topic.key(),
-            second_topic.value(),
-        )
-        .await?;
-        assert_subscribe_failure(&topic_client, second_cache, second_topic.key()).await?;
+        assert_publish_success(&tc, first_cache, first_topic.key(), first_topic.value()).await?;
+        assert_subscribe_success(&tc, first_cache, first_topic.key()).await?;
+        assert_publish_failure(&tc, second_cache, first_topic.key(), first_topic.value()).await?;
+        assert_subscribe_failure(&tc, second_cache, first_topic.key()).await?;
+        assert_publish_success(&tc, first_cache, second_topic.key(), second_topic.value()).await?;
+        assert_subscribe_success(&tc, first_cache, second_topic.key()).await?;
+        assert_publish_failure(&tc, second_cache, second_topic.key(), second_topic.value()).await?;
+        assert_subscribe_failure(&tc, second_cache, second_topic.key()).await?;
 
         Ok(())
     }
@@ -1334,61 +1088,25 @@ mod disposable_tokens_topics {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let topic_client = new_topic_client(creds.clone());
-        let cache_client = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds.clone());
+        let cc = new_cache_client(creds.clone());
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
         // should be able to publish and subscribe in both caches on all topics
-        assert_publish_success(
-            &topic_client,
-            first_cache,
-            first_topic.key(),
-            first_topic.value(),
-        )
-        .await?;
-        assert_subscribe_success(&topic_client, first_cache, first_topic.key()).await?;
-        assert_publish_success(
-            &topic_client,
-            second_cache,
-            first_topic.key(),
-            first_topic.value(),
-        )
-        .await?;
-        assert_subscribe_success(&topic_client, second_cache, first_topic.key()).await?;
-        assert_publish_success(
-            &topic_client,
-            first_cache,
-            second_topic.key(),
-            second_topic.value(),
-        )
-        .await?;
-        assert_subscribe_success(&topic_client, first_cache, second_topic.key()).await?;
-        assert_publish_success(
-            &topic_client,
-            second_cache,
-            second_topic.key(),
-            second_topic.value(),
-        )
-        .await?;
-        assert_subscribe_success(&topic_client, second_cache, second_topic.key()).await?;
+        assert_publish_success(&tc, first_cache, first_topic.key(), first_topic.value()).await?;
+        assert_subscribe_success(&tc, first_cache, first_topic.key()).await?;
+        assert_publish_success(&tc, second_cache, first_topic.key(), first_topic.value()).await?;
+        assert_subscribe_success(&tc, second_cache, first_topic.key()).await?;
+        assert_publish_success(&tc, first_cache, second_topic.key(), second_topic.value()).await?;
+        assert_subscribe_success(&tc, first_cache, second_topic.key()).await?;
+        assert_publish_success(&tc, second_cache, second_topic.key(), second_topic.value()).await?;
+        assert_subscribe_success(&tc, second_cache, second_topic.key()).await?;
 
         Ok(())
     }
@@ -1397,59 +1115,39 @@ mod disposable_tokens_topics {
     async fn test_topics_subscribe_only_specific_topic_specific_cache() -> MomentoResult<()> {
         let first_cache = &CACHE_TEST_STATE.cache_name;
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
-        let test_topic = TestScalar::new();
+        let first_topic = TestScalar::new();
+        let second_topic = TestScalar::new();
         let response = generate_disposable_token_success(
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::TopicPermission(TopicPermission {
                     cache: (*first_cache).clone().into(),
-                    topic: test_topic.key().into(),
+                    topic: first_topic.key().into(),
                     role: TopicRole::SubscribeOnly,
                 })],
             }),
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let topic_client = new_topic_client(creds.clone());
-        let cache_client = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds.clone());
+        let cc = new_cache_client(creds.clone());
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
-        // should not be able to publish in either cache on only the specific topic
-        assert_publish_failure(
-            &topic_client,
-            first_cache,
-            test_topic.key(),
-            test_topic.value(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache,
-            test_topic.key(),
-            test_topic.value(),
-        )
-        .await?;
+        // should not be able to publish in either cache on either topic
+        assert_publish_failure(&tc, first_cache, first_topic.key(), first_topic.value()).await?;
+        assert_publish_failure(&tc, first_cache, second_topic.key(), second_topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, first_topic.key(), first_topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, second_topic.key(), second_topic.value()).await?;
 
-        // should be able to subscribe in only first cache on only the specific topic
-        assert_subscribe_success(&topic_client, first_cache, test_topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, test_topic.key()).await?;
+        // should be able to subscribe in only first cache to the specific topic
+        assert_subscribe_success(&tc, first_cache, first_topic.key()).await?;
+        assert_subscribe_failure(&tc, first_cache, second_topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, first_topic.key()).await?;
 
         Ok(())
     }
@@ -1458,59 +1156,40 @@ mod disposable_tokens_topics {
     async fn test_topics_subscribe_only_specific_topic_all_caches() -> MomentoResult<()> {
         let first_cache = &CACHE_TEST_STATE.cache_name;
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
-        let test_topic = TestScalar::new();
+        let first_topic = TestScalar::new();
+        let second_topic = TestScalar::new();
         let response = generate_disposable_token_success(
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::TopicPermission(TopicPermission {
                     cache: CacheSelector::AllCaches,
-                    topic: test_topic.key().into(),
+                    topic: first_topic.key().into(),
                     role: TopicRole::SubscribeOnly,
                 })],
             }),
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let topic_client = new_topic_client(creds.clone());
-        let cache_client = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds.clone());
+        let cc = new_cache_client(creds.clone());
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
-        // should not be able to publish in either cache
-        assert_publish_failure(
-            &topic_client,
-            first_cache,
-            test_topic.key(),
-            test_topic.value(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache,
-            test_topic.key(),
-            test_topic.value(),
-        )
-        .await?;
+        // should not be able to publish in either cache on either topic
+        assert_publish_failure(&tc, first_cache, first_topic.key(), first_topic.value()).await?;
+        assert_publish_failure(&tc, first_cache, second_topic.key(), second_topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, first_topic.key(), first_topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, second_topic.key(), second_topic.value()).await?;
 
-        // should be able to subscribe in both caches
-        assert_subscribe_success(&topic_client, first_cache, test_topic.key()).await?;
-        assert_subscribe_success(&topic_client, second_cache, test_topic.key()).await?;
+        // should be able to subscribe in both caches to only the specific topic
+        assert_subscribe_success(&tc, first_cache, first_topic.key()).await?;
+        assert_subscribe_failure(&tc, first_cache, second_topic.key()).await?;
+        assert_subscribe_success(&tc, second_cache, first_topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, second_topic.key()).await?;
 
         Ok(())
     }
@@ -1532,61 +1211,27 @@ mod disposable_tokens_topics {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let topic_client = new_topic_client(creds.clone());
-        let cache_client = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds.clone());
+        let cc = new_cache_client(creds.clone());
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
-        // should not be able to publish in either cache on all topics
-        assert_publish_failure(
-            &topic_client,
-            first_cache,
-            first_topic.key(),
-            first_topic.value(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache,
-            first_topic.key(),
-            first_topic.value(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            first_cache,
-            second_topic.key(),
-            second_topic.value(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache,
-            second_topic.key(),
-            second_topic.value(),
-        )
-        .await?;
+        // should not be able to publish in either cache on either topic
+        assert_publish_failure(&tc, first_cache, first_topic.key(), first_topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, first_topic.key(), first_topic.value()).await?;
+        assert_publish_failure(&tc, first_cache, second_topic.key(), second_topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, second_topic.key(), second_topic.value()).await?;
 
-        // should be able to subscribe in only first cache on all topics
-        assert_subscribe_success(&topic_client, first_cache, first_topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, first_topic.key()).await?;
+        // should be able to subscribe in only first cache on either topic
+        assert_subscribe_success(&tc, first_cache, first_topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, first_topic.key()).await?;
+        assert_subscribe_success(&tc, first_cache, second_topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, second_topic.key()).await?;
 
         Ok(())
     }
@@ -1608,63 +1253,27 @@ mod disposable_tokens_topics {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let topic_client = new_topic_client(creds.clone());
-        let cache_client = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds.clone());
+        let cc = new_cache_client(creds.clone());
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
-        // should not be able to publish in either cache on all topics
-        assert_publish_failure(
-            &topic_client,
-            first_cache,
-            first_topic.key(),
-            first_topic.value(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache,
-            first_topic.key(),
-            first_topic.value(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            first_cache,
-            second_topic.key(),
-            second_topic.value(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache,
-            second_topic.key(),
-            second_topic.value(),
-        )
-        .await?;
+        // should not be able to publish in either cache on either topic
+        assert_publish_failure(&tc, first_cache, first_topic.key(), first_topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, first_topic.key(), first_topic.value()).await?;
+        assert_publish_failure(&tc, first_cache, second_topic.key(), second_topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, second_topic.key(), second_topic.value()).await?;
 
-        // should be able to subscribe in both caches on all topics
-        assert_subscribe_success(&topic_client, first_cache, first_topic.key()).await?;
-        assert_subscribe_success(&topic_client, second_cache, first_topic.key()).await?;
-        assert_subscribe_success(&topic_client, first_cache, second_topic.key()).await?;
-        assert_subscribe_success(&topic_client, second_cache, second_topic.key()).await?;
+        // should be able to subscribe in both caches on both topics
+        assert_subscribe_success(&tc, first_cache, first_topic.key()).await?;
+        assert_subscribe_success(&tc, second_cache, first_topic.key()).await?;
+        assert_subscribe_success(&tc, first_cache, second_topic.key()).await?;
+        assert_subscribe_success(&tc, second_cache, second_topic.key()).await?;
 
         Ok(())
     }
@@ -1673,59 +1282,40 @@ mod disposable_tokens_topics {
     async fn test_topics_publish_only_specific_topic_specific_cache() -> MomentoResult<()> {
         let first_cache = &CACHE_TEST_STATE.cache_name;
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
-        let test_topic = TestScalar::new();
+        let first_topic = TestScalar::new();
+        let second_topic = TestScalar::new();
         let response = generate_disposable_token_success(
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::TopicPermission(TopicPermission {
                     cache: (*first_cache).clone().into(),
-                    topic: test_topic.key().into(),
+                    topic: first_topic.key().into(),
                     role: TopicRole::PublishOnly,
                 })],
             }),
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let topic_client = new_topic_client(creds.clone());
-        let cache_client = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds.clone());
+        let cc = new_cache_client(creds.clone());
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
         // should be able to publish in only first cache on only the specific topic
-        assert_publish_success(
-            &topic_client,
-            first_cache,
-            test_topic.key(),
-            test_topic.value(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache,
-            test_topic.key(),
-            test_topic.value(),
-        )
-        .await?;
+        assert_publish_success(&tc, first_cache, first_topic.key(), first_topic.value()).await?;
+        assert_publish_failure(&tc, first_cache, second_topic.key(), second_topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, first_topic.key(), first_topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, second_topic.key(), second_topic.value()).await?;
 
-        // should not be able to subscribe in either cache on only the specific topic
-        assert_subscribe_failure(&topic_client, first_cache, test_topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, test_topic.key()).await?;
+        // should not be able to subscribe in either cache on either topic
+        assert_subscribe_failure(&tc, first_cache, first_topic.key()).await?;
+        assert_subscribe_failure(&tc, first_cache, second_topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, first_topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, second_topic.key()).await?;
 
         Ok(())
     }
@@ -1734,59 +1324,40 @@ mod disposable_tokens_topics {
     async fn test_topics_publish_only_specific_topic_all_caches() -> MomentoResult<()> {
         let first_cache = &CACHE_TEST_STATE.cache_name;
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
-        let test_topic = TestScalar::new();
+        let first_topic = TestScalar::new();
+        let second_topic = TestScalar::new();
         let response = generate_disposable_token_success(
             DisposableTokenScope::Permissions::<String>(Permissions {
                 permissions: vec![Permission::TopicPermission(TopicPermission {
                     cache: CacheSelector::AllCaches,
-                    topic: test_topic.key().into(),
+                    topic: first_topic.key().into(),
                     role: TopicRole::PublishOnly,
                 })],
             }),
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let topic_client = new_topic_client(creds.clone());
-        let cache_client = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds.clone());
+        let cc = new_cache_client(creds.clone());
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
         // should be able to publish in both caches on only the specific topic
-        assert_publish_success(
-            &topic_client,
-            first_cache,
-            test_topic.key(),
-            test_topic.value(),
-        )
-        .await?;
-        assert_publish_success(
-            &topic_client,
-            second_cache,
-            test_topic.key(),
-            test_topic.value(),
-        )
-        .await?;
+        assert_publish_success(&tc, first_cache, first_topic.key(), first_topic.value()).await?;
+        assert_publish_success(&tc, second_cache, first_topic.key(), first_topic.value()).await?;
+        assert_publish_failure(&tc, first_cache, second_topic.key(), second_topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, second_topic.key(), second_topic.value()).await?;
 
-        // should not be able to subscribe in either cache on only the specific topic
-        assert_subscribe_failure(&topic_client, first_cache, test_topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, test_topic.key()).await?;
+        // should not be able to subscribe in either cache on either topic
+        assert_subscribe_failure(&tc, first_cache, first_topic.key()).await?;
+        assert_subscribe_failure(&tc, first_cache, second_topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, first_topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, second_topic.key()).await?;
 
         Ok(())
     }
@@ -1808,63 +1379,27 @@ mod disposable_tokens_topics {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let topic_client = new_topic_client(creds.clone());
-        let cache_client = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds.clone());
+        let cc = new_cache_client(creds.clone());
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
         // should be able to publish in only first cache on all topics
-        assert_publish_success(
-            &topic_client,
-            first_cache,
-            first_topic.key(),
-            first_topic.value(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache,
-            first_topic.key(),
-            first_topic.value(),
-        )
-        .await?;
-        assert_publish_success(
-            &topic_client,
-            first_cache,
-            second_topic.key(),
-            second_topic.value(),
-        )
-        .await?;
-        assert_publish_failure(
-            &topic_client,
-            second_cache,
-            second_topic.key(),
-            second_topic.value(),
-        )
-        .await?;
+        assert_publish_success(&tc, first_cache, first_topic.key(), first_topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, first_topic.key(), first_topic.value()).await?;
+        assert_publish_success(&tc, first_cache, second_topic.key(), second_topic.value()).await?;
+        assert_publish_failure(&tc, second_cache, second_topic.key(), second_topic.value()).await?;
 
         // should not be able to subscribe in either cache on all topics
-        assert_subscribe_failure(&topic_client, first_cache, first_topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, first_topic.key()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, second_topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, second_topic.key()).await?;
+        assert_subscribe_failure(&tc, first_cache, first_topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, first_topic.key()).await?;
+        assert_subscribe_failure(&tc, first_cache, second_topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, second_topic.key()).await?;
 
         Ok(())
     }
@@ -1886,63 +1421,27 @@ mod disposable_tokens_topics {
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let topic_client = new_topic_client(creds.clone());
-        let cache_client = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds.clone());
+        let cc = new_cache_client(creds.clone());
 
         // should not be able to use cache directly
         let test_item = TestScalar::new();
-        assert_get_failure(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_failure(&cache_client, second_cache, test_item.key()).await?;
-        assert_set_failure(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_failure(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_get_failure(&cc, first_cache, test_item.key()).await?;
+        assert_get_failure(&cc, second_cache, test_item.key()).await?;
+        assert_set_failure(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_failure(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
-        // should be able to publish in both caches on all topics
-        assert_publish_success(
-            &topic_client,
-            first_cache,
-            first_topic.key(),
-            first_topic.value(),
-        )
-        .await?;
-        assert_publish_success(
-            &topic_client,
-            second_cache,
-            first_topic.key(),
-            first_topic.value(),
-        )
-        .await?;
-        assert_publish_success(
-            &topic_client,
-            first_cache,
-            second_topic.key(),
-            second_topic.value(),
-        )
-        .await?;
-        assert_publish_success(
-            &topic_client,
-            second_cache,
-            second_topic.key(),
-            second_topic.value(),
-        )
-        .await?;
+        // should be able to publish in both caches on both topics
+        assert_publish_success(&tc, first_cache, first_topic.key(), first_topic.value()).await?;
+        assert_publish_success(&tc, second_cache, first_topic.key(), first_topic.value()).await?;
+        assert_publish_success(&tc, first_cache, second_topic.key(), second_topic.value()).await?;
+        assert_publish_success(&tc, second_cache, second_topic.key(), second_topic.value()).await?;
 
-        // should not be able to subscribe in either cache on all topics
-        assert_subscribe_failure(&topic_client, first_cache, first_topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, first_topic.key()).await?;
-        assert_subscribe_failure(&topic_client, first_cache, second_topic.key()).await?;
-        assert_subscribe_failure(&topic_client, second_cache, second_topic.key()).await?;
+        // should not be able to subscribe in either cache on either topic
+        assert_subscribe_failure(&tc, first_cache, first_topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, first_topic.key()).await?;
+        assert_subscribe_failure(&tc, first_cache, second_topic.key()).await?;
+        assert_subscribe_failure(&tc, second_cache, second_topic.key()).await?;
 
         Ok(())
     }
@@ -1955,69 +1454,33 @@ mod disposable_tokens_all_data {
     async fn test_all_data_read_write() -> MomentoResult<()> {
         let first_cache = &CACHE_TEST_STATE.cache_name;
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
-        let first_topic = TestScalar::new();
-        let second_topic = TestScalar::new();
         let response = generate_disposable_token_success(
             DisposableTokenScope::Permissions::<String>(Permissions::all_data_read_write()),
         )
         .await?;
         let creds = new_credential_provider_from_token(response.auth_token());
-        let cache_client = new_cache_client(creds.clone());
-        let topic_client = new_topic_client(creds);
+        let cc = new_cache_client(creds.clone());
+        let tc = new_topic_client(creds);
 
         // should be able to read and write in both caches
         let test_item = TestScalar::new();
-        assert_get_success(&cache_client, first_cache, test_item.key()).await?;
-        assert_get_success(&cache_client, second_cache, test_item.key()).await?;
-        assert_set_success(
-            &cache_client,
-            first_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_set_success(
-            &cache_client,
-            second_cache,
-            test_item.key(),
-            test_item.value(),
-        )
-        .await?;
+        assert_get_success(&cc, first_cache, test_item.key()).await?;
+        assert_get_success(&cc, second_cache, test_item.key()).await?;
+        assert_set_success(&cc, first_cache, test_item.key(), test_item.value()).await?;
+        assert_set_success(&cc, second_cache, test_item.key(), test_item.value()).await?;
 
         // should be able to publish and subscribe in both caches on both topics
-        assert_publish_success(
-            &topic_client,
-            first_cache,
-            first_topic.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_subscribe_success(&topic_client, first_cache, first_topic.key()).await?;
-        assert_publish_success(
-            &topic_client,
-            second_cache,
-            first_topic.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_subscribe_success(&topic_client, second_cache, first_topic.key()).await?;
+        let first_topic = TestScalar::new();
+        assert_publish_success(&tc, first_cache, first_topic.key(), test_item.value()).await?;
+        assert_subscribe_success(&tc, first_cache, first_topic.key()).await?;
+        assert_publish_success(&tc, second_cache, first_topic.key(), test_item.value()).await?;
+        assert_subscribe_success(&tc, second_cache, first_topic.key()).await?;
 
-        assert_publish_success(
-            &topic_client,
-            first_cache,
-            second_topic.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_subscribe_success(&topic_client, first_cache, second_topic.key()).await?;
-        assert_publish_success(
-            &topic_client,
-            second_cache,
-            second_topic.key(),
-            test_item.value(),
-        )
-        .await?;
-        assert_subscribe_success(&topic_client, second_cache, second_topic.key()).await?;
+        let second_topic = TestScalar::new();
+        assert_publish_success(&tc, first_cache, second_topic.key(), test_item.value()).await?;
+        assert_subscribe_success(&tc, first_cache, second_topic.key()).await?;
+        assert_publish_success(&tc, second_cache, second_topic.key(), test_item.value()).await?;
+        assert_subscribe_success(&tc, second_cache, second_topic.key()).await?;
 
         Ok(())
     }

--- a/tests/auth/disposable_tokens.rs
+++ b/tests/auth/disposable_tokens.rs
@@ -1,0 +1,2968 @@
+use std::time::Duration;
+
+use momento::auth::CacheSelector;
+use momento::auth::{CachePermission, CacheRole, Permission, Permissions};
+use momento::{
+    auth::{
+        DisposableTokenScope, DisposableTokenScopes, ExpiresIn, GenerateDisposableTokenResponse,
+    },
+    CacheClient, CredentialProvider, IntoBytes, MomentoResult, TopicClient,
+};
+use momento::{MomentoError, MomentoErrorCode};
+use momento_test_util::{unique_key, TestScalar, CACHE_TEST_STATE};
+
+// Helper function that generates a disposable token with the given scope
+// that expires in 5 minutes.
+async fn generate_disposable_token_success(
+    scope: DisposableTokenScope<impl IntoBytes>,
+) -> MomentoResult<GenerateDisposableTokenResponse> {
+    let expiry = ExpiresIn::minutes(5);
+    let response = CACHE_TEST_STATE
+        .auth_client
+        .generate_disposable_token(scope, expiry)
+        .await?;
+    assert!(!response.clone().auth_token().is_empty());
+    Ok(response)
+}
+
+fn new_credential_provider_from_token(token: String) -> CredentialProvider {
+    CredentialProvider::from_string(token).expect("auth token should be valid")
+}
+
+fn new_cache_client(credential_provider: CredentialProvider) -> CacheClient {
+    CacheClient::builder()
+        .default_ttl(Duration::from_secs(30))
+        .configuration(momento::cache::configurations::Laptop::latest())
+        .credential_provider(credential_provider)
+        .build()
+        .expect("Failed to create cache client")
+}
+
+fn new_topic_client(credential_provider: CredentialProvider) -> TopicClient {
+    TopicClient::builder()
+        .configuration(momento::topics::configurations::Laptop::latest())
+        .credential_provider(credential_provider)
+        .build()
+        .expect("Failed to create topic client")
+}
+
+async fn assert_get_success(
+    cache_client: &CacheClient,
+    cache_name: String,
+    key: String,
+) -> MomentoResult<()> {
+    match cache_client.get(cache_name.clone(), key.clone()).await {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            eprintln!(
+                "Expected to successfully get key '{}' from cache '{}'",
+                key, cache_name
+            );
+            Err(e)
+        }
+    }
+}
+
+async fn assert_get_failure(
+    cache_client: &CacheClient,
+    cache_name: String,
+    key: String,
+) -> MomentoResult<()> {
+    match cache_client.get(cache_name.clone(), key.clone()).await {
+        Ok(_) => Err(MomentoError {
+            message: format!(
+                "Expected getting key '{}' from cache '{}' to fail",
+                key, cache_name
+            ),
+            error_code: MomentoErrorCode::UnknownError,
+            inner_error: None,
+            details: None,
+        }),
+        Err(e) => {
+            assert_eq!(e.error_code, MomentoErrorCode::PermissionError);
+            Ok(())
+        }
+    }
+}
+
+async fn assert_set_success(
+    cache_client: &CacheClient,
+    cache_name: String,
+    key: String,
+    value: String,
+) -> MomentoResult<()> {
+    match cache_client
+        .set(cache_name.clone(), key.clone(), value.clone())
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            eprintln!(
+                "Expected to successfully set value '{}' for key '{}' from cache '{}'",
+                value, key, cache_name
+            );
+            Err(e)
+        }
+    }
+}
+
+async fn assert_set_failure(
+    cache_client: &CacheClient,
+    cache_name: String,
+    key: String,
+    value: String,
+) -> MomentoResult<()> {
+    match cache_client
+        .set(cache_name.clone(), key.clone(), value.clone())
+        .await
+    {
+        Ok(_) => Err(MomentoError {
+            message: format!(
+                "Expected setting value '{}' for key '{}' from cache '{}' to fail",
+                value, key, cache_name
+            ),
+            error_code: MomentoErrorCode::UnknownError,
+            inner_error: None,
+            details: None,
+        }),
+        Err(e) => {
+            assert_eq!(e.error_code, MomentoErrorCode::PermissionError);
+            Ok(())
+        }
+    }
+}
+
+async fn assert_publish_success(
+    topic_client: &TopicClient,
+    cache_name: String,
+    topic_name: String,
+    value: String,
+) -> MomentoResult<()> {
+    match topic_client
+        .publish(cache_name.clone(), topic_name.clone(), value.clone())
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            eprintln!(
+                "Expected to successfully publish value '{}' for topic '{}' in cache '{}'",
+                value, topic_name, cache_name
+            );
+            Err(e)
+        }
+    }
+}
+
+async fn assert_publish_failure(
+    topic_client: &TopicClient,
+    cache_name: String,
+    topic_name: String,
+    value: String,
+) -> MomentoResult<()> {
+    match topic_client
+        .publish(cache_name.clone(), topic_name.clone(), value.clone())
+        .await
+    {
+        Ok(_) => Err(MomentoError {
+            message: format!(
+                "Expected publishing value '{}' for topic '{}' in cache '{}' to fail",
+                value, topic_name, cache_name
+            ),
+            error_code: MomentoErrorCode::UnknownError,
+            inner_error: None,
+            details: None,
+        }),
+        Err(e) => {
+            assert_eq!(e.error_code, MomentoErrorCode::PermissionError);
+            Ok(())
+        }
+    }
+}
+
+async fn assert_subscribe_success(
+    topic_client: &TopicClient,
+    cache_name: String,
+    topic_name: String,
+) -> MomentoResult<()> {
+    match topic_client
+        .subscribe(cache_name.clone(), topic_name.clone())
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            eprintln!(
+                "Expected to successfully subscribe to topic '{}' in cache '{}'",
+                topic_name, cache_name
+            );
+            Err(e)
+        }
+    }
+}
+
+async fn assert_subscribe_failure(
+    topic_client: &TopicClient,
+    cache_name: String,
+    topic_name: String,
+) -> MomentoResult<()> {
+    match topic_client
+        .subscribe(cache_name.clone(), topic_name.clone())
+        .await
+    {
+        Ok(_) => Err(MomentoError {
+            message: format!(
+                "Expected subscribe to topic '{}' in cache '{}' to fail",
+                topic_name, cache_name
+            ),
+            error_code: MomentoErrorCode::UnknownError,
+            inner_error: None,
+            details: None,
+        }),
+        Err(e) => {
+            assert_eq!(e.error_code, MomentoErrorCode::PermissionError);
+            Ok(())
+        }
+    }
+}
+
+mod disposable_tokens_cache_key {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_cache_key_read_only_all_caches() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_item = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScopes::cache_key_read_only(CacheSelector::AllCaches, test_item.key()),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should be able to read this key in both caches
+        assert_get_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_success(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+
+        // should not be able to read another key in either cache
+        let other_key = unique_key();
+        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
+        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+
+        // should not be able to write the key in either cache
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cache_key_read_only_specific_cache() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_item = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScopes::cache_key_read_only(first_cache.clone(), test_item.key()),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should be able to read this key in only first cache
+        assert_get_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+
+        // should not be able to read another key in either cache
+        let other_key = unique_key();
+        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
+        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+
+        // should not be able to write the key in either cache
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cache_key_write_only_all_caches() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_item = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScopes::cache_key_write_only(CacheSelector::AllCaches, test_item.key()),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should not be able to read this key in either cache
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+
+        // should not be able to read another key in either cache
+        let other_key = unique_key();
+        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
+        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+
+        // should be able to write the key in both caches
+        assert_set_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_success(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cache_key_write_only_specific_cache() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_item = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScopes::cache_key_write_only(first_cache.clone(), test_item.key()),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should not be able to read this key in either cache
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+
+        // should not be able to read another key in either cache
+        let other_key = unique_key();
+        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
+        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+
+        // should be able to write the key in only first cache
+        assert_set_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cache_key_read_write_all_caches() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_item = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScopes::cache_key_read_write(CacheSelector::AllCaches, test_item.key()),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should be able to read this key in both caches
+        assert_get_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_success(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+
+        // should not be able to read another key in either cache
+        let other_key = unique_key();
+        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
+        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+
+        // should be able to write the key in both caches
+        assert_set_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_success(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cache_key_read_write_specific_cache() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_item = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScopes::cache_key_read_write(first_cache.clone(), test_item.key()),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should be able to read this key in only first cache
+        assert_get_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+
+        // should not be able to read another key in either cache
+        let other_key = unique_key();
+        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
+        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+
+        // should be able to write the key in only first cache
+        assert_set_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+}
+
+mod disposable_tokens_cache_key_prefix {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_cache_key_prefix_read_only_specific_cache() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_item = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScopes::cache_key_prefix_read_only(first_cache.clone(), test_item.key()),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should be able to read this key in only first cache
+        assert_get_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+
+        // should be able to read a prefixed key in only first cache
+        let prefixed_key = format!("{}-smth-else", test_item.key());
+        assert_get_success(&cache_client, first_cache.to_string(), prefixed_key.clone()).await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            prefixed_key.clone(),
+        )
+        .await?;
+
+        // should not be able to read another key in either cache
+        let other_key = unique_key();
+        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
+        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+
+        // should not be able to write the key in either cache
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cache_key_prefix_read_only_all_caches() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_item = TestScalar::new();
+        let response =
+            generate_disposable_token_success(DisposableTokenScopes::cache_key_prefix_read_only(
+                CacheSelector::AllCaches,
+                test_item.key(),
+            ))
+            .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should be able to read this key in both caches
+        assert_get_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_success(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+
+        // should be able to read a prefixed key in both caches
+        let prefixed_key = format!("{}-smth-else", test_item.key());
+        assert_get_success(&cache_client, first_cache.to_string(), prefixed_key.clone()).await?;
+        assert_get_success(
+            &cache_client,
+            second_cache.to_string(),
+            prefixed_key.clone(),
+        )
+        .await?;
+
+        // should not be able to read another key in either cache
+        let other_key = unique_key();
+        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
+        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+
+        // should not be able to write the key in either cache
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cache_key_prefix_write_only_specific_cache() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_item = TestScalar::new();
+        let response =
+            generate_disposable_token_success(DisposableTokenScopes::cache_key_prefix_write_only(
+                first_cache.clone(),
+                test_item.key(),
+            ))
+            .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should not be able to read this key in either cache
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+
+        // should not be able to read a prefixed key in either cache
+        let prefixed_key = format!("{}-smth-else", test_item.key());
+        assert_get_failure(&cache_client, first_cache.to_string(), prefixed_key.clone()).await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            prefixed_key.clone(),
+        )
+        .await?;
+
+        // should not be able to read another key in either cache
+        let other_key = unique_key();
+        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
+        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+
+        // should be able to write the key in only first cache
+        assert_set_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cache_key_prefix_write_only_all_caches() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_item = TestScalar::new();
+        let response =
+            generate_disposable_token_success(DisposableTokenScopes::cache_key_prefix_write_only(
+                CacheSelector::AllCaches,
+                test_item.key(),
+            ))
+            .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should not be able to read this key in either cache
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+
+        // should not be able to read a prefixed key in either cache
+        let prefixed_key = format!("{}-smth-else", test_item.key());
+        assert_get_failure(&cache_client, first_cache.to_string(), prefixed_key.clone()).await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            prefixed_key.clone(),
+        )
+        .await?;
+
+        // should not be able to read another key in either cache
+        let other_key = unique_key();
+        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
+        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+
+        // should be able to write the key in both caches
+        assert_set_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_success(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cache_key_prefix_read_write_specific_cache() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_item = TestScalar::new();
+        let response =
+            generate_disposable_token_success(DisposableTokenScopes::cache_key_prefix_read_write(
+                first_cache.clone(),
+                test_item.key(),
+            ))
+            .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should be able to read this key in only first cache
+        assert_get_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+
+        // should be able to read a prefixed key in only first cache
+        let prefixed_key = format!("{}-smth-else", test_item.key());
+        assert_get_success(&cache_client, first_cache.to_string(), prefixed_key.clone()).await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            prefixed_key.clone(),
+        )
+        .await?;
+
+        // should not be able to read another key in either cache
+        let other_key = unique_key();
+        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
+        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+
+        // should be able to write the key in only first cache
+        assert_set_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cache_key_prefix_read_write_all_caches() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_item = TestScalar::new();
+        let response =
+            generate_disposable_token_success(DisposableTokenScopes::cache_key_prefix_read_write(
+                CacheSelector::AllCaches,
+                test_item.key(),
+            ))
+            .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should be able to read this key in both caches
+        assert_get_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_success(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+
+        // should be able to read a prefixed key in both caches
+        let prefixed_key = format!("{}-smth-else", test_item.key());
+        assert_get_success(&cache_client, first_cache.to_string(), prefixed_key.clone()).await?;
+        assert_get_success(
+            &cache_client,
+            second_cache.to_string(),
+            prefixed_key.clone(),
+        )
+        .await?;
+
+        // should not be able to read another key in either cache
+        let other_key = unique_key();
+        assert_get_failure(&cache_client, first_cache.to_string(), other_key.clone()).await?;
+        assert_get_failure(&cache_client, second_cache.to_string(), other_key).await?;
+
+        // should be able to write the key in both caches
+        assert_set_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_success(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+}
+
+mod disposable_tokens_cache {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_cache_read_write_specific_cache() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::CachePermission(CachePermission {
+                    cache: first_cache.to_string().into(),
+                    role: CacheRole::ReadWrite,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should be able to read and write in only first cache
+        let test_item = TestScalar::new();
+        assert_get_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_set_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cache_read_write_all_caches() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::CachePermission(CachePermission {
+                    cache: CacheSelector::AllCaches,
+                    role: CacheRole::ReadWrite,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should be able to read and write in both caches
+        let test_item = TestScalar::new();
+        assert_get_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_success(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_set_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_success(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cache_read_only_specific_cache() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::CachePermission(CachePermission {
+                    cache: first_cache.to_string().into(),
+                    role: CacheRole::ReadOnly,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should be able to read in only first cache
+        let test_item = TestScalar::new();
+        assert_get_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+
+        // should not be able to write in either cache
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cache_read_only_all_caches() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::CachePermission(CachePermission {
+                    cache: CacheSelector::AllCaches,
+                    role: CacheRole::ReadOnly,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should be able to read in both caches
+        let test_item = TestScalar::new();
+        assert_get_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_success(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+
+        // should not be able to write in either cache
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cache_write_only_specific_cache() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::CachePermission(CachePermission {
+                    cache: first_cache.to_string().into(),
+                    role: CacheRole::WriteOnly,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should not be able to read in either cache
+        let test_item = TestScalar::new();
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+
+        // should be able to write in only first cache
+        assert_set_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cache_write_only_all_caches() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::CachePermission(CachePermission {
+                    cache: CacheSelector::AllCaches,
+                    role: CacheRole::WriteOnly,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should not be able to read in either cache
+        let test_item = TestScalar::new();
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+
+        // should be able to write in both caches
+        assert_set_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_success(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to use topics
+        let topic = TestScalar::new();
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+            topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+}
+
+mod disposable_tokens_topics {
+    use momento::auth::{TopicPermission, TopicRole, TopicSelector};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_topics_publish_subscribe_specific_topic_specific_cache() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_topic = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: first_cache.to_string().into(),
+                    topic: test_topic.key().to_string().into(),
+                    role: TopicRole::PublishSubscribe,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let topic_client = new_topic_client(creds.clone());
+        let cache_client = new_cache_client(creds.clone());
+
+        // should not be able to use cache directly
+        let test_item = TestScalar::new();
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should be able to publish and subscribe in only first cache on only the specific topic
+        assert_publish_success(
+            &topic_client,
+            first_cache.to_string(),
+            test_topic.key().to_string(),
+            test_topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_success(
+            &topic_client,
+            first_cache.to_string(),
+            test_topic.key().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            test_topic.key().to_string(),
+            test_topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            test_topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_topics_publish_subscribe_specific_topic_all_caches() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_topic = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::AllCaches,
+                    topic: test_topic.key().to_string().into(),
+                    role: TopicRole::PublishSubscribe,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let topic_client = new_topic_client(creds.clone());
+        let cache_client = new_cache_client(creds.clone());
+
+        // should not be able to use cache directly
+        let test_item = TestScalar::new();
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should be able to publish and subscribe in both caches on only the specific topic
+        assert_publish_success(
+            &topic_client,
+            first_cache.to_string(),
+            test_topic.key().to_string(),
+            test_topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_success(
+            &topic_client,
+            first_cache.to_string(),
+            test_topic.key().to_string(),
+        )
+        .await?;
+        assert_publish_success(
+            &topic_client,
+            second_cache.to_string(),
+            test_topic.key().to_string(),
+            test_topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_success(
+            &topic_client,
+            second_cache.to_string(),
+            test_topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_topics_publish_subscribe_all_topics_specific_cache() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let first_topic = TestScalar::new();
+        let second_topic = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: first_cache.to_string().into(),
+                    topic: TopicSelector::AllTopics,
+                    role: TopicRole::PublishSubscribe,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let topic_client = new_topic_client(creds.clone());
+        let cache_client = new_cache_client(creds.clone());
+
+        // should not be able to use cache directly
+        let test_item = TestScalar::new();
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should be able to publish and subscribe in only first cache on all topics
+        assert_publish_success(
+            &topic_client,
+            first_cache.to_string(),
+            first_topic.key().to_string(),
+            first_topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_success(
+            &topic_client,
+            first_cache.to_string(),
+            first_topic.key().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            first_topic.key().to_string(),
+            first_topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            first_topic.key().to_string(),
+        )
+        .await?;
+        assert_publish_success(
+            &topic_client,
+            first_cache.to_string(),
+            second_topic.key().to_string(),
+            second_topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_success(
+            &topic_client,
+            first_cache.to_string(),
+            second_topic.key().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            second_topic.key().to_string(),
+            second_topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            second_topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_topics_publish_subscribe_all_topics_all_caches() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let first_topic = TestScalar::new();
+        let second_topic = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::AllCaches,
+                    topic: TopicSelector::AllTopics,
+                    role: TopicRole::PublishSubscribe,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let topic_client = new_topic_client(creds.clone());
+        let cache_client = new_cache_client(creds.clone());
+
+        // should not be able to use cache directly
+        let test_item = TestScalar::new();
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should be able to publish and subscribe in both caches on all topics
+        assert_publish_success(
+            &topic_client,
+            first_cache.to_string(),
+            first_topic.key().to_string(),
+            first_topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_success(
+            &topic_client,
+            first_cache.to_string(),
+            first_topic.key().to_string(),
+        )
+        .await?;
+        assert_publish_success(
+            &topic_client,
+            second_cache.to_string(),
+            first_topic.key().to_string(),
+            first_topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_success(
+            &topic_client,
+            second_cache.to_string(),
+            first_topic.key().to_string(),
+        )
+        .await?;
+        assert_publish_success(
+            &topic_client,
+            first_cache.to_string(),
+            second_topic.key().to_string(),
+            second_topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_success(
+            &topic_client,
+            first_cache.to_string(),
+            second_topic.key().to_string(),
+        )
+        .await?;
+        assert_publish_success(
+            &topic_client,
+            second_cache.to_string(),
+            second_topic.key().to_string(),
+            second_topic.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_success(
+            &topic_client,
+            second_cache.to_string(),
+            second_topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_topics_subscribe_only_specific_topic_specific_cache() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_topic = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: first_cache.to_string().into(),
+                    topic: test_topic.key().to_string().into(),
+                    role: TopicRole::SubscribeOnly,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let topic_client = new_topic_client(creds.clone());
+        let cache_client = new_cache_client(creds.clone());
+
+        // should not be able to use cache directly
+        let test_item = TestScalar::new();
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to publish in either cache on only the specific topic
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            test_topic.key().to_string(),
+            test_topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            test_topic.key().to_string(),
+            test_topic.value().to_string(),
+        )
+        .await?;
+
+        // should be able to subscribe in only first cache on only the specific topic
+        assert_subscribe_success(
+            &topic_client,
+            first_cache.to_string(),
+            test_topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            test_topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_topics_subscribe_only_specific_topic_all_caches() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_topic = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::AllCaches,
+                    topic: test_topic.key().to_string().into(),
+                    role: TopicRole::SubscribeOnly,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let topic_client = new_topic_client(creds.clone());
+        let cache_client = new_cache_client(creds.clone());
+
+        // should not be able to use cache directly
+        let test_item = TestScalar::new();
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to publish in either cache
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            test_topic.key().to_string(),
+            test_topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            test_topic.key().to_string(),
+            test_topic.value().to_string(),
+        )
+        .await?;
+
+        // should be able to subscribe in both caches
+        assert_subscribe_success(
+            &topic_client,
+            first_cache.to_string(),
+            test_topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_success(
+            &topic_client,
+            second_cache.to_string(),
+            test_topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_topics_subscribe_only_all_topics_specific_cache() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let first_topic = TestScalar::new();
+        let second_topic = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: first_cache.to_string().into(),
+                    topic: TopicSelector::AllTopics,
+                    role: TopicRole::SubscribeOnly,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let topic_client = new_topic_client(creds.clone());
+        let cache_client = new_cache_client(creds.clone());
+
+        // should not be able to use cache directly
+        let test_item = TestScalar::new();
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to publish in either cache on all topics
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            first_topic.key().to_string(),
+            first_topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            first_topic.key().to_string(),
+            first_topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            second_topic.key().to_string(),
+            second_topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            second_topic.key().to_string(),
+            second_topic.value().to_string(),
+        )
+        .await?;
+
+        // should be able to subscribe in only first cache on all topics
+        assert_subscribe_success(
+            &topic_client,
+            first_cache.to_string(),
+            first_topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            first_topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_topics_subscribe_only_all_topics_all_caches() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let first_topic = TestScalar::new();
+        let second_topic = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::AllCaches,
+                    topic: TopicSelector::AllTopics,
+                    role: TopicRole::SubscribeOnly,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let topic_client = new_topic_client(creds.clone());
+        let cache_client = new_cache_client(creds.clone());
+
+        // should not be able to use cache directly
+        let test_item = TestScalar::new();
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to publish in either cache on all topics
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            first_topic.key().to_string(),
+            first_topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            first_topic.key().to_string(),
+            first_topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            first_cache.to_string(),
+            second_topic.key().to_string(),
+            second_topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            second_topic.key().to_string(),
+            second_topic.value().to_string(),
+        )
+        .await?;
+
+        // should be able to subscribe in both caches on all topics
+        assert_subscribe_success(
+            &topic_client,
+            first_cache.to_string(),
+            first_topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_success(
+            &topic_client,
+            second_cache.to_string(),
+            first_topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_success(
+            &topic_client,
+            first_cache.to_string(),
+            second_topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_success(
+            &topic_client,
+            second_cache.to_string(),
+            second_topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_topics_publish_only_specific_topic_specific_cache() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_topic = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: first_cache.to_string().into(),
+                    topic: test_topic.key().to_string().into(),
+                    role: TopicRole::PublishOnly,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let topic_client = new_topic_client(creds.clone());
+        let cache_client = new_cache_client(creds.clone());
+
+        // should not be able to use cache directly
+        let test_item = TestScalar::new();
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should be able to publish in only first cache on only the specific topic
+        assert_publish_success(
+            &topic_client,
+            first_cache.to_string(),
+            test_topic.key().to_string(),
+            test_topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            test_topic.key().to_string(),
+            test_topic.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to subscribe in either cache on only the specific topic
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            test_topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            test_topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_topics_publish_only_specific_topic_all_caches() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let test_topic = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::AllCaches,
+                    topic: test_topic.key().to_string().into(),
+                    role: TopicRole::PublishOnly,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let topic_client = new_topic_client(creds.clone());
+        let cache_client = new_cache_client(creds.clone());
+
+        // should not be able to use cache directly
+        let test_item = TestScalar::new();
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should be able to publish in both caches on only the specific topic
+        assert_publish_success(
+            &topic_client,
+            first_cache.to_string(),
+            test_topic.key().to_string(),
+            test_topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_success(
+            &topic_client,
+            second_cache.to_string(),
+            test_topic.key().to_string(),
+            test_topic.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to subscribe in either cache on only the specific topic
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            test_topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            test_topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_topics_publish_only_all_topics_specific_cache() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let first_topic = TestScalar::new();
+        let second_topic = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: first_cache.to_string().into(),
+                    topic: TopicSelector::AllTopics,
+                    role: TopicRole::PublishOnly,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let topic_client = new_topic_client(creds.clone());
+        let cache_client = new_cache_client(creds.clone());
+
+        // should not be able to use cache directly
+        let test_item = TestScalar::new();
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should be able to publish in only first cache on all topics
+        assert_publish_success(
+            &topic_client,
+            first_cache.to_string(),
+            first_topic.key().to_string(),
+            first_topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            first_topic.key().to_string(),
+            first_topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_success(
+            &topic_client,
+            first_cache.to_string(),
+            second_topic.key().to_string(),
+            second_topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_failure(
+            &topic_client,
+            second_cache.to_string(),
+            second_topic.key().to_string(),
+            second_topic.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to subscribe in either cache on all topics
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            first_topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            first_topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            second_topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            second_topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_topics_publish_only_all_topics_all_caches() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let first_topic = TestScalar::new();
+        let second_topic = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::AllCaches,
+                    topic: TopicSelector::AllTopics,
+                    role: TopicRole::PublishOnly,
+                })],
+            }),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let topic_client = new_topic_client(creds.clone());
+        let cache_client = new_cache_client(creds.clone());
+
+        // should not be able to use cache directly
+        let test_item = TestScalar::new();
+        assert_get_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_failure(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should be able to publish in both caches on all topics
+        assert_publish_success(
+            &topic_client,
+            first_cache.to_string(),
+            first_topic.key().to_string(),
+            first_topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_success(
+            &topic_client,
+            second_cache.to_string(),
+            first_topic.key().to_string(),
+            first_topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_success(
+            &topic_client,
+            first_cache.to_string(),
+            second_topic.key().to_string(),
+            second_topic.value().to_string(),
+        )
+        .await?;
+        assert_publish_success(
+            &topic_client,
+            second_cache.to_string(),
+            second_topic.key().to_string(),
+            second_topic.value().to_string(),
+        )
+        .await?;
+
+        // should not be able to subscribe in either cache on all topics
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            first_topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            first_topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            first_cache.to_string(),
+            second_topic.key().to_string(),
+        )
+        .await?;
+        assert_subscribe_failure(
+            &topic_client,
+            second_cache.to_string(),
+            second_topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+}
+
+mod disposable_tokens_all_data {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_all_data_read_write() -> MomentoResult<()> {
+        let first_cache = &CACHE_TEST_STATE.cache_name;
+        let second_cache = &CACHE_TEST_STATE.auth_cache_name;
+        let first_topic = TestScalar::new();
+        let second_topic = TestScalar::new();
+        let response = generate_disposable_token_success(
+            DisposableTokenScope::Permissions::<String>(Permissions::all_data_read_write()),
+        )
+        .await?;
+        let creds = new_credential_provider_from_token(response.auth_token());
+        let cache_client = new_cache_client(creds.clone());
+        let topic_client = new_topic_client(creds);
+
+        // should be able to read and write in both caches
+        let test_item = TestScalar::new();
+        assert_get_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_get_success(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+        )
+        .await?;
+        assert_set_success(
+            &cache_client,
+            first_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_set_success(
+            &cache_client,
+            second_cache.to_string(),
+            test_item.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+
+        // should be able to publish and subscribe in both caches on both topics
+        assert_publish_success(
+            &topic_client,
+            first_cache.to_string(),
+            first_topic.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_success(
+            &topic_client,
+            first_cache.to_string(),
+            first_topic.key().to_string(),
+        )
+        .await?;
+        assert_publish_success(
+            &topic_client,
+            second_cache.to_string(),
+            first_topic.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_success(
+            &topic_client,
+            second_cache.to_string(),
+            first_topic.key().to_string(),
+        )
+        .await?;
+
+        assert_publish_success(
+            &topic_client,
+            first_cache.to_string(),
+            second_topic.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_success(
+            &topic_client,
+            first_cache.to_string(),
+            second_topic.key().to_string(),
+        )
+        .await?;
+        assert_publish_success(
+            &topic_client,
+            second_cache.to_string(),
+            second_topic.key().to_string(),
+            test_item.value().to_string(),
+        )
+        .await?;
+        assert_subscribe_success(
+            &topic_client,
+            second_cache.to_string(),
+            second_topic.key().to_string(),
+        )
+        .await?;
+
+        Ok(())
+    }
+}

--- a/tests/auth/mod.rs
+++ b/tests/auth/mod.rs
@@ -1,0 +1,1 @@
+mod disposable_tokens;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,3 +1,4 @@
+mod auth;
 mod cache;
 mod storage;
 mod topics;


### PR DESCRIPTION
Work towards https://github.com/momentohq/client-sdk-rust/issues/419

- Implemented AuthClient and builder. No config object since there's no logging object to configure in this SDK like in the JS or Go ones.
- Implemented permissions structure (`PermissionScope` and `DisposableTokenScope` and related objects)
- Implemented `generate_disposable_token` method
- Added docs and doctests for public-facing objects
- Added integration tests to verify correctness of `generate_disposable_token` implementation
- Updated test-util and on-pull-request workflow to accommodate new tests

After cutting a release, I can fast-follow with updating the docs snippets example file and unit tests for the permissions conversions.