### PR TITLE
ci: make sure on-pull-request uses latest commit

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Log rust versions
         run: |

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -109,7 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: Swatinem/rust-cache@v2
 
@@ -137,7 +137,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Commitlint and Other Shared Build Steps
         uses: momentohq/standards-and-practices/github-actions/shared-build@gh-actions-v1


### PR DESCRIPTION
Noticed on a recent PR that the second to last commit on the PR was being used for CI instead of the most recent commit. This PR will make it so the most recent commit on a PR is checked out. 

We should also make sure that the repo has enabled "Require branches to be up to date before merging".

FYI: we ran into this issue in the JS sdk as well and updated the workflow file in the same way ([reference](https://github.com/momentohq/client-sdk-javascript/pull/1506)).