### PR TITLE
ci: restore checks against the merge commit

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -108,9 +108,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-# temporary so that storage examples won't run
-#        with:
-#          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
We disabled checks against the merge commit while removing the storage
client in order for CI to pass. Since we hvae removed and released the
SDK with the storage client removed, we can restore these checks.
