### PR TITLE
fix: separate publish and subscribe channels in topic client

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -114,6 +114,19 @@ impl MomentoError {
             details: None,
         }
     }
+
+    pub(crate) fn max_concurrent_streams_reached(
+        num_grpc_channels: usize,
+        num_active_subscriptions: usize,
+        max_concurrent_streams: usize,
+    ) -> Self {
+        Self {
+            message: format!("Number of active streams: {}; number of grpc channels: {}; max concurrent streams: {}; Already at maximum number of concurrent grpc streams, cannot make new subscribe requests", num_active_subscriptions, num_grpc_channels, max_concurrent_streams),
+            error_code: MomentoErrorCode::LimitExceededError,
+            inner_error: None,
+            details: None,
+        }
+    }
 }
 
 /// Indicates an error source

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -122,7 +122,7 @@ impl MomentoError {
     ) -> Self {
         Self {
             message: format!("Number of active streams: {}; number of grpc channels: {}; max concurrent streams: {}; Already at maximum number of concurrent grpc streams, cannot make new subscribe requests", num_active_subscriptions, num_grpc_channels, max_concurrent_streams),
-            error_code: MomentoErrorCode::LimitExceededError,
+            error_code: MomentoErrorCode::ClientResourceExhausted,
             inner_error: None,
             details: None,
         }

--- a/src/topics/config/configuration.rs
+++ b/src/topics/config/configuration.rs
@@ -30,7 +30,7 @@ use crate::config::transport_strategy::TransportStrategy;
 ///             )
 ///     );
 
-#[derive(Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Configuration {
     /// Low-level options for network interactions with Momento.
     pub(crate) transport_strategy: TransportStrategy,

--- a/src/topics/messages/publish.rs
+++ b/src/topics/messages/publish.rs
@@ -66,7 +66,10 @@ impl<V: IntoTopicValue + std::marker::Send> MomentoRequest for PublishRequest<V>
             },
         )?;
 
-        let _ = topic_client.client.clone().publish(request).await?;
+        let _ = topic_client
+            .get_next_unary_client()
+            .publish(request)
+            .await?;
         Ok(TopicPublishResponse {})
     }
 }

--- a/src/topics/messages/subscribe.rs
+++ b/src/topics/messages/subscribe.rs
@@ -87,14 +87,14 @@ impl MomentoRequest for SubscribeRequest {
             },
         )?;
 
-        let stream = topic_client
-            .client
+        let next_stream_client = topic_client.get_next_streaming_client()?;
+        let stream = next_stream_client
             .clone()
             .subscribe(request)
             .await?
             .into_inner();
         Ok(Subscription::new(
-            topic_client.client.clone(),
+            next_stream_client,
             self.cache_name,
             self.topic,
             self.resume_at_topic_sequence_number.unwrap_or_default(),

--- a/src/topics/mod.rs
+++ b/src/topics/mod.rs
@@ -14,4 +14,3 @@ mod topic_client_builder;
 pub use topic_client::TopicClient;
 
 mod topic_subscription_manager;
-// pub use topic_subscription_manager::TopicSubscriptionManager;

--- a/src/topics/mod.rs
+++ b/src/topics/mod.rs
@@ -12,3 +12,6 @@ pub use config::configurations;
 mod topic_client;
 mod topic_client_builder;
 pub use topic_client::TopicClient;
+
+mod topic_subscription_manager;
+// pub use topic_subscription_manager::TopicSubscriptionManager;

--- a/src/topics/topic_client.rs
+++ b/src/topics/topic_client.rs
@@ -1,4 +1,7 @@
-use momento_protos::cache_client::pubsub;
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+
+use momento_protos::cache_client::pubsub::pubsub_client::PubsubClient;
 use tonic::{codegen::InterceptedService, transport::Channel};
 
 use crate::grpc::header_interceptor::HeaderInterceptor;
@@ -10,7 +13,7 @@ use crate::{MomentoError, MomentoResult};
 use crate::topics::messages::publish::TopicPublishResponse;
 use crate::topics::messages::subscribe::SubscribeRequest;
 
-type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
+use super::topic_subscription_manager::TopicSubscriptionManager;
 
 /// Client to work with Momento Topics, the pub/sub service.
 ///
@@ -40,8 +43,12 @@ type ChannelType = InterceptedService<Channel, HeaderInterceptor>;
 /// ```
 #[derive(Clone, Debug)]
 pub struct TopicClient {
-    pub(crate) client: pubsub::pubsub_client::PubsubClient<ChannelType>,
+    pub(crate) unary_client_index: Arc<AtomicUsize>,
+    pub(crate) streaming_client_index: Arc<AtomicUsize>,
+    pub(crate) unary_clients: Vec<PubsubClient<InterceptedService<Channel, HeaderInterceptor>>>,
+    pub(crate) streaming_clients: Vec<TopicSubscriptionManager>,
     pub(crate) configuration: Configuration,
+    pub(crate) max_concurrent_streams: usize,
 }
 
 impl TopicClient {
@@ -164,5 +171,80 @@ impl TopicClient {
     /// See [SubscribeRequest] for an example of creating a request with optional fields.
     pub async fn send_request<R: MomentoRequest>(&self, request: R) -> MomentoResult<R::Response> {
         request.send(self).await
+    }
+
+    pub(crate) fn get_next_unary_client(
+        &self,
+    ) -> PubsubClient<InterceptedService<Channel, HeaderInterceptor>> {
+        let index = self
+            .unary_client_index
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let num_clients = self.unary_clients.len();
+        self.unary_clients[index % num_clients].clone()
+    }
+
+    pub(crate) fn get_next_streaming_client(
+        &self,
+    ) -> MomentoResult<PubsubClient<InterceptedService<Channel, HeaderInterceptor>>> {
+        // First check if there is enough capacity to make a new subscription.
+        self.check_number_of_concurrent_streams()?;
+
+        // Max number of attempts is set to the max number of concurrent streams in order to preserve
+        // the round-robin system (incrementing nextManagerIndex) but to not cut short the number
+        //  of attempts in case there are many subscriptions starting up at the same time.
+        for _ in 0..self.max_concurrent_streams {
+            let next_manager_index = self
+                .streaming_client_index
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let topic_manager =
+                &self.streaming_clients[next_manager_index % self.streaming_clients.len()];
+            let new_count = topic_manager.increment_num_active_subscriptions();
+            if new_count <= self.max_concurrent_streams {
+                log::debug!(
+                    "Starting new subscription on grpc channel {} which now has {} streams",
+                    next_manager_index % self.streaming_clients.len(),
+                    new_count
+                );
+                return Ok(topic_manager.client().clone());
+            }
+            topic_manager.decrement_num_active_subscriptions();
+        }
+
+        // If no more streams available, return an error
+        Err(MomentoError::max_concurrent_streams_reached(
+            self.count_number_of_active_subscriptions(),
+            self.streaming_clients.len(),
+            self.max_concurrent_streams,
+        ))
+    }
+
+    fn count_number_of_active_subscriptions(&self) -> usize {
+        self.streaming_clients
+            .iter()
+            .map(|client| client.get_num_active_subscriptions())
+            .sum()
+    }
+
+    fn check_number_of_concurrent_streams(&self) -> MomentoResult<()> {
+        let num_active_subscriptions = self.count_number_of_active_subscriptions();
+        if num_active_subscriptions >= self.max_concurrent_streams {
+            return Err(MomentoError::max_concurrent_streams_reached(
+                num_active_subscriptions,
+                self.streaming_clients.len(),
+                self.max_concurrent_streams,
+            ));
+        }
+
+        // If we are approaching the maximum number of concurrent streams, log a warning.
+        let remaining_streams = self.max_concurrent_streams - num_active_subscriptions;
+        if remaining_streams < 10 {
+            log::warn!(
+                "Only {} streams remaining.  You may hit the limit of {} concurrent streams soon.",
+                remaining_streams,
+                self.max_concurrent_streams
+            );
+        }
+
+        Ok(())
     }
 }

--- a/src/topics/topic_client_builder.rs
+++ b/src/topics/topic_client_builder.rs
@@ -68,7 +68,7 @@ impl TopicClientBuilder<ReadyToBuild> {
         // Create a pool of grpc channels for streaming operations. Default to 4 channels.
         // TODO: Make this configurable.
         let mut streaming_clients = Vec::new();
-        let num_stream_clients = 1;
+        let num_stream_clients = 4;
         for _ in 0..num_stream_clients {
             let stream_manager = TopicSubscriptionManager::new(create_pubsub_client(
                 &self.0.credential_provider.cache_endpoint,

--- a/src/topics/topic_client_builder.rs
+++ b/src/topics/topic_client_builder.rs
@@ -9,9 +9,7 @@ use crate::{
 use momento_protos::cache_client::pubsub::pubsub_client::PubsubClient;
 use tonic::{service::interceptor::InterceptedService, transport::Channel};
 
-use super::topic_subscription_manager::{
-    TopicSubscriptionManager, MAX_CONCURRENT_STREAMS_PER_CHANNEL,
-};
+use super::topic_subscription_manager::TopicSubscriptionManager;
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct TopicClientBuilder<State>(pub State);
@@ -83,7 +81,6 @@ impl TopicClientBuilder<ReadyToBuild> {
             unary_clients,
             streaming_clients,
             configuration: self.0.configuration,
-            max_concurrent_streams: num_stream_clients * MAX_CONCURRENT_STREAMS_PER_CHANNEL,
         })
     }
 }

--- a/src/topics/topic_client_builder.rs
+++ b/src/topics/topic_client_builder.rs
@@ -1,21 +1,30 @@
-use momento_protos::cache_client::pubsub::pubsub_client::PubsubClient;
-use tonic::service::interceptor::InterceptedService;
+use std::sync::{atomic::AtomicUsize, Arc};
 
 use crate::{
     grpc::header_interceptor::HeaderInterceptor,
     topics::Configuration,
-    utils::{self, connect_channel_lazily},
+    utils::{self, connect_channel_lazily, ChannelConnectError},
     CredentialProvider, MomentoResult, TopicClient,
 };
+use momento_protos::cache_client::pubsub::pubsub_client::PubsubClient;
+use tonic::{service::interceptor::InterceptedService, transport::Channel};
 
+use super::topic_subscription_manager::{
+    TopicSubscriptionManager, MAX_CONCURRENT_STREAMS_PER_CHANNEL,
+};
+
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct TopicClientBuilder<State>(pub State);
 
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct NeedsConfiguration(pub ());
 
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct NeedsCredentialProvider {
     configuration: Configuration,
 }
 
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct ReadyToBuild {
     configuration: Configuration,
     credential_provider: CredentialProvider,
@@ -46,15 +55,46 @@ impl TopicClientBuilder<NeedsCredentialProvider> {
 
 impl TopicClientBuilder<ReadyToBuild> {
     pub fn build(self) -> MomentoResult<TopicClient> {
-        let agent_value = &utils::user_agent("topic");
-        let channel = connect_channel_lazily(&self.0.credential_provider.cache_endpoint)?;
-        let authorized_channel = InterceptedService::new(
-            channel,
-            HeaderInterceptor::new(&self.0.credential_provider.auth_token, agent_value),
-        );
+        // Create a pool of grpc channels for unary operations. Default to 4 channels.
+        // TODO: Make this configurable.
+        let mut unary_clients = Vec::new();
+        for _ in 0..4 {
+            unary_clients.push(create_pubsub_client(
+                &self.0.credential_provider.cache_endpoint,
+                &self.0.credential_provider.auth_token,
+            )?);
+        }
+
+        // Create a pool of grpc channels for streaming operations. Default to 4 channels.
+        // TODO: Make this configurable.
+        let mut streaming_clients = Vec::new();
+        let num_stream_clients = 1;
+        for _ in 0..num_stream_clients {
+            let stream_manager = TopicSubscriptionManager::new(create_pubsub_client(
+                &self.0.credential_provider.cache_endpoint,
+                &self.0.credential_provider.auth_token,
+            )?);
+            streaming_clients.push(stream_manager);
+        }
+
         Ok(TopicClient {
-            client: PubsubClient::new(authorized_channel),
+            unary_client_index: Arc::new(AtomicUsize::new(0)),
+            streaming_client_index: Arc::new(AtomicUsize::new(0)),
+            unary_clients,
+            streaming_clients,
             configuration: self.0.configuration,
+            max_concurrent_streams: num_stream_clients * MAX_CONCURRENT_STREAMS_PER_CHANNEL,
         })
     }
+}
+
+fn create_pubsub_client(
+    endpoint: &str,
+    auth_token: &str,
+) -> Result<PubsubClient<InterceptedService<Channel, HeaderInterceptor>>, ChannelConnectError> {
+    let agent_value = &utils::user_agent("topic");
+    let channel = connect_channel_lazily(endpoint)?;
+    let authorized_channel =
+        InterceptedService::new(channel, HeaderInterceptor::new(auth_token, agent_value));
+    Ok(PubsubClient::new(authorized_channel))
 }

--- a/src/topics/topic_subscription_manager.rs
+++ b/src/topics/topic_subscription_manager.rs
@@ -1,0 +1,42 @@
+use tonic::transport::Channel;
+
+use crate::grpc::header_interceptor::HeaderInterceptor;
+use momento_protos::cache_client::pubsub::pubsub_client::PubsubClient;
+use std::sync::{atomic::AtomicUsize, Arc};
+use tonic::codegen::InterceptedService;
+
+pub const MAX_CONCURRENT_STREAMS_PER_CHANNEL: usize = 100;
+
+#[derive(Clone, Debug)]
+pub struct TopicSubscriptionManager {
+    client: PubsubClient<InterceptedService<Channel, HeaderInterceptor>>,
+    num_active_subscriptions: Arc<AtomicUsize>,
+}
+
+impl TopicSubscriptionManager {
+    pub fn new(client: PubsubClient<InterceptedService<Channel, HeaderInterceptor>>) -> Self {
+        Self {
+            client,
+            num_active_subscriptions: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    pub fn get_num_active_subscriptions(&self) -> usize {
+        self.num_active_subscriptions
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub fn increment_num_active_subscriptions(&self) -> usize {
+        self.num_active_subscriptions
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub fn decrement_num_active_subscriptions(&self) -> usize {
+        self.num_active_subscriptions
+            .fetch_sub(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub fn client(&self) -> &PubsubClient<InterceptedService<Channel, HeaderInterceptor>> {
+        &self.client
+    }
+}

--- a/tests/topics/pubsub.rs
+++ b/tests/topics/pubsub.rs
@@ -55,4 +55,39 @@ mod publish_and_subscribe {
         subscription_handle.abort();
         Ok(())
     }
+
+    // Previously, the topic client used only 1 grpc channel for both unary and streaming requests and starting
+    // 100 subscribers and attempting to would have caused the publish request would be silently queued up.
+    #[tokio::test]
+    async fn publish_and_subscribe_with_multiple_subscribers() -> MomentoResult<()> {
+        let client = &CACHE_TEST_STATE.topic_client;
+        let cache_name = &CACHE_TEST_STATE.cache_name;
+        let topic_name = unique_topic_name();
+
+        let mut subscribers = Vec::new();
+        for _ in 0..100 {
+            let mut subscriber = client.subscribe(cache_name, &topic_name).await?;
+            let subscription_handle = tokio::spawn(async move {
+                let message = subscriber.next().await;
+                match message {
+                    Some(message) => {
+                        let message_text: String =
+                            message.try_into().expect("Expected to receive a string");
+                        assert_eq!(message_text, "value");
+                    }
+                    None => panic!("Expected to receive a message"),
+                }
+            });
+            subscribers.push(subscription_handle);
+        }
+
+        // If it times out, the test should fail.
+        let result = client.publish(cache_name, &topic_name, "value").await?;
+        assert_eq!(result, TopicPublishResponse {});
+
+        for subscriber in subscribers {
+            subscriber.abort();
+        }
+        Ok(())
+    }
 }


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1158

- Added a test to confirm topic client channel can become full and silently queue up requests
- Created separate pools of grpc channels in the topic client for publish and subscribe requests
- Bookkeeping for number of active subscriptions allows the topic client to return a limit exceeded error instead of silently queueing up requests
