### PR TITLE
chore: add auth client docs snippets

### DIFF
--- a/example/rust/Cargo.lock
+++ b/example/rust/Cargo.lock
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.44.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b17859dc0a6c5c0f227f98054723ec32a07f00d6851663ddd9a4d1f00d87b1"
+checksum = "fc7de71fc41987b56bda2a3f97f31e701431d63ad29a01ba5fe0b4f78cb01d01"
 dependencies = [
  "base64",
  "derive_more",

--- a/example/rust/Cargo.toml
+++ b/example/rust/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/docs_examples/docs_examples.rs"
 
 [dependencies]
 futures = "0.3.30"
-momento = { version = "0.44.0" }
+momento = { version = "0.47.0" }
 tokio = { version = "1.37.0", features = ["full"] }
 uuid = { version = "1.8.0", features = ["v4"] }
 anyhow = "1"


### PR DESCRIPTION
Follow up for https://github.com/momentohq/client-sdk-rust/issues/419

Adds code snippets for dev docs for creating an auth client and using `generate_disposable_token`