### PR TITLE
fix: add permission scope unit tests and From conversions for convenience

### DIFF
--- a/src/auth/auth_client.rs
+++ b/src/auth/auth_client.rs
@@ -5,7 +5,7 @@ use crate::auth::auth_client_builder::{AuthClientBuilder, NeedsCredentialProvide
 use crate::grpc::header_interceptor::HeaderInterceptor;
 
 use crate::auth::messages::MomentoRequest;
-use crate::{utils, CredentialProvider, IntoBytes, MomentoResult};
+use crate::{utils, CredentialProvider, MomentoResult};
 
 use crate::auth::expiration::ExpiresIn;
 
@@ -114,7 +114,7 @@ impl AuthClient {
     /// You can also use the [send_request](AuthClient::send_request) method to get an item using a [GenerateDisposableTokenRequest].
     pub async fn generate_disposable_token(
         &self,
-        scope: DisposableTokenScope<impl IntoBytes>,
+        scope: DisposableTokenScope,
         expires_in: ExpiresIn,
     ) -> MomentoResult<GenerateDisposableTokenResponse> {
         utils::is_disposable_token_expiry_valid(expires_in.clone())?;

--- a/src/auth/messages/generate_disposable_token.rs
+++ b/src/auth/messages/generate_disposable_token.rs
@@ -4,7 +4,7 @@ use crate::{
         permissions::disposable_token_scope::DisposableTokenScope,
     },
     utils::is_disposable_token_id_valid,
-    AuthClient, IntoBytes, MomentoResult,
+    AuthClient, MomentoResult,
 };
 
 use super::{permissions_conversions::permissions_from_disposable_token_scope, MomentoRequest};
@@ -49,15 +49,15 @@ pub struct DisposableTokenProps {
 /// # })
 /// # }
 /// ```
-pub struct GenerateDisposableTokenRequest<K: IntoBytes> {
-    scope: DisposableTokenScope<K>,
+pub struct GenerateDisposableTokenRequest {
+    scope: DisposableTokenScope,
     expires_in: ExpiresIn,
     props: Option<DisposableTokenProps>,
 }
 
-impl<K: IntoBytes> GenerateDisposableTokenRequest<K> {
+impl GenerateDisposableTokenRequest {
     /// Construct a new GenerateDisposableTokenRequest.
-    pub fn new(scope: DisposableTokenScope<K>, expires_in: ExpiresIn) -> Self {
+    pub fn new(scope: DisposableTokenScope, expires_in: ExpiresIn) -> Self {
         Self {
             scope,
             expires_in,
@@ -80,7 +80,7 @@ impl<K: IntoBytes> GenerateDisposableTokenRequest<K> {
     }
 }
 
-impl<K: IntoBytes> MomentoRequest for GenerateDisposableTokenRequest<K> {
+impl MomentoRequest for GenerateDisposableTokenRequest {
     type Response = GenerateDisposableTokenResponse;
 
     async fn send(self, client: &AuthClient) -> MomentoResult<Self::Response> {

--- a/src/auth/messages/permissions_conversions.rs
+++ b/src/auth/messages/permissions_conversions.rs
@@ -24,7 +24,7 @@ use crate::{
 
 // Create protobuf Permissions from DisposableTokenScope
 pub(crate) fn permissions_from_disposable_token_scope(
-    scope: DisposableTokenScope<impl IntoBytes>,
+    scope: DisposableTokenScope,
 ) -> permission_messages::Permissions {
     match scope {
         DisposableTokenScope::Permissions(permissions) => permission_messages::Permissions {
@@ -132,9 +132,7 @@ fn topic_permission_to_grpc_permission(permission: TopicPermission) -> Permissio
     }
 }
 
-fn assign_cache_item_selector(
-    item_selector: CacheItemSelector<impl IntoBytes>,
-) -> cache_permissions::CacheItem {
+fn assign_cache_item_selector(item_selector: CacheItemSelector) -> cache_permissions::CacheItem {
     match item_selector {
         CacheItemSelector::AllCacheItems => cache_permissions::CacheItem::AllItems(All {}),
         CacheItemSelector::CacheItemKey(CacheItemKey { key }) => {
@@ -153,7 +151,7 @@ fn assign_cache_item_selector(
 }
 
 fn disposable_token_permission_to_grpc_permission(
-    permission: DisposableTokenCachePermission<impl IntoBytes>,
+    permission: DisposableTokenCachePermission,
 ) -> PermissionsType {
     let grpc_perm = permissions_type::CachePermissions {
         role: assign_cache_role(permission.role).into(),
@@ -172,8 +170,7 @@ mod tests {
 
     #[test]
     fn creates_expected_grpc_permissions_from_all_data_read_write() {
-        let sdk_permissions =
-            DisposableTokenScope::Permissions::<String>(Permissions::all_data_read_write());
+        let sdk_permissions = DisposableTokenScope::Permissions(Permissions::all_data_read_write());
         let converted_permissions = permissions_from_disposable_token_scope(sdk_permissions);
         let expected_permissions = permission_messages::Permissions {
             kind: Some(permission_messages::permissions::Kind::Explicit(
@@ -211,7 +208,7 @@ mod tests {
     #[test]
     fn creates_expected_grpc_permissions_from_mixed_cache_topics_permissions() {
         // Construct sdk permissions object
-        let sdk_permissions = DisposableTokenScope::Permissions::<String>(Permissions {
+        let sdk_permissions = DisposableTokenScope::Permissions(Permissions {
             permissions: vec![
                 // read only for all caches
                 Permission::CachePermission(CachePermission {
@@ -388,7 +385,7 @@ mod tests {
                         role: CacheRole::ReadWrite,
                         cache: CacheSelector::AllCaches,
                         item_selector: CacheItemSelector::CacheItemKey(CacheItemKey {
-                            key: "specific-key".to_string(),
+                            key: "specific-key".into(),
                         }),
                     },
                     DisposableTokenCachePermission {
@@ -397,7 +394,7 @@ mod tests {
                             name: "foo".to_string(),
                         },
                         item_selector: CacheItemSelector::CacheItemKeyPrefix(CacheItemKeyPrefix {
-                            key_prefix: "key-prefix".to_string(),
+                            key_prefix: "key-prefix".into(),
                         }),
                     },
                 ],

--- a/src/auth/permissions/disposable_token_scope.rs
+++ b/src/auth/permissions/disposable_token_scope.rs
@@ -75,6 +75,12 @@ impl From<Permissions> for DisposableTokenScope<String> {
     }
 }
 
+impl From<DisposableTokenCachePermissions<String>> for DisposableTokenScope<String> {
+    fn from(permissions: DisposableTokenCachePermissions<String>) -> Self {
+        DisposableTokenScope::DisposableTokenPermissions(permissions)
+    }
+}
+
 impl From<PermissionScope> for DisposableTokenScope<String> {
     fn from(permission_scope: PermissionScope) -> Self {
         match permission_scope {
@@ -87,29 +93,648 @@ impl From<PermissionScope> for DisposableTokenScope<String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::auth::{DisposableTokenScope, Permissions};
+    use crate::auth::{
+        CacheItemKey, CacheItemKeyPrefix, CacheItemSelector, CachePermission, CacheRole,
+        CacheSelector, DisposableTokenCachePermission, DisposableTokenCachePermissions,
+        DisposableTokenScope, Permission, PermissionScopes, Permissions, TopicPermission,
+        TopicRole, TopicSelector,
+    };
 
     #[test]
     fn should_support_assignment_from_all_data_read_write() {
         let scope: DisposableTokenScope<String> = Permissions::all_data_read_write().into();
-        match scope {
-            DisposableTokenScope::Permissions(perms) => {
-                assert_eq!(2, perms.permissions.len());
-                for p in perms.permissions {
-                    match p {
-                        crate::auth::Permission::CachePermission(cache_perm) => {
-                            assert_eq!(crate::auth::CacheRole::ReadWrite, cache_perm.role);
-                            assert_eq!(crate::auth::CacheSelector::AllCaches, cache_perm.cache);
-                        }
-                        crate::auth::Permission::TopicPermission(topic_perm) => {
-                            assert_eq!(crate::auth::TopicRole::PublishSubscribe, topic_perm.role);
-                            assert_eq!(crate::auth::CacheSelector::AllCaches, topic_perm.cache);
-                            assert_eq!(crate::auth::TopicSelector::AllTopics, topic_perm.topic);
-                        }
-                    }
-                }
-            }
-            _ => panic!("Expected Permissions"),
+        let expected_permissions = vec![
+            Permission::CachePermission(crate::auth::CachePermission {
+                role: crate::auth::CacheRole::ReadWrite,
+                cache: crate::auth::CacheSelector::AllCaches,
+            }),
+            Permission::TopicPermission(TopicPermission {
+                role: TopicRole::PublishSubscribe,
+                cache: crate::auth::CacheSelector::AllCaches,
+                topic: crate::auth::TopicSelector::AllTopics,
+            }),
+        ];
+        assert_eq!(
+            DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions
+            }),
+            scope
+        );
+    }
+
+    mod from_permissions_literals {
+        use super::*;
+
+        #[test]
+        fn cache_selectors_in_cache_permission() {
+            let expected_permissions = vec![Permission::CachePermission(CachePermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                role: CacheRole::ReadWrite,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // Accepts string literal as cache selector
+            let perm_literal = Permissions {
+                permissions: vec![Permission::CachePermission(CachePermission {
+                    cache: "my-cache".into(),
+                    role: CacheRole::ReadWrite,
+                })],
+            };
+            let disp_token_scope: DisposableTokenScope<String> = perm_literal.into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // Accepts CacheName as cache selector
+            let perm_literal = Permissions {
+                permissions: vec![Permission::CachePermission(CachePermission {
+                    cache: CacheSelector::CacheName {
+                        name: "my-cache".into(),
+                    },
+                    role: CacheRole::ReadWrite,
+                })],
+            };
+            let disp_token_scope: DisposableTokenScope<String> = perm_literal.into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // Accepts AllCaches as cache selector
+            let expected_permissions = vec![Permission::CachePermission(CachePermission {
+                cache: CacheSelector::AllCaches,
+                role: CacheRole::ReadWrite,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let perm_literal = Permissions {
+                permissions: vec![Permission::CachePermission(CachePermission {
+                    cache: CacheSelector::AllCaches,
+                    role: CacheRole::ReadWrite,
+                })],
+            };
+            let disp_token_scope: DisposableTokenScope<String> = perm_literal.into();
+            assert_eq!(expected_scope, disp_token_scope);
         }
+
+        #[test]
+        fn item_selectors_in_cache_permission() {
+            // Accepts string literal as cache key selector
+            let expected_permissions = vec![DisposableTokenCachePermission {
+                cache: CacheSelector::AllCaches,
+                role: CacheRole::ReadWrite,
+                item_selector: CacheItemSelector::CacheItemKey(CacheItemKey::<&str> {
+                    key: "my-key",
+                }),
+            }];
+            let expected_scope =
+                DisposableTokenScope::DisposableTokenPermissions(DisposableTokenCachePermissions {
+                    permissions: expected_permissions,
+                });
+            let perm_literal = DisposableTokenCachePermissions {
+                permissions: vec![DisposableTokenCachePermission {
+                    cache: CacheSelector::AllCaches,
+                    role: CacheRole::ReadWrite,
+                    item_selector: CacheItemSelector::CacheItemKey("my-key".into()),
+                }],
+            };
+            let disp_token_scope: DisposableTokenScope<&str> =
+                DisposableTokenScope::DisposableTokenPermissions(perm_literal);
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // Accepts string literal as cache key prefix selector
+            let expected_permissions = vec![DisposableTokenCachePermission {
+                cache: CacheSelector::AllCaches,
+                role: CacheRole::ReadWrite,
+                item_selector: CacheItemSelector::CacheItemKeyPrefix(CacheItemKeyPrefix::<&str> {
+                    key_prefix: "my-key-prefix",
+                }),
+            }];
+            let expected_scope =
+                DisposableTokenScope::DisposableTokenPermissions(DisposableTokenCachePermissions {
+                    permissions: expected_permissions,
+                });
+            let perm_literal = DisposableTokenCachePermissions {
+                permissions: vec![DisposableTokenCachePermission {
+                    cache: CacheSelector::AllCaches,
+                    role: CacheRole::ReadWrite,
+                    item_selector: CacheItemSelector::CacheItemKeyPrefix("my-key-prefix".into()),
+                }],
+            };
+            let disp_token_scope: DisposableTokenScope<&str> =
+                DisposableTokenScope::DisposableTokenPermissions(perm_literal);
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // Accepts CacheItemKey as cache selector
+            let expected_permissions = vec![DisposableTokenCachePermission {
+                cache: CacheSelector::AllCaches,
+                role: CacheRole::ReadWrite,
+                item_selector: CacheItemSelector::CacheItemKey(CacheItemKey::<String> {
+                    key: "my-key".into(),
+                }),
+            }];
+            let expected_scope =
+                DisposableTokenScope::DisposableTokenPermissions(DisposableTokenCachePermissions {
+                    permissions: expected_permissions,
+                });
+            let perm_literal = DisposableTokenCachePermissions {
+                permissions: vec![DisposableTokenCachePermission {
+                    cache: CacheSelector::AllCaches,
+                    role: CacheRole::ReadWrite,
+                    item_selector: CacheItemSelector::CacheItemKey(CacheItemKey {
+                        key: "my-key".into(),
+                    }),
+                }],
+            };
+            let disp_token_scope: DisposableTokenScope<String> = perm_literal.into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // Accepts CacheItemKeyPrefix as cache selector
+            let expected_permissions = vec![DisposableTokenCachePermission {
+                cache: CacheSelector::AllCaches,
+                role: CacheRole::ReadWrite,
+                item_selector: CacheItemSelector::CacheItemKeyPrefix(
+                    CacheItemKeyPrefix::<String> {
+                        key_prefix: "my-key-prefix".into(),
+                    },
+                ),
+            }];
+            let expected_scope =
+                DisposableTokenScope::DisposableTokenPermissions(DisposableTokenCachePermissions {
+                    permissions: expected_permissions,
+                });
+            let perm_literal = DisposableTokenCachePermissions {
+                permissions: vec![DisposableTokenCachePermission {
+                    cache: CacheSelector::AllCaches,
+                    role: CacheRole::ReadWrite,
+                    item_selector: CacheItemSelector::CacheItemKeyPrefix(CacheItemKeyPrefix {
+                        key_prefix: "my-key-prefix".into(),
+                    }),
+                }],
+            };
+            let disp_token_scope: DisposableTokenScope<String> = perm_literal.into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // Accepts AllCacheItems as item selector
+            let expected_permissions = vec![DisposableTokenCachePermission {
+                cache: CacheSelector::AllCaches,
+                role: CacheRole::ReadWrite,
+                item_selector: CacheItemSelector::AllCacheItems,
+            }];
+            let expected_scope =
+                DisposableTokenScope::DisposableTokenPermissions(DisposableTokenCachePermissions {
+                    permissions: expected_permissions,
+                });
+            let perm_literal = DisposableTokenCachePermissions {
+                permissions: vec![DisposableTokenCachePermission {
+                    cache: CacheSelector::AllCaches,
+                    role: CacheRole::ReadWrite,
+                    item_selector: CacheItemSelector::AllCacheItems,
+                }],
+            };
+            let disp_token_scope: DisposableTokenScope<String> = perm_literal.into();
+            assert_eq!(expected_scope, disp_token_scope);
+        }
+
+        #[test]
+        fn cache_selectors_in_topic_permission() {
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                topic: "my-topic".into(),
+                role: TopicRole::PublishSubscribe,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // Accepts string literal as cache selector
+            let perm_literal = Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: "my-cache".into(),
+                    topic: "my-topic".into(),
+                    role: TopicRole::PublishSubscribe,
+                })],
+            };
+            let disp_token_scope: DisposableTokenScope<String> = perm_literal.into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // Accepts CacheName as cache selector
+            let perm_literal = Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::CacheName {
+                        name: "my-cache".into(),
+                    },
+                    topic: "my-topic".into(),
+                    role: TopicRole::PublishSubscribe,
+                })],
+            };
+            let disp_token_scope: DisposableTokenScope<String> = perm_literal.into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // Accepts AllCaches as cache selector
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::AllCaches,
+                topic: "my-topic".into(),
+                role: TopicRole::PublishSubscribe,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let perm_literal = Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::AllCaches,
+                    topic: "my-topic".into(),
+                    role: TopicRole::PublishSubscribe,
+                })],
+            };
+            let disp_token_scope: DisposableTokenScope<String> = perm_literal.into();
+            assert_eq!(expected_scope, disp_token_scope);
+        }
+
+        #[test]
+        fn topics_selectors_in_topic_permission() {
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::AllCaches,
+                topic: TopicSelector::TopicName {
+                    name: "my-topic".into(),
+                },
+                role: TopicRole::PublishSubscribe,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // Accepts string literal as topic selector
+            let perm_literal = Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::AllCaches,
+                    topic: "my-topic".into(),
+                    role: TopicRole::PublishSubscribe,
+                })],
+            };
+            let disp_token_scope: DisposableTokenScope<String> = perm_literal.into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // Accepts TopicName as cache selector
+            let perm_literal = Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::AllCaches,
+                    topic: TopicSelector::TopicName {
+                        name: "my-topic".into(),
+                    },
+                    role: TopicRole::PublishSubscribe,
+                })],
+            };
+            let disp_token_scope: DisposableTokenScope<String> = perm_literal.into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // Accepts AllTopics as topic selector
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::AllCaches,
+                topic: TopicSelector::AllTopics,
+                role: TopicRole::PublishSubscribe,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let perm_literal = Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::AllCaches,
+                    topic: TopicSelector::AllTopics,
+                    role: TopicRole::PublishSubscribe,
+                })],
+            };
+            let disp_token_scope: DisposableTokenScope<String> = perm_literal.into();
+            assert_eq!(expected_scope, disp_token_scope);
+        }
+
+        #[test]
+        fn mixed_cache_and_topic_permissions() {
+            let expected_permissions = vec![
+                Permission::CachePermission(CachePermission {
+                    cache: CacheSelector::CacheName {
+                        name: "my-cache".into(),
+                    },
+                    role: CacheRole::ReadOnly,
+                }),
+                Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::CacheName {
+                        name: "my-cache".into(),
+                    },
+                    topic: TopicSelector::AllTopics,
+                    role: TopicRole::SubscribeOnly,
+                }),
+            ];
+
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            let perm_literal = Permissions {
+                permissions: vec![
+                    Permission::CachePermission(CachePermission {
+                        cache: "my-cache".into(),
+                        role: CacheRole::ReadOnly,
+                    }),
+                    Permission::TopicPermission(TopicPermission {
+                        cache: "my-cache".into(),
+                        topic: TopicSelector::AllTopics,
+                        role: TopicRole::SubscribeOnly,
+                    }),
+                ],
+            };
+            let disp_token_scope: DisposableTokenScope<String> = perm_literal.into();
+            assert_eq!(expected_scope, disp_token_scope);
+        }
+    }
+
+    mod from_permission_scopes_factory_functions {
+        use super::*;
+
+        #[test]
+        fn cache_read_write() {
+            let expected_permissions = vec![Permission::CachePermission(CachePermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                role: CacheRole::ReadWrite,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // String literal cache name
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::cache_read_write("my-cache").into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // CacheName
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::cache_read_write(CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                })
+                .into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // AllCaches
+            let expected_permissions = vec![Permission::CachePermission(CachePermission {
+                cache: CacheSelector::AllCaches,
+                role: CacheRole::ReadWrite,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::cache_read_write(CacheSelector::AllCaches).into();
+            assert_eq!(expected_scope, disp_token_scope);
+        }
+
+        #[test]
+        fn cache_write_only() {
+            let expected_permissions = vec![Permission::CachePermission(CachePermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                role: CacheRole::WriteOnly,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // String literal cache name
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::cache_write_only("my-cache").into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // CacheName
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::cache_write_only(CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                })
+                .into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // AllCaches
+            let expected_permissions = vec![Permission::CachePermission(CachePermission {
+                cache: CacheSelector::AllCaches,
+                role: CacheRole::WriteOnly,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::cache_write_only(CacheSelector::AllCaches).into();
+            assert_eq!(expected_scope, disp_token_scope);
+        }
+
+        #[test]
+        fn cache_read_only() {
+            let expected_permissions = vec![Permission::CachePermission(CachePermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                role: CacheRole::ReadOnly,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // String literal cache name
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::cache_read_only("my-cache").into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // CacheName
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::cache_read_only(CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                })
+                .into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // AllCaches
+            let expected_permissions = vec![Permission::CachePermission(CachePermission {
+                cache: CacheSelector::AllCaches,
+                role: CacheRole::ReadOnly,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::cache_read_only(CacheSelector::AllCaches).into();
+            assert_eq!(expected_scope, disp_token_scope);
+        }
+
+        #[test]
+        fn topic_publish_subscribe() {
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                topic: TopicSelector::TopicName {
+                    name: "my-topic".into(),
+                },
+                role: TopicRole::PublishSubscribe,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // String literal  topic name
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::topic_publish_subscribe("my-cache", "my-topic").into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // TopicName
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::topic_publish_subscribe(
+                    CacheSelector::CacheName {
+                        name: "my-cache".into(),
+                    },
+                    TopicSelector::TopicName {
+                        name: "my-topic".into(),
+                    },
+                )
+                .into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // AllTopics
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                topic: TopicSelector::AllTopics,
+                role: TopicRole::PublishSubscribe,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::topic_publish_subscribe("my-cache", TopicSelector::AllTopics)
+                    .into();
+            assert_eq!(expected_scope, disp_token_scope);
+        }
+
+        #[test]
+        fn topic_publish_only() {
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                topic: TopicSelector::TopicName {
+                    name: "my-topic".into(),
+                },
+                role: TopicRole::PublishOnly,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // String literal topic name
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::topic_publish_only("my-cache", "my-topic").into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // TopicName
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::topic_publish_only(
+                    CacheSelector::CacheName {
+                        name: "my-cache".into(),
+                    },
+                    TopicSelector::TopicName {
+                        name: "my-topic".into(),
+                    },
+                )
+                .into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // AllTopics
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                topic: TopicSelector::AllTopics,
+                role: TopicRole::PublishOnly,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::topic_publish_only("my-cache", TopicSelector::AllTopics).into();
+            assert_eq!(expected_scope, disp_token_scope);
+        }
+
+        #[test]
+        fn topic_subscribe_only() {
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                topic: TopicSelector::TopicName {
+                    name: "my-topic".into(),
+                },
+                role: TopicRole::SubscribeOnly,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // String literal topic name
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::topic_subscribe_only("my-cache", "my-topic").into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // TopicName
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::topic_subscribe_only(
+                    CacheSelector::CacheName {
+                        name: "my-cache".into(),
+                    },
+                    TopicSelector::TopicName {
+                        name: "my-topic".into(),
+                    },
+                )
+                .into();
+            assert_eq!(expected_scope, disp_token_scope);
+
+            // AllTopics
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                topic: TopicSelector::AllTopics,
+                role: TopicRole::SubscribeOnly,
+            })];
+            let expected_scope = DisposableTokenScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let disp_token_scope: DisposableTokenScope<String> =
+                PermissionScopes::topic_subscribe_only("my-cache", TopicSelector::AllTopics).into();
+            assert_eq!(expected_scope, disp_token_scope);
+        }
+    }
+
+    mod from_disposable_token_scopes_factory_functions {
+        // use super::*;
+
+        #[test]
+        fn cache_key_prefix_read_write() {}
+
+        #[test]
+        fn cache_key_prefix_write_only() {}
+
+        #[test]
+        fn cache_key_prefix_read_only() {}
+
+        #[test]
+        fn cache_key_read_write() {}
+
+        #[test]
+        fn cache_key_write_only() {}
+
+        #[test]
+        fn cache_key_read_only() {}
     }
 }

--- a/src/auth/permissions/disposable_token_scope.rs
+++ b/src/auth/permissions/disposable_token_scope.rs
@@ -1,9 +1,10 @@
 use crate::{auth::PermissionScope, IntoBytes};
 
 use super::permission_scope::{CacheRole, CacheSelector, Permissions};
+use derive_more::Display;
 
 /// A key for a specific item in a cache.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Display, Clone, PartialEq)]
 pub struct CacheItemKey<K: IntoBytes> {
     /// The cache item key
     pub key: K,
@@ -17,7 +18,7 @@ impl<K: IntoBytes> From<K> for CacheItemKey<K> {
 }
 
 /// A key prefix for items in a cache.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Display, Clone, PartialEq)]
 pub struct CacheItemKeyPrefix<K: IntoBytes> {
     /// The key prefix
     pub key_prefix: K,
@@ -32,7 +33,7 @@ impl<K: IntoBytes> From<K> for CacheItemKeyPrefix<K> {
 
 /// A component of a [DisposableTokenCachePermission].
 /// Specifies the cache item(s) to which the permission applies.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Display, Clone, PartialEq)]
 pub enum CacheItemSelector<K: IntoBytes> {
     /// Access to all cache items
     AllCacheItems,
@@ -54,14 +55,24 @@ pub struct DisposableTokenCachePermission<K: IntoBytes> {
     pub item_selector: CacheItemSelector<K>,
 }
 
+impl<K: IntoBytes + std::fmt::Display> std::fmt::Display for DisposableTokenCachePermission<K> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "DisposableTokenCachePermission {{ role: {}, cache: {}, item_selector: {} }}",
+            self.role, self.cache, self.item_selector
+        )
+    }
+}
+
 /// A set of permissions to be granted to a new disposable access token.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Display, Clone, PartialEq)]
 pub struct DisposableTokenCachePermissions<K: IntoBytes> {
     pub(crate) permissions: Vec<DisposableTokenCachePermission<K>>,
 }
 
 /// The permission scope for creating a new disposable access token.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Display, Clone, PartialEq)]
 pub enum DisposableTokenScope<K: IntoBytes> {
     /// Set of permissions to be granted to a new token on the level of a cache or topic
     Permissions(Permissions),

--- a/src/auth/permissions/disposable_token_scope.rs
+++ b/src/auth/permissions/disposable_token_scope.rs
@@ -1,8 +1,9 @@
-use crate::IntoBytes;
+use crate::{auth::PermissionScope, IntoBytes};
 
 use super::permission_scope::{CacheRole, CacheSelector, Permissions};
 
 /// A key for a specific item in a cache.
+#[derive(Debug, Clone, PartialEq)]
 pub struct CacheItemKey<K: IntoBytes> {
     /// The cache item key
     pub key: K,
@@ -16,6 +17,7 @@ impl<K: IntoBytes> From<K> for CacheItemKey<K> {
 }
 
 /// A key prefix for items in a cache.
+#[derive(Debug, Clone, PartialEq)]
 pub struct CacheItemKeyPrefix<K: IntoBytes> {
     /// The key prefix
     pub key_prefix: K,
@@ -30,6 +32,7 @@ impl<K: IntoBytes> From<K> for CacheItemKeyPrefix<K> {
 
 /// A component of a [DisposableTokenCachePermission].
 /// Specifies the cache item(s) to which the permission applies.
+#[derive(Debug, Clone, PartialEq)]
 pub enum CacheItemSelector<K: IntoBytes> {
     /// Access to all cache items
     AllCacheItems,
@@ -41,6 +44,7 @@ pub enum CacheItemSelector<K: IntoBytes> {
 
 /// A permission to be granted to a new disposable access token, specifying
 /// access to specific cache items.
+#[derive(Debug, Clone, PartialEq)]
 pub struct DisposableTokenCachePermission<K: IntoBytes> {
     /// The type of access granted by the permission.
     pub role: CacheRole,
@@ -51,14 +55,61 @@ pub struct DisposableTokenCachePermission<K: IntoBytes> {
 }
 
 /// A set of permissions to be granted to a new disposable access token.
+#[derive(Debug, Clone, PartialEq)]
 pub struct DisposableTokenCachePermissions<K: IntoBytes> {
     pub(crate) permissions: Vec<DisposableTokenCachePermission<K>>,
 }
 
 /// The permission scope for creating a new disposable access token.
+#[derive(Debug, Clone, PartialEq)]
 pub enum DisposableTokenScope<K: IntoBytes> {
     /// Set of permissions to be granted to a new token on the level of a cache or topic
     Permissions(Permissions),
     /// Set of permissions to be granted to a new token on the level of a cache item (key or key prefix)
     DisposableTokenPermissions(DisposableTokenCachePermissions<K>),
+}
+
+impl From<Permissions> for DisposableTokenScope<String> {
+    fn from(permissions: Permissions) -> Self {
+        DisposableTokenScope::Permissions(permissions)
+    }
+}
+
+impl From<PermissionScope> for DisposableTokenScope<String> {
+    fn from(permission_scope: PermissionScope) -> Self {
+        match permission_scope {
+            PermissionScope::Permissions(permissions) => {
+                DisposableTokenScope::Permissions(permissions)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::auth::{DisposableTokenScope, Permissions};
+
+    #[test]
+    fn should_support_assignment_from_all_data_read_write() {
+        let scope: DisposableTokenScope<String> = Permissions::all_data_read_write().into();
+        match scope {
+            DisposableTokenScope::Permissions(perms) => {
+                assert_eq!(2, perms.permissions.len());
+                for p in perms.permissions {
+                    match p {
+                        crate::auth::Permission::CachePermission(cache_perm) => {
+                            assert_eq!(crate::auth::CacheRole::ReadWrite, cache_perm.role);
+                            assert_eq!(crate::auth::CacheSelector::AllCaches, cache_perm.cache);
+                        }
+                        crate::auth::Permission::TopicPermission(topic_perm) => {
+                            assert_eq!(crate::auth::TopicRole::PublishSubscribe, topic_perm.role);
+                            assert_eq!(crate::auth::CacheSelector::AllCaches, topic_perm.cache);
+                            assert_eq!(crate::auth::TopicSelector::AllTopics, topic_perm.topic);
+                        }
+                    }
+                }
+            }
+            _ => panic!("Expected Permissions"),
+        }
+    }
 }

--- a/src/auth/permissions/disposable_token_scopes.rs
+++ b/src/auth/permissions/disposable_token_scopes.rs
@@ -2,8 +2,8 @@ use crate::IntoBytes;
 
 use super::{
     disposable_token_scope::{
-        CacheItemKey, CacheItemKeyPrefix, CacheItemSelector, DisposableTokenCachePermission,
-        DisposableTokenCachePermissions, DisposableTokenScope,
+        CacheItemSelector, DisposableTokenCachePermission, DisposableTokenCachePermissions,
+        DisposableTokenScope,
     },
     permission_scope::{CacheRole, CacheSelector},
 };
@@ -16,12 +16,12 @@ impl DisposableTokenScopes {
     pub fn cache_key_read_write(
         cache_selector: impl Into<CacheSelector>,
         key: impl IntoBytes,
-    ) -> DisposableTokenScope<impl IntoBytes> {
+    ) -> DisposableTokenScope {
         DisposableTokenScope::DisposableTokenPermissions(DisposableTokenCachePermissions {
             permissions: vec![DisposableTokenCachePermission {
                 role: CacheRole::ReadWrite,
                 cache: cache_selector.into(),
-                item_selector: CacheItemSelector::CacheItemKey(CacheItemKey { key }),
+                item_selector: CacheItemSelector::CacheItemKey(key.into()),
             }],
         })
     }
@@ -30,14 +30,12 @@ impl DisposableTokenScopes {
     pub fn cache_key_prefix_read_write(
         cache_selector: impl Into<CacheSelector>,
         key_prefix: impl IntoBytes,
-    ) -> DisposableTokenScope<impl IntoBytes> {
+    ) -> DisposableTokenScope {
         DisposableTokenScope::DisposableTokenPermissions(DisposableTokenCachePermissions {
             permissions: vec![DisposableTokenCachePermission {
                 role: CacheRole::ReadWrite,
                 cache: cache_selector.into(),
-                item_selector: CacheItemSelector::CacheItemKeyPrefix(CacheItemKeyPrefix {
-                    key_prefix,
-                }),
+                item_selector: CacheItemSelector::CacheItemKeyPrefix(key_prefix.into()),
             }],
         })
     }
@@ -46,12 +44,12 @@ impl DisposableTokenScopes {
     pub fn cache_key_read_only(
         cache_selector: impl Into<CacheSelector>,
         key: impl IntoBytes,
-    ) -> DisposableTokenScope<impl IntoBytes> {
+    ) -> DisposableTokenScope {
         DisposableTokenScope::DisposableTokenPermissions(DisposableTokenCachePermissions {
             permissions: vec![DisposableTokenCachePermission {
                 role: CacheRole::ReadOnly,
                 cache: cache_selector.into(),
-                item_selector: CacheItemSelector::CacheItemKey(CacheItemKey { key }),
+                item_selector: CacheItemSelector::CacheItemKey(key.into()),
             }],
         })
     }
@@ -60,14 +58,12 @@ impl DisposableTokenScopes {
     pub fn cache_key_prefix_read_only(
         cache_selector: impl Into<CacheSelector>,
         key_prefix: impl IntoBytes,
-    ) -> DisposableTokenScope<impl IntoBytes> {
+    ) -> DisposableTokenScope {
         DisposableTokenScope::DisposableTokenPermissions(DisposableTokenCachePermissions {
             permissions: vec![DisposableTokenCachePermission {
                 role: CacheRole::ReadOnly,
                 cache: cache_selector.into(),
-                item_selector: CacheItemSelector::CacheItemKeyPrefix(CacheItemKeyPrefix {
-                    key_prefix,
-                }),
+                item_selector: CacheItemSelector::CacheItemKeyPrefix(key_prefix.into()),
             }],
         })
     }
@@ -76,12 +72,12 @@ impl DisposableTokenScopes {
     pub fn cache_key_write_only(
         cache_selector: impl Into<CacheSelector>,
         key: impl IntoBytes,
-    ) -> DisposableTokenScope<impl IntoBytes> {
+    ) -> DisposableTokenScope {
         DisposableTokenScope::DisposableTokenPermissions(DisposableTokenCachePermissions {
             permissions: vec![DisposableTokenCachePermission {
                 role: CacheRole::WriteOnly,
                 cache: cache_selector.into(),
-                item_selector: CacheItemSelector::CacheItemKey(CacheItemKey { key }),
+                item_selector: CacheItemSelector::CacheItemKey(key.into()),
             }],
         })
     }
@@ -90,14 +86,12 @@ impl DisposableTokenScopes {
     pub fn cache_key_prefix_write_only(
         cache_selector: impl Into<CacheSelector>,
         key_prefix: impl IntoBytes,
-    ) -> DisposableTokenScope<impl IntoBytes> {
+    ) -> DisposableTokenScope {
         DisposableTokenScope::DisposableTokenPermissions(DisposableTokenCachePermissions {
             permissions: vec![DisposableTokenCachePermission {
                 role: CacheRole::WriteOnly,
                 cache: cache_selector.into(),
-                item_selector: CacheItemSelector::CacheItemKeyPrefix(CacheItemKeyPrefix {
-                    key_prefix,
-                }),
+                item_selector: CacheItemSelector::CacheItemKeyPrefix(key_prefix.into()),
             }],
         })
     }

--- a/src/auth/permissions/permission_scope.rs
+++ b/src/auth/permissions/permission_scope.rs
@@ -1,5 +1,6 @@
 /// A component of a [CachePermission].
 /// Type of access granted by the permission.
+#[derive(Debug, Clone, PartialEq)]
 pub enum CacheRole {
     /// Allows read-write access to a cache
     ReadWrite,
@@ -11,6 +12,7 @@ pub enum CacheRole {
 
 /// A component of a [CachePermission].
 /// A permission can be restricted to a specific cache or to all caches.
+#[derive(Debug, Clone, PartialEq)]
 pub enum CacheSelector {
     /// Apply permission to all caches
     AllCaches,
@@ -38,6 +40,7 @@ impl From<&str> for CacheSelector {
 }
 
 /// Defines access permissions for a cache.
+#[derive(Debug, Clone, PartialEq)]
 pub struct CachePermission {
     /// The type of access granted by the permission.
     pub role: CacheRole,
@@ -47,6 +50,7 @@ pub struct CachePermission {
 
 /// A component of a [TopicPermission].
 /// Type of access granted by the permission.
+#[derive(Debug, Clone, PartialEq)]
 pub enum TopicRole {
     /// Allows both publishing and subscribing to a topic
     PublishSubscribe,
@@ -58,6 +62,7 @@ pub enum TopicRole {
 
 /// A component of a [TopicPermission].
 /// A permission can be restricted to a specific topic or to all topics in a cache.
+#[derive(Debug, Clone, PartialEq)]
 pub enum TopicSelector {
     /// Apply permission to all topics
     AllTopics,
@@ -85,6 +90,7 @@ impl From<&str> for TopicSelector {
 }
 
 /// Defines access permissions for a topic in a cache.
+#[derive(Debug, Clone, PartialEq)]
 pub struct TopicPermission {
     /// The type of access granted by the permission.
     pub role: TopicRole,
@@ -95,6 +101,7 @@ pub struct TopicPermission {
 }
 
 /// A component of a [PermissionScope].
+#[derive(Debug, Clone, PartialEq)]
 pub enum Permission {
     /// Defines the permissions for a cache.
     CachePermission(CachePermission),
@@ -103,6 +110,7 @@ pub enum Permission {
 }
 
 /// Permissions object contains the set of permissions to be granted to a new API key.
+#[derive(Debug, Clone, PartialEq)]
 pub struct Permissions {
     /// The set of permissions to be granted to a new API key.
     pub permissions: Vec<Permission>,
@@ -131,6 +139,4 @@ impl Permissions {
 pub enum PermissionScope {
     /// Set of permissions to be granted to a new API key
     Permissions(Permissions),
-    /// PredefinedScope for internal use
-    PredefinedScope,
 }

--- a/src/auth/permissions/permission_scope.rs
+++ b/src/auth/permissions/permission_scope.rs
@@ -1,6 +1,8 @@
+use derive_more::Display;
+
 /// A component of a [CachePermission].
 /// Type of access granted by the permission.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Display, Clone, PartialEq)]
 pub enum CacheRole {
     /// Allows read-write access to a cache
     ReadWrite,
@@ -12,7 +14,7 @@ pub enum CacheRole {
 
 /// A component of a [CachePermission].
 /// A permission can be restricted to a specific cache or to all caches.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Display, Clone, PartialEq)]
 pub enum CacheSelector {
     /// Apply permission to all caches
     AllCaches,
@@ -48,9 +50,19 @@ pub struct CachePermission {
     pub cache: CacheSelector,
 }
 
+impl std::fmt::Display for CachePermission {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "CachePermission {{ role: {}, cache: {} }}",
+            self.role, self.cache
+        )
+    }
+}
+
 /// A component of a [TopicPermission].
 /// Type of access granted by the permission.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Display, Clone, PartialEq)]
 pub enum TopicRole {
     /// Allows both publishing and subscribing to a topic
     PublishSubscribe,
@@ -62,7 +74,7 @@ pub enum TopicRole {
 
 /// A component of a [TopicPermission].
 /// A permission can be restricted to a specific topic or to all topics in a cache.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Display, Clone, PartialEq)]
 pub enum TopicSelector {
     /// Apply permission to all topics
     AllTopics,
@@ -100,8 +112,18 @@ pub struct TopicPermission {
     pub topic: TopicSelector,
 }
 
+impl std::fmt::Display for TopicPermission {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "TopicPermission {{ role: {}, cache: {}, topic: {} }}",
+            self.role, self.cache, self.topic
+        )
+    }
+}
+
 /// A component of a [PermissionScope].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Display, Clone, PartialEq)]
 pub enum Permission {
     /// Defines the permissions for a cache.
     CachePermission(CachePermission),
@@ -114,6 +136,12 @@ pub enum Permission {
 pub struct Permissions {
     /// The set of permissions to be granted to a new API key.
     pub permissions: Vec<Permission>,
+}
+
+impl std::fmt::Display for Permissions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Permissions {{ permissions: {:?} }}", self.permissions)
+    }
 }
 
 impl Permissions {
@@ -136,7 +164,7 @@ impl Permissions {
 }
 
 /// The permission scope for creating a new API key.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Display, Clone, PartialEq)]
 pub enum PermissionScope {
     /// Set of permissions to be granted to a new API key
     Permissions(Permissions),

--- a/src/auth/permissions/permission_scope.rs
+++ b/src/auth/permissions/permission_scope.rs
@@ -136,7 +136,506 @@ impl Permissions {
 }
 
 /// The permission scope for creating a new API key.
+#[derive(Debug, Clone, PartialEq)]
 pub enum PermissionScope {
     /// Set of permissions to be granted to a new API key
     Permissions(Permissions),
+}
+
+impl From<Permissions> for PermissionScope {
+    fn from(permissions: Permissions) -> Self {
+        PermissionScope::Permissions(permissions)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::auth::{
+        CachePermission, CacheRole, CacheSelector, Permission, PermissionScope, PermissionScopes,
+        Permissions, TopicPermission, TopicRole, TopicSelector,
+    };
+
+    #[test]
+    fn should_support_assignment_from_all_data_read_write() {
+        let scope: PermissionScope = Permissions::all_data_read_write().into();
+        let expected_permissions = vec![
+            Permission::CachePermission(crate::auth::CachePermission {
+                role: crate::auth::CacheRole::ReadWrite,
+                cache: crate::auth::CacheSelector::AllCaches,
+            }),
+            Permission::TopicPermission(TopicPermission {
+                role: TopicRole::PublishSubscribe,
+                cache: crate::auth::CacheSelector::AllCaches,
+                topic: crate::auth::TopicSelector::AllTopics,
+            }),
+        ];
+        assert_eq!(
+            PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions
+            }),
+            scope
+        );
+    }
+
+    mod from_permissions_literals {
+        use super::*;
+
+        #[test]
+        fn cache_selectors_in_cache_permission() {
+            let expected_permissions = vec![Permission::CachePermission(CachePermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                role: CacheRole::ReadWrite,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // Accepts string literal as cache selector
+            let perm_literal = Permissions {
+                permissions: vec![Permission::CachePermission(CachePermission {
+                    cache: "my-cache".into(),
+                    role: CacheRole::ReadWrite,
+                })],
+            };
+            let perm_scope: PermissionScope = perm_literal.into();
+            assert_eq!(expected_scope, perm_scope);
+
+            // Accepts CacheName as cache selector
+            let perm_literal = Permissions {
+                permissions: vec![Permission::CachePermission(CachePermission {
+                    cache: CacheSelector::CacheName {
+                        name: "my-cache".into(),
+                    },
+                    role: CacheRole::ReadWrite,
+                })],
+            };
+            let perm_scope: PermissionScope = perm_literal.into();
+            assert_eq!(expected_scope, perm_scope);
+
+            // Accepts AllCaches as cache selector
+            let expected_permissions = vec![Permission::CachePermission(CachePermission {
+                cache: CacheSelector::AllCaches,
+                role: CacheRole::ReadWrite,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let perm_literal = Permissions {
+                permissions: vec![Permission::CachePermission(CachePermission {
+                    cache: CacheSelector::AllCaches,
+                    role: CacheRole::ReadWrite,
+                })],
+            };
+            let perm_scope: PermissionScope = perm_literal.into();
+            assert_eq!(expected_scope, perm_scope);
+        }
+
+        #[test]
+        fn cache_selectors_in_topic_permission() {
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                topic: "my-topic".into(),
+                role: TopicRole::PublishSubscribe,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // Accepts string literal as cache selector
+            let perm_literal = Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: "my-cache".into(),
+                    topic: "my-topic".into(),
+                    role: TopicRole::PublishSubscribe,
+                })],
+            };
+            let perm_scope: PermissionScope = perm_literal.into();
+            assert_eq!(expected_scope, perm_scope);
+
+            // Accepts CacheName as cache selector
+            let perm_literal = Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::CacheName {
+                        name: "my-cache".into(),
+                    },
+                    topic: "my-topic".into(),
+                    role: TopicRole::PublishSubscribe,
+                })],
+            };
+            let perm_scope: PermissionScope = perm_literal.into();
+            assert_eq!(expected_scope, perm_scope);
+
+            // Accepts AllCaches as cache selector
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::AllCaches,
+                topic: "my-topic".into(),
+                role: TopicRole::PublishSubscribe,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let perm_literal = Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::AllCaches,
+                    topic: "my-topic".into(),
+                    role: TopicRole::PublishSubscribe,
+                })],
+            };
+            let perm_scope: PermissionScope = perm_literal.into();
+            assert_eq!(expected_scope, perm_scope);
+        }
+
+        #[test]
+        fn topics_selectors_in_topic_permission() {
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::AllCaches,
+                topic: TopicSelector::TopicName {
+                    name: "my-topic".into(),
+                },
+                role: TopicRole::PublishSubscribe,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // Accepts string literal as topic selector
+            let perm_literal = Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::AllCaches,
+                    topic: "my-topic".into(),
+                    role: TopicRole::PublishSubscribe,
+                })],
+            };
+            let perm_scope: PermissionScope = perm_literal.into();
+            assert_eq!(expected_scope, perm_scope);
+
+            // Accepts TopicName as cache selector
+            let perm_literal = Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::AllCaches,
+                    topic: TopicSelector::TopicName {
+                        name: "my-topic".into(),
+                    },
+                    role: TopicRole::PublishSubscribe,
+                })],
+            };
+            let perm_scope: PermissionScope = perm_literal.into();
+            assert_eq!(expected_scope, perm_scope);
+
+            // Accepts AllTopics as topic selector
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::AllCaches,
+                topic: TopicSelector::AllTopics,
+                role: TopicRole::PublishSubscribe,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let perm_literal = Permissions {
+                permissions: vec![Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::AllCaches,
+                    topic: TopicSelector::AllTopics,
+                    role: TopicRole::PublishSubscribe,
+                })],
+            };
+            let perm_scope: PermissionScope = perm_literal.into();
+            assert_eq!(expected_scope, perm_scope);
+        }
+
+        #[test]
+        fn mixed_cache_and_topic_permissions() {
+            let expected_permissions = vec![
+                Permission::CachePermission(CachePermission {
+                    cache: CacheSelector::CacheName {
+                        name: "my-cache".into(),
+                    },
+                    role: CacheRole::ReadOnly,
+                }),
+                Permission::TopicPermission(TopicPermission {
+                    cache: CacheSelector::CacheName {
+                        name: "my-cache".into(),
+                    },
+                    topic: TopicSelector::AllTopics,
+                    role: TopicRole::SubscribeOnly,
+                }),
+            ];
+
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            let perm_literal = Permissions {
+                permissions: vec![
+                    Permission::CachePermission(CachePermission {
+                        cache: "my-cache".into(),
+                        role: CacheRole::ReadOnly,
+                    }),
+                    Permission::TopicPermission(TopicPermission {
+                        cache: "my-cache".into(),
+                        topic: TopicSelector::AllTopics,
+                        role: TopicRole::SubscribeOnly,
+                    }),
+                ],
+            };
+            let perm_scope: PermissionScope = perm_literal.into();
+            assert_eq!(expected_scope, perm_scope);
+        }
+    }
+
+    mod from_permission_scopes_factory_functions {
+        use super::*;
+
+        #[test]
+        fn cache_read_write() {
+            let expected_permissions = vec![Permission::CachePermission(CachePermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                role: CacheRole::ReadWrite,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // String literal cache name
+            let perm_scope: PermissionScope = PermissionScopes::cache_read_write("my-cache");
+            assert_eq!(expected_scope, perm_scope);
+
+            // CacheName
+            let perm_scope: PermissionScope =
+                PermissionScopes::cache_read_write(CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                });
+            assert_eq!(expected_scope, perm_scope);
+
+            // AllCaches
+            let expected_permissions = vec![Permission::CachePermission(CachePermission {
+                cache: CacheSelector::AllCaches,
+                role: CacheRole::ReadWrite,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let perm_scope: PermissionScope =
+                PermissionScopes::cache_read_write(CacheSelector::AllCaches);
+            assert_eq!(expected_scope, perm_scope);
+        }
+
+        #[test]
+        fn cache_write_only() {
+            let expected_permissions = vec![Permission::CachePermission(CachePermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                role: CacheRole::WriteOnly,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // String literal cache name
+            let perm_scope: PermissionScope = PermissionScopes::cache_write_only("my-cache");
+            assert_eq!(expected_scope, perm_scope);
+
+            // CacheName
+            let perm_scope: PermissionScope =
+                PermissionScopes::cache_write_only(CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                });
+            assert_eq!(expected_scope, perm_scope);
+
+            // AllCaches
+            let expected_permissions = vec![Permission::CachePermission(CachePermission {
+                cache: CacheSelector::AllCaches,
+                role: CacheRole::WriteOnly,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let perm_scope: PermissionScope =
+                PermissionScopes::cache_write_only(CacheSelector::AllCaches);
+            assert_eq!(expected_scope, perm_scope);
+        }
+
+        #[test]
+        fn cache_read_only() {
+            let expected_permissions = vec![Permission::CachePermission(CachePermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                role: CacheRole::ReadOnly,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // String literal cache name
+            let perm_scope: PermissionScope = PermissionScopes::cache_read_only("my-cache");
+            assert_eq!(expected_scope, perm_scope);
+
+            // CacheName
+            let perm_scope: PermissionScope =
+                PermissionScopes::cache_read_only(CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                });
+            assert_eq!(expected_scope, perm_scope);
+
+            // AllCaches
+            let expected_permissions = vec![Permission::CachePermission(CachePermission {
+                cache: CacheSelector::AllCaches,
+                role: CacheRole::ReadOnly,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let perm_scope: PermissionScope =
+                PermissionScopes::cache_read_only(CacheSelector::AllCaches);
+            assert_eq!(expected_scope, perm_scope);
+        }
+
+        #[test]
+        fn topic_publish_subscribe() {
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                topic: TopicSelector::TopicName {
+                    name: "my-topic".into(),
+                },
+                role: TopicRole::PublishSubscribe,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // String literal  topic name
+            let perm_scope: PermissionScope =
+                PermissionScopes::topic_publish_subscribe("my-cache", "my-topic");
+            assert_eq!(expected_scope, perm_scope);
+
+            // TopicName
+            let perm_scope: PermissionScope = PermissionScopes::topic_publish_subscribe(
+                CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                TopicSelector::TopicName {
+                    name: "my-topic".into(),
+                },
+            );
+            assert_eq!(expected_scope, perm_scope);
+
+            // AllTopics
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                topic: TopicSelector::AllTopics,
+                role: TopicRole::PublishSubscribe,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let perm_scope: PermissionScope =
+                PermissionScopes::topic_publish_subscribe("my-cache", TopicSelector::AllTopics);
+            assert_eq!(expected_scope, perm_scope);
+        }
+
+        #[test]
+        fn topic_publish_only() {
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                topic: TopicSelector::TopicName {
+                    name: "my-topic".into(),
+                },
+                role: TopicRole::PublishOnly,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // String literal topic name
+            let perm_scope: PermissionScope =
+                PermissionScopes::topic_publish_only("my-cache", "my-topic");
+            assert_eq!(expected_scope, perm_scope);
+
+            // TopicName
+            let perm_scope: PermissionScope = PermissionScopes::topic_publish_only(
+                CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                TopicSelector::TopicName {
+                    name: "my-topic".into(),
+                },
+            );
+            assert_eq!(expected_scope, perm_scope);
+
+            // AllTopics
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                topic: TopicSelector::AllTopics,
+                role: TopicRole::PublishOnly,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let perm_scope: PermissionScope =
+                PermissionScopes::topic_publish_only("my-cache", TopicSelector::AllTopics);
+            assert_eq!(expected_scope, perm_scope);
+        }
+
+        #[test]
+        fn topic_subscribe_only() {
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                topic: TopicSelector::TopicName {
+                    name: "my-topic".into(),
+                },
+                role: TopicRole::SubscribeOnly,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+
+            // String literal topic name
+            let perm_scope: PermissionScope =
+                PermissionScopes::topic_subscribe_only("my-cache", "my-topic");
+            assert_eq!(expected_scope, perm_scope);
+
+            // TopicName
+            let perm_scope: PermissionScope = PermissionScopes::topic_subscribe_only(
+                CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                TopicSelector::TopicName {
+                    name: "my-topic".into(),
+                },
+            );
+            assert_eq!(expected_scope, perm_scope);
+
+            // AllTopics
+            let expected_permissions = vec![Permission::TopicPermission(TopicPermission {
+                cache: CacheSelector::CacheName {
+                    name: "my-cache".into(),
+                },
+                topic: TopicSelector::AllTopics,
+                role: TopicRole::SubscribeOnly,
+            })];
+            let expected_scope = PermissionScope::Permissions(Permissions {
+                permissions: expected_permissions,
+            });
+            let perm_scope: PermissionScope =
+                PermissionScopes::topic_subscribe_only("my-cache", TopicSelector::AllTopics);
+            assert_eq!(expected_scope, perm_scope);
+        }
+    }
 }

--- a/tests/auth/disposable_tokens.rs
+++ b/tests/auth/disposable_tokens.rs
@@ -7,7 +7,7 @@ use momento::{
     auth::{
         DisposableTokenScope, DisposableTokenScopes, ExpiresIn, GenerateDisposableTokenResponse,
     },
-    CacheClient, CredentialProvider, IntoBytes, MomentoResult, TopicClient,
+    CacheClient, CredentialProvider, MomentoResult, TopicClient,
 };
 use momento::{MomentoError, MomentoErrorCode};
 use momento_test_util::{unique_key, TestScalar, CACHE_TEST_STATE};
@@ -15,7 +15,7 @@ use momento_test_util::{unique_key, TestScalar, CACHE_TEST_STATE};
 // Helper function that generates a disposable token with the given scope
 // that expires in 5 minutes.
 async fn generate_disposable_token_success(
-    scope: DisposableTokenScope<impl IntoBytes>,
+    scope: DisposableTokenScope,
 ) -> MomentoResult<GenerateDisposableTokenResponse> {
     let expiry = ExpiresIn::minutes(5);
     let response = CACHE_TEST_STATE

--- a/tests/auth/disposable_tokens.rs
+++ b/tests/auth/disposable_tokens.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use momento::auth::CacheSelector;
 use momento::auth::Expiration;
-use momento::auth::{CachePermission, CacheRole, Permission, Permissions};
+use momento::auth::Permissions;
 use momento::{
     auth::{
         DisposableTokenScope, DisposableTokenScopes, ExpiresIn, GenerateDisposableTokenResponse,
@@ -792,21 +792,16 @@ mod disposable_tokens_cache_key_prefix {
 }
 
 mod disposable_tokens_cache {
+    use momento::auth::PermissionScopes;
+
     use super::*;
 
     #[tokio::test]
     async fn test_cache_read_write_specific_cache() -> MomentoResult<()> {
         let first_cache = &CACHE_TEST_STATE.cache_name;
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::CachePermission(CachePermission {
-                    cache: (*first_cache).clone().into(),
-                    role: CacheRole::ReadWrite,
-                })],
-            }),
-        )
-        .await?;
+        let scope = PermissionScopes::cache_read_write(first_cache.clone()).into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let cc = new_cache_client(creds.clone());
         let tc = new_topic_client(creds);
@@ -832,15 +827,8 @@ mod disposable_tokens_cache {
     async fn test_cache_read_write_all_caches() -> MomentoResult<()> {
         let first_cache = &CACHE_TEST_STATE.cache_name;
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::CachePermission(CachePermission {
-                    cache: CacheSelector::AllCaches,
-                    role: CacheRole::ReadWrite,
-                })],
-            }),
-        )
-        .await?;
+        let scope = PermissionScopes::cache_read_write(CacheSelector::AllCaches).into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let cc = new_cache_client(creds.clone());
         let tc = new_topic_client(creds);
@@ -866,15 +854,8 @@ mod disposable_tokens_cache {
     async fn test_cache_read_only_specific_cache() -> MomentoResult<()> {
         let first_cache = &CACHE_TEST_STATE.cache_name;
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::CachePermission(CachePermission {
-                    cache: (*first_cache).clone().into(),
-                    role: CacheRole::ReadOnly,
-                })],
-            }),
-        )
-        .await?;
+        let scope = PermissionScopes::cache_read_only(first_cache.clone()).into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let cc = new_cache_client(creds.clone());
         let tc = new_topic_client(creds);
@@ -902,15 +883,8 @@ mod disposable_tokens_cache {
     async fn test_cache_read_only_all_caches() -> MomentoResult<()> {
         let first_cache = &CACHE_TEST_STATE.cache_name;
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::CachePermission(CachePermission {
-                    cache: CacheSelector::AllCaches,
-                    role: CacheRole::ReadOnly,
-                })],
-            }),
-        )
-        .await?;
+        let scope = PermissionScopes::cache_read_only(CacheSelector::AllCaches).into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let cc = new_cache_client(creds.clone());
         let tc = new_topic_client(creds);
@@ -938,15 +912,8 @@ mod disposable_tokens_cache {
     async fn test_cache_write_only_specific_cache() -> MomentoResult<()> {
         let first_cache = &CACHE_TEST_STATE.cache_name;
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::CachePermission(CachePermission {
-                    cache: (*first_cache).clone().into(),
-                    role: CacheRole::WriteOnly,
-                })],
-            }),
-        )
-        .await?;
+        let scope = PermissionScopes::cache_write_only(first_cache.clone()).into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let cc = new_cache_client(creds.clone());
         let tc = new_topic_client(creds);
@@ -974,15 +941,8 @@ mod disposable_tokens_cache {
     async fn test_cache_write_only_all_caches() -> MomentoResult<()> {
         let first_cache = &CACHE_TEST_STATE.cache_name;
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::CachePermission(CachePermission {
-                    cache: CacheSelector::AllCaches,
-                    role: CacheRole::WriteOnly,
-                })],
-            }),
-        )
-        .await?;
+        let scope = PermissionScopes::cache_write_only(CacheSelector::AllCaches).into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let cc = new_cache_client(creds.clone());
         let tc = new_topic_client(creds);
@@ -1008,7 +968,7 @@ mod disposable_tokens_cache {
 }
 
 mod disposable_tokens_topics {
-    use momento::auth::{TopicPermission, TopicRole, TopicSelector};
+    use momento::auth::{PermissionScopes, TopicSelector};
 
     use super::*;
 
@@ -1018,16 +978,10 @@ mod disposable_tokens_topics {
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
         let first_topic = TestScalar::new();
         let second_topic = TestScalar::new();
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: (*first_cache).clone().into(),
-                    topic: first_topic.key().into(),
-                    role: TopicRole::PublishSubscribe,
-                })],
-            }),
-        )
-        .await?;
+        let scope =
+            PermissionScopes::topic_publish_subscribe(first_cache.clone(), first_topic.key())
+                .into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let tc = new_topic_client(creds.clone());
         let cc = new_cache_client(creds.clone());
@@ -1056,16 +1010,10 @@ mod disposable_tokens_topics {
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
         let first_topic = TestScalar::new();
         let second_topic = TestScalar::new();
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: CacheSelector::AllCaches,
-                    topic: first_topic.key().into(),
-                    role: TopicRole::PublishSubscribe,
-                })],
-            }),
-        )
-        .await?;
+        let scope =
+            PermissionScopes::topic_publish_subscribe(CacheSelector::AllCaches, first_topic.key())
+                .into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let tc = new_topic_client(creds.clone());
         let cc = new_cache_client(creds.clone());
@@ -1094,16 +1042,12 @@ mod disposable_tokens_topics {
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
         let first_topic = TestScalar::new();
         let second_topic = TestScalar::new();
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: (*first_cache).clone().into(),
-                    topic: TopicSelector::AllTopics,
-                    role: TopicRole::PublishSubscribe,
-                })],
-            }),
+        let scope = PermissionScopes::topic_publish_subscribe(
+            first_cache.clone(),
+            TopicSelector::AllTopics,
         )
-        .await?;
+        .into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let tc = new_topic_client(creds.clone());
         let cc = new_cache_client(creds.clone());
@@ -1134,16 +1078,12 @@ mod disposable_tokens_topics {
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
         let first_topic = TestScalar::new();
         let second_topic = TestScalar::new();
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: CacheSelector::AllCaches,
-                    topic: TopicSelector::AllTopics,
-                    role: TopicRole::PublishSubscribe,
-                })],
-            }),
+        let scope = PermissionScopes::topic_publish_subscribe(
+            CacheSelector::AllCaches,
+            TopicSelector::AllTopics,
         )
-        .await?;
+        .into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let tc = new_topic_client(creds.clone());
         let cc = new_cache_client(creds.clone());
@@ -1174,16 +1114,9 @@ mod disposable_tokens_topics {
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
         let first_topic = TestScalar::new();
         let second_topic = TestScalar::new();
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: (*first_cache).clone().into(),
-                    topic: first_topic.key().into(),
-                    role: TopicRole::SubscribeOnly,
-                })],
-            }),
-        )
-        .await?;
+        let scope =
+            PermissionScopes::topic_subscribe_only(first_cache.clone(), first_topic.key()).into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let tc = new_topic_client(creds.clone());
         let cc = new_cache_client(creds.clone());
@@ -1215,16 +1148,10 @@ mod disposable_tokens_topics {
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
         let first_topic = TestScalar::new();
         let second_topic = TestScalar::new();
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: CacheSelector::AllCaches,
-                    topic: first_topic.key().into(),
-                    role: TopicRole::SubscribeOnly,
-                })],
-            }),
-        )
-        .await?;
+        let scope =
+            PermissionScopes::topic_subscribe_only(CacheSelector::AllCaches, first_topic.key())
+                .into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let tc = new_topic_client(creds.clone());
         let cc = new_cache_client(creds.clone());
@@ -1257,16 +1184,10 @@ mod disposable_tokens_topics {
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
         let first_topic = TestScalar::new();
         let second_topic = TestScalar::new();
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: (*first_cache).clone().into(),
-                    topic: TopicSelector::AllTopics,
-                    role: TopicRole::SubscribeOnly,
-                })],
-            }),
-        )
-        .await?;
+        let scope =
+            PermissionScopes::topic_subscribe_only(first_cache.clone(), TopicSelector::AllTopics)
+                .into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let tc = new_topic_client(creds.clone());
         let cc = new_cache_client(creds.clone());
@@ -1299,16 +1220,12 @@ mod disposable_tokens_topics {
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
         let first_topic = TestScalar::new();
         let second_topic = TestScalar::new();
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: CacheSelector::AllCaches,
-                    topic: TopicSelector::AllTopics,
-                    role: TopicRole::SubscribeOnly,
-                })],
-            }),
+        let scope = PermissionScopes::topic_subscribe_only(
+            CacheSelector::AllCaches,
+            TopicSelector::AllTopics,
         )
-        .await?;
+        .into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let tc = new_topic_client(creds.clone());
         let cc = new_cache_client(creds.clone());
@@ -1341,16 +1258,9 @@ mod disposable_tokens_topics {
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
         let first_topic = TestScalar::new();
         let second_topic = TestScalar::new();
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: (*first_cache).clone().into(),
-                    topic: first_topic.key().into(),
-                    role: TopicRole::PublishOnly,
-                })],
-            }),
-        )
-        .await?;
+        let scope =
+            PermissionScopes::topic_publish_only(first_cache.clone(), first_topic.key()).into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let tc = new_topic_client(creds.clone());
         let cc = new_cache_client(creds.clone());
