### PR TITLE
ci: allow maintainers to approve test workflow on PRs from forks

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,7 +1,7 @@
 name: on-pull-request
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
 
 env:
@@ -12,6 +12,23 @@ env:
   TEST_AUTH_CACHE_NAME: rust-integration-test-ci-cache-auth-${{ github.sha }}
 
 jobs:
+  verify-user-permissions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get User Permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+      - name: Check User Permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+
   rustfmt:
     name: main - Style & Lint
     runs-on: ubuntu-latest
@@ -83,6 +100,7 @@ jobs:
         run: make docs
 
   build_rust:
+    needs: verify-user-permissions
     runs-on: ubuntu-24.04
     env:
       MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}


### PR DESCRIPTION
Closes https://github.com/momentohq/client-sdk-rust/issues/429

Currently, PRs from forks cannot successfully run integration tests because they lack access to our api key secret.
This blocks open-source contributors from being able to easily work on our repo (see #422).

This PR implements the same github actions workflow we had implemented in the JS repo to allow maintainers to approve/rerun workflows on PRs from forks and allow them access to the api key secret (see https://github.com/momentohq/client-sdk-javascript/pull/1485).