### PR TITLE
ci: ensure we checkout the correct commit when running pr checks

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -34,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Log rust versions
         run: |
@@ -107,6 +109,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - uses: Swatinem/rust-cache@v2
 
@@ -133,6 +137,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Commitlint and Other Shared Build Steps
         uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1


### PR DESCRIPTION
`checkout` was checking out the main branch rather than the merge commit (the commit that would result from merging a PR branch into main)

Caused https://github.com/momentohq/client-sdk-rust/pull/433 to appear to have no issues, so I merged it, but all following PRs failed a lint/build error (see https://github.com/momentohq/client-sdk-rust/pull/434 for that fix)