@@ -1383,16 +1293,10 @@ mod disposable_tokens_topics {
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
         let first_topic = TestScalar::new();
         let second_topic = TestScalar::new();
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: CacheSelector::AllCaches,
-                    topic: first_topic.key().into(),
-                    role: TopicRole::PublishOnly,
-                })],
-            }),
-        )
-        .await?;
+        let scope =
+            PermissionScopes::topic_publish_only(CacheSelector::AllCaches, first_topic.key())
+                .into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let tc = new_topic_client(creds.clone());
         let cc = new_cache_client(creds.clone());
@@ -1425,16 +1329,10 @@ mod disposable_tokens_topics {
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
         let first_topic = TestScalar::new();
         let second_topic = TestScalar::new();
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: (*first_cache).clone().into(),
-                    topic: TopicSelector::AllTopics,
-                    role: TopicRole::PublishOnly,
-                })],
-            }),
-        )
-        .await?;
+        let scope =
+            PermissionScopes::topic_publish_only(first_cache.clone(), TopicSelector::AllTopics)
+                .into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let tc = new_topic_client(creds.clone());
         let cc = new_cache_client(creds.clone());
@@ -1467,16 +1365,12 @@ mod disposable_tokens_topics {
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
         let first_topic = TestScalar::new();
         let second_topic = TestScalar::new();
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions {
-                permissions: vec![Permission::TopicPermission(TopicPermission {
-                    cache: CacheSelector::AllCaches,
-                    topic: TopicSelector::AllTopics,
-                    role: TopicRole::PublishOnly,
-                })],
-            }),
+        let scope = PermissionScopes::topic_publish_only(
+            CacheSelector::AllCaches,
+            TopicSelector::AllTopics,
         )
-        .await?;
+        .into();
+        let response = generate_disposable_token_success(scope).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let tc = new_topic_client(creds.clone());
         let cc = new_cache_client(creds.clone());
@@ -1511,10 +1405,8 @@ mod disposable_tokens_all_data {
     async fn test_all_data_read_write() -> MomentoResult<()> {
         let first_cache = &CACHE_TEST_STATE.cache_name;
         let second_cache = &CACHE_TEST_STATE.auth_cache_name;
-        let response = generate_disposable_token_success(
-            DisposableTokenScope::Permissions::<String>(Permissions::all_data_read_write()),
-        )
-        .await?;
+        let response =
+            generate_disposable_token_success(Permissions::all_data_read_write().into()).await?;
         let creds = new_credential_provider_from_token(response.auth_token());
         let cc = new_cache_client(creds.clone());
         let tc = new_topic_client(creds);
@@ -1550,9 +1442,7 @@ mod disposable_tokens_expiry {
     async fn test_expiry() -> MomentoResult<()> {
         // Generate a token that expires soon
         let expiry = ExpiresIn::seconds(5);
-        let scope = momento::auth::DisposableTokenScope::Permissions::<String>(
-            Permissions::all_data_read_write(),
-        );
+        let scope = Permissions::all_data_read_write().into();
         let response = CACHE_TEST_STATE
             .auth_client
             .generate_disposable_token(scope, expiry)


### PR DESCRIPTION
Follow up for https://github.com/momentohq/client-sdk-rust/issues/419

Adds more unit tests for the permissions structure for the auth client to match the test coverage we have in the JS sdk.

In the process of writing these tests, I also:

- Wrote more `From` implementations to make conversion between relevant objects easier and refactored the disposable tokens integration tests to make use of these.
- Added `#[derive(Debug, Display, Clone, PartialEq)]` statements to permissions objects to make more `assert`s possible.
- Made CacheItemKey and CacheItemKeyPrefix store `Vec<u8>` directly instead of `<impl IntoBytes>` so that we can avoid the propagation of the generic type everywhere
