### PR TITLE
ci: checkout default ref on PRs if merge commit is unavailable

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
 
       - name: Log rust versions
         run: |
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
 
       - uses: Swatinem/rust-cache@v2
 
@@ -138,7 +138,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
 
       - name: Commitlint and Other Shared Build Steps
         uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1


### PR DESCRIPTION
It appears that sometimes the `merge_commit_sha` we want to check out in combination with using `on: pull_request_target` does not always exist.

This PR ensures we checkout `merge_commit_sha || pull_request.head.sha` so that it has a fallback ref that will always exist. (The head.sha is the last commit on the PR, the merge_commit_sha is the test merge with main).

Note: The updated workflow will not run on this PR because `pull_request_target` runs in the context of the base branch (main), not the PR branch.