### PR TITLE
chore: add basic trait derivations for cache client builder

### DIFF
--- a/src/cache/cache_client_builder.rs
+++ b/src/cache/cache_client_builder.rs
@@ -11,19 +11,24 @@ use momento_protos::cache_client::scs_client::ScsClient;
 use momento_protos::control_client::scs_control_client::ScsControlClient;
 use tonic::transport::Channel;
 
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct CacheClientBuilder<State>(pub State);
 
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct NeedsDefaultTtl(pub ());
 
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct NeedsConfiguration {
     default_ttl: Duration,
 }
 
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct NeedsCredentialProvider {
     default_ttl: Duration,
     configuration: Configuration,
 }
 
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct ReadyToBuild {
     default_ttl: Duration,
     configuration: Configuration,

--- a/src/cache/config/configuration.rs
+++ b/src/cache/config/configuration.rs
@@ -30,7 +30,7 @@ use crate::config::transport_strategy::TransportStrategy;
 ///             )
 ///     );
 
-#[derive(Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Configuration {
     /// Low-level options for network interactions with Momento.
     pub(crate) transport_strategy: TransportStrategy,

--- a/src/config/grpc_configuration.rs
+++ b/src/config/grpc_configuration.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 const MAX_NUM_CHANNELS: usize = 200;
 
 /// Low-level gRPC settings for communicating with Momento.
-#[derive(Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct GrpcConfiguration {
     /// The duration the client is willing to wait for an RPC to complete before it is terminated
     /// with a DeadlineExceeded error.

--- a/src/config/transport_strategy.rs
+++ b/src/config/transport_strategy.rs
@@ -1,7 +1,7 @@
 use crate::config::grpc_configuration::GrpcConfiguration;
 
 /// Low-level settings for communicating with Momento.
-#[derive(Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct TransportStrategy {
     /// Low-level gRPC settings for communicating with Momento.
     pub(crate) grpc_configuration: GrpcConfiguration,

--- a/src/credential_provider.rs
+++ b/src/credential_provider.rs
@@ -13,7 +13,7 @@ struct V1Token {
 
 /// Provides information that the client needs in order to establish a connection to and
 /// authenticate with the Momento service.
-#[derive(Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct CredentialProvider {
     pub(crate) auth_token: String,
     pub(crate) control_endpoint: String,


### PR DESCRIPTION
Adds basic traits (eq, partialeq, clone, etc) for the cache client
builder and dependent types.
