### PR TITLE
feat: add options for exclusive min/max for sorted set fetch by score and length by score

### DIFF
--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -1231,13 +1231,12 @@ impl CacheClient {
     /// If you use [send_request](CacheClient::send_request) to fetch elements using a
     /// [SortedSetFetchByScoreRequest], you can also provide the following optional arguments:
     ///
-    /// * `min_score` - The minimum score (inclusive) of the elements to fetch. Defaults to negative
-    ///   infinity.
-    /// * `max_score` - The maximum score (inclusive) of the elements to fetch. Defaults to positive
-    ///   infinity.
-    /// * `exclusive_min_score` - the minimum score (exclusive) of the elements to fetch. Defaults to negative infinity.
-    /// * `exclusive_max_score` - the maximum score (exclusive) of the elements to fetch. Defaults to positive
-    ///   infinity.
+    /// * `min_score` - the minimum score of the elements to fetch. Defaults to negative
+    ///   infinity. Use [ScoreBound::Inclusive](crate::cache::ScoreBound::Inclusive) or [ScoreBound::Exclusive](crate::cache::ScoreBound::Exclusive) to specify whether
+    ///   the minimum score is inclusive or exclusive.
+    /// * `max_score` - the maximum score of the elements to fetch. Defaults to positive
+    ///   infinity. Use [ScoreBound::Inclusive](crate::cache::ScoreBound::Inclusive) or [ScoreBound::Exclusive](crate::cache::ScoreBound::Exclusive) to specify whether
+    ///   the maximum score is inclusive or exclusive.
     /// * `offset` - The number of elements to skip before returning the first element. Defaults to
     /// 0. Note: this is not the rank of the first element to return, but the number of elements of
     ///    the result set to skip before returning the first element.
@@ -1563,13 +1562,12 @@ impl CacheClient {
     /// If you use [send_request](CacheClient::send_request) to fetch elements using a
     /// [SortedSetLengthByScoreRequest], you can also provide the following optional arguments:
     ///
-    /// * `min_score` - The minimum score (inclusive) of the elements to fetch. Defaults to negative
-    ///   infinity.
-    /// * `max_score` - The maximum score (inclusive) of the elements to fetch. Defaults to positive
-    ///   infinity.
-    /// * `exclusive_min_score` - the minimum score (exclusive) of the elements to fetch. Defaults to negative infinity.
-    /// * `exclusive_max_score` - the maximum score (exclusive) of the elements to fetch. Defaults to positive
-    ///   infinity.
+    /// * `min_score` - the minimum score of the elements to fetch. Defaults to negative
+    ///   infinity. Use [ScoreBound::Inclusive](crate::cache::ScoreBound::Inclusive) or [ScoreBound::Exclusive](crate::cache::ScoreBound::Exclusive) to specify whether
+    ///   the minimum score is inclusive or exclusive.
+    /// * `max_score` - the maximum score of the elements to fetch. Defaults to positive
+    ///   infinity. Use [ScoreBound::Inclusive](crate::cache::ScoreBound::Inclusive) or [ScoreBound::Exclusive](crate::cache::ScoreBound::Exclusive) to specify whether
+    ///   the maximum score is inclusive or exclusive.
     ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -1235,6 +1235,9 @@ impl CacheClient {
     ///   infinity.
     /// * `max_score` - The maximum score (inclusive) of the elements to fetch. Defaults to positive
     ///   infinity.
+    /// * `exclusive_min_score` - the minimum score (exclusive) of the elements to fetch. Defaults to negative infinity.
+    /// * `exclusive_max_score` - the maximum score (exclusive) of the elements to fetch. Defaults to positive
+    ///   infinity.
     /// * `offset` - The number of elements to skip before returning the first element. Defaults to
     /// 0. Note: this is not the rank of the first element to return, but the number of elements of
     ///    the result set to skip before returning the first element.
@@ -1563,6 +1566,9 @@ impl CacheClient {
     /// * `min_score` - The minimum score (inclusive) of the elements to fetch. Defaults to negative
     ///   infinity.
     /// * `max_score` - The maximum score (inclusive) of the elements to fetch. Defaults to positive
+    ///   infinity.
+    /// * `exclusive_min_score` - the minimum score (exclusive) of the elements to fetch. Defaults to negative infinity.
+    /// * `exclusive_max_score` - the maximum score (exclusive) of the elements to fetch. Defaults to positive
     ///   infinity.
     ///
     /// # Examples

--- a/src/cache/messages/data/sorted_set/mod.rs
+++ b/src/cache/messages/data/sorted_set/mod.rs
@@ -1,3 +1,5 @@
+/// Contains common types for the sorted set module.
+pub mod sorted_set_common;
 /// Contains the request and response types for fetching elements from a sorted set.
 pub mod sorted_set_fetch_by_rank;
 /// Contains the request and response types for fetching elements from a sorted set.

--- a/src/cache/messages/data/sorted_set/sorted_set_common.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_common.rs
@@ -1,0 +1,20 @@
+/// Boundary for a sorted set score range.
+#[derive(Debug, PartialEq, Clone)]
+pub enum ScoreBound {
+    /// Include the score in the range.
+    Inclusive(f64),
+    /// Exclude the score from the range.
+    Exclusive(f64),
+}
+
+/// The order with which to sort the elements by score in the sorted set.
+/// The sort order determines the rank of the elements.
+/// The elements with same score are ordered lexicographically.
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum SortedSetOrder {
+    /// Scores are ordered from low to high. This is the default order.
+    Ascending = 0,
+    /// Scores are ordered from high to low.
+    Descending = 1,
+}

--- a/src/cache/messages/data/sorted_set/sorted_set_fetch_by_rank.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_fetch_by_rank.rs
@@ -4,20 +4,9 @@ use momento_protos::common::Unbounded;
 
 use crate::cache::messages::data::sorted_set::sorted_set_fetch_response::SortedSetFetchResponse;
 use crate::cache::messages::MomentoRequest;
+use crate::cache::SortedSetOrder;
 use crate::utils::prep_request_with_timeout;
 use crate::{CacheClient, IntoBytes, MomentoResult};
-
-/// The order with which to sort the elements by score in the sorted set.
-/// The sort order determines the rank of the elements.
-/// The elements with same score are ordered lexicographically.
-#[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub enum SortedSetOrder {
-    /// Scores are ordered from low to high. This is the default order.
-    Ascending = 0,
-    /// Scores are ordered from high to low.
-    Descending = 1,
-}
 
 /// Request to fetch the elements in a sorted set by their rank.
 ///

--- a/src/cache/messages/data/sorted_set/sorted_set_fetch_by_score.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_fetch_by_score.rs
@@ -25,6 +25,9 @@ use crate::{CacheClient, IntoBytes, MomentoResult};
 ///   infinity.
 /// * `max_score` - The maximum score (inclusive) of the elements to fetch. Defaults to positive
 ///   infinity.
+/// * `exclusive_min_score` - the minimum score (exclusive) of the elements to fetch. Defaults to negative infinity.
+/// * `exclusive_max_score` - the maximum score (exclusive) of the elements to fetch. Defaults to positive
+///   infinity.
 /// * `offset` - The number of elements to skip before returning the first element. Defaults to
 /// 0. Note: this is not the rank of the first element to return, but the number of elements of
 ///    the result set to skip before returning the first element.
@@ -65,7 +68,9 @@ pub struct SortedSetFetchByScoreRequest<S: IntoBytes> {
     cache_name: String,
     sorted_set_name: S,
     min_score: Option<f64>,
+    min_score_exclusive: Option<bool>,
     max_score: Option<f64>,
+    max_score_exclusive: Option<bool>,
     order: SortedSetOrder,
     offset: Option<u32>,
     count: Option<i32>,
@@ -78,7 +83,9 @@ impl<S: IntoBytes> SortedSetFetchByScoreRequest<S> {
             cache_name: cache_name.into(),
             sorted_set_name,
             min_score: None,
+            min_score_exclusive: None,
             max_score: None,
+            max_score_exclusive: None,
             order: Ascending,
             offset: None,
             count: None,
@@ -87,13 +94,37 @@ impl<S: IntoBytes> SortedSetFetchByScoreRequest<S> {
 
     /// Set the minimum score of the request.
     pub fn min_score(mut self, min_score: impl Into<Option<f64>>) -> Self {
-        self.min_score = min_score.into();
+        if let Some(min) = min_score.into() {
+            self.min_score = Some(min);
+            self.min_score_exclusive = None;
+        }
+        self
+    }
+
+    /// Set the minimum score of the request.
+    pub fn exclusive_min_score(mut self, exclusive_min_score: impl Into<Option<f64>>) -> Self {
+        if let Some(min) = exclusive_min_score.into() {
+            self.min_score = Some(min);
+            self.min_score_exclusive = Some(true);
+        }
         self
     }
 
     /// Set the maximum score of the request.
     pub fn max_score(mut self, max_score: impl Into<Option<f64>>) -> Self {
-        self.max_score = max_score.into();
+        if let Some(max) = max_score.into() {
+            self.max_score = Some(max);
+            self.max_score_exclusive = None;
+        }
+        self
+    }
+
+    /// Set the maximum score of the request.
+    pub fn exclusive_max_score(mut self, exclusive_max_score: impl Into<Option<f64>>) -> Self {
+        if let Some(max) = exclusive_max_score.into() {
+            self.max_score = Some(max);
+            self.max_score_exclusive = Some(true);
+        }
         self
     }
 
@@ -123,27 +154,33 @@ impl<S: IntoBytes> MomentoRequest for SortedSetFetchByScoreRequest<S> {
         let set_name = self.sorted_set_name.into_bytes();
         let cache_name = &self.cache_name;
 
+        let min_score = match (self.min_score, self.min_score_exclusive) {
+            (Some(score), Some(true)) => Some(by_score::Min::MinScore(Score {
+                score,
+                exclusive: true,
+            })),
+            (Some(score), _) => Some(by_score::Min::MinScore(Score {
+                score,
+                exclusive: false,
+            })),
+            (None, _) => Some(by_score::Min::UnboundedMin(Unbounded {})),
+        };
+
+        let max_score = match (self.max_score, self.max_score_exclusive) {
+            (Some(score), Some(true)) => Some(by_score::Max::MaxScore(Score {
+                score,
+                exclusive: true,
+            })),
+            (Some(score), _) => Some(by_score::Max::MaxScore(Score {
+                score,
+                exclusive: false,
+            })),
+            (None, _) => Some(by_score::Max::UnboundedMax(Unbounded {})),
+        };
+
         let by_score = ByScore {
-            min: Some(
-                self.min_score
-                    .map(|score| {
-                        by_score::Min::MinScore(Score {
-                            score,
-                            exclusive: false,
-                        })
-                    })
-                    .unwrap_or(by_score::Min::UnboundedMin(Unbounded {})),
-            ),
-            max: Some(
-                self.max_score
-                    .map(|score| {
-                        by_score::Max::MaxScore(Score {
-                            score,
-                            exclusive: false,
-                        })
-                    })
-                    .unwrap_or(by_score::Max::UnboundedMax(Unbounded {})),
-            ),
+            min: min_score,
+            max: max_score,
             offset: self.offset.unwrap_or(0),
             count: self.count.unwrap_or(-1),
         };
@@ -174,9 +211,8 @@ mod test {
     use super::SortedSetFetchByScoreRequest;
     use crate::cache::SortedSetOrder;
 
-    // test the sorted set request with options
     #[tokio::test]
-    async fn test_sorted_set_fetch_by_score_request_with_options() {
+    async fn test_sorted_set_fetch_by_score_request_with_inclusive_options() {
         // Define the cache name and sorted set name
         let cache_name = "test_cache";
         let sorted_set_name = "test_sorted_set";
@@ -193,7 +229,9 @@ mod test {
         assert_eq!(fetch_request.cache_name, cache_name);
         assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
         assert_eq!(fetch_request.min_score, Some(2.0));
+        assert_eq!(fetch_request.min_score_exclusive, None);
         assert_eq!(fetch_request.max_score, Some(3.0));
+        assert_eq!(fetch_request.max_score_exclusive, None);
         assert_eq!(fetch_request.order, SortedSetOrder::Ascending);
         assert_eq!(fetch_request.offset, Some(1));
         assert_eq!(fetch_request.count, Some(2));
@@ -210,7 +248,9 @@ mod test {
         assert_eq!(fetch_request.cache_name, cache_name);
         assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
         assert_eq!(fetch_request.min_score, Some(2.0));
+        assert_eq!(fetch_request.min_score_exclusive, None);
         assert_eq!(fetch_request.max_score, Some(3.0));
+        assert_eq!(fetch_request.max_score_exclusive, None);
         assert_eq!(fetch_request.order, SortedSetOrder::Ascending);
         assert_eq!(fetch_request.offset, Some(1));
         assert_eq!(fetch_request.count, Some(2));
@@ -227,9 +267,112 @@ mod test {
         assert_eq!(fetch_request.cache_name, cache_name);
         assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
         assert_eq!(fetch_request.min_score, None);
+        assert_eq!(fetch_request.min_score_exclusive, None);
         assert_eq!(fetch_request.max_score, None);
+        assert_eq!(fetch_request.max_score_exclusive, None);
         assert_eq!(fetch_request.order, SortedSetOrder::Ascending);
         assert_eq!(fetch_request.offset, None);
         assert_eq!(fetch_request.count, None);
+    }
+
+    #[tokio::test]
+    async fn test_sorted_set_fetch_by_score_request_with_exclusive_options() {
+        // Define the cache name and sorted set name
+        let cache_name = "test_cache";
+        let sorted_set_name = "test_sorted_set";
+
+        // Create the fetch request with options
+        let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
+            .order(SortedSetOrder::Ascending)
+            .exclusive_min_score(2.0)
+            .exclusive_max_score(3.0)
+            .offset(1)
+            .count(2);
+
+        // Verify the built request
+        assert_eq!(fetch_request.cache_name, cache_name);
+        assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
+        assert_eq!(fetch_request.min_score, Some(2.0));
+        assert_eq!(fetch_request.min_score_exclusive, Some(true));
+        assert_eq!(fetch_request.max_score, Some(3.0));
+        assert_eq!(fetch_request.max_score_exclusive, Some(true));
+        assert_eq!(fetch_request.order, SortedSetOrder::Ascending);
+        assert_eq!(fetch_request.offset, Some(1));
+        assert_eq!(fetch_request.count, Some(2));
+
+        // Now pass in explicit Options to min score, max score, offset, and count
+        let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
+            .order(SortedSetOrder::Ascending)
+            .exclusive_min_score(Some(2.0))
+            .exclusive_max_score(Some(3.0))
+            .offset(Some(1))
+            .count(Some(2));
+
+        // Verify the built request
+        assert_eq!(fetch_request.cache_name, cache_name);
+        assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
+        assert_eq!(fetch_request.min_score, Some(2.0));
+        assert_eq!(fetch_request.min_score_exclusive, Some(true));
+        assert_eq!(fetch_request.max_score, Some(3.0));
+        assert_eq!(fetch_request.max_score_exclusive, Some(true));
+        assert_eq!(fetch_request.order, SortedSetOrder::Ascending);
+        assert_eq!(fetch_request.offset, Some(1));
+        assert_eq!(fetch_request.count, Some(2));
+
+        // Now pass in explicit None to min score, max score, offset, and count
+        let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
+            .order(SortedSetOrder::Ascending)
+            .exclusive_min_score(None)
+            .exclusive_max_score(None)
+            .offset(None)
+            .count(None);
+
+        // Verify the built request
+        assert_eq!(fetch_request.cache_name, cache_name);
+        assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
+        assert_eq!(fetch_request.min_score, None);
+        assert_eq!(fetch_request.min_score_exclusive, None);
+        assert_eq!(fetch_request.max_score, None);
+        assert_eq!(fetch_request.max_score_exclusive, None);
+        assert_eq!(fetch_request.order, SortedSetOrder::Ascending);
+        assert_eq!(fetch_request.offset, None);
+        assert_eq!(fetch_request.count, None);
+    }
+
+    #[tokio::test]
+    async fn test_sorted_set_fetch_by_score_request_with_conflicting_scores() {
+        // Define the cache name and sorted set name
+        let cache_name = "test_cache";
+        let sorted_set_name = "test_sorted_set";
+
+        // Create the fetch request with all score options, but only the last revisions should be used.
+        let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
+            .exclusive_min_score(4.0)
+            .exclusive_max_score(5.0)
+            .min_score(1.0)
+            .max_score(2.0);
+
+        // Verify the built request
+        assert_eq!(fetch_request.cache_name, cache_name);
+        assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
+        assert_eq!(fetch_request.min_score, Some(1.0));
+        assert_eq!(fetch_request.min_score_exclusive, None);
+        assert_eq!(fetch_request.max_score, Some(2.0));
+        assert_eq!(fetch_request.max_score_exclusive, None);
+
+        // Verify exclusive is used when order is switched.
+        let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, sorted_set_name)
+            .min_score(1.0)
+            .max_score(2.0)
+            .exclusive_min_score(4.0)
+            .exclusive_max_score(5.0);
+
+        // Verify the built request
+        assert_eq!(fetch_request.cache_name, cache_name);
+        assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
+        assert_eq!(fetch_request.min_score, Some(4.0));
+        assert_eq!(fetch_request.min_score_exclusive, Some(true));
+        assert_eq!(fetch_request.max_score, Some(5.0));
+        assert_eq!(fetch_request.max_score_exclusive, Some(true));
     }
 }

--- a/src/cache/messages/data/sorted_set/sorted_set_fetch_by_score.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_fetch_by_score.rs
@@ -3,14 +3,12 @@ use momento_protos::cache_client::sorted_set_fetch_request::{by_score, ByScore, 
 use momento_protos::cache_client::SortedSetFetchRequest;
 use momento_protos::common::Unbounded;
 
-use crate::cache::messages::data::sorted_set::sorted_set_fetch_by_rank::SortedSetOrder;
-use crate::cache::messages::data::sorted_set::sorted_set_fetch_by_rank::SortedSetOrder::Ascending;
 use crate::cache::messages::data::sorted_set::sorted_set_fetch_response::SortedSetFetchResponse;
 use crate::cache::messages::MomentoRequest;
 use crate::utils::prep_request_with_timeout;
 use crate::{CacheClient, IntoBytes, MomentoResult};
 
-use super::sorted_set_length_by_score::ScoreBound;
+use super::sorted_set_common::{ScoreBound, SortedSetOrder};
 
 /// Fetch the elements in the given sorted set by their score.
 ///
@@ -83,7 +81,7 @@ impl<S: IntoBytes> SortedSetFetchByScoreRequest<S> {
             sorted_set_name,
             min_score: None,
             max_score: None,
-            order: Ascending,
+            order: SortedSetOrder::Ascending,
             offset: None,
             count: None,
         }

--- a/src/cache/messages/data/sorted_set/sorted_set_length_by_score.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_length_by_score.rs
@@ -10,6 +10,15 @@ use crate::{
     MomentoResult,
 };
 
+/// Boundary for a sorted set score range.
+#[derive(Debug, PartialEq, Clone)]
+pub enum ScoreBound {
+    /// Include the score in the range.
+    Inclusive(f64),
+    /// Exclude the score from the range.
+    Exclusive(f64),
+}
+
 /// Get the number of entries in a sorted set that fall between a minimum and maximum score.
 ///
 /// # Arguments
@@ -17,13 +26,12 @@ use crate::{
 /// * `sorted_set_name` - name of the sorted set
 ///
 /// # Optional Arguments
-/// * `min_score` - the minimum score (inclusive) of the elements to fetch. Defaults to negative
-///   infinity.
-/// * `max_score` - the maximum score (inclusive) of the elements to fetch. Defaults to positive
-///   infinity.
-/// * `exclusive_min_score` - the minimum score (exclusive) of the elements to fetch. Defaults to negative infinity.
-/// * `exclusive_max_score` - the maximum score (exclusive) of the elements to fetch. Defaults to positive
-///   infinity.
+/// * `min_score` - the minimum score of the elements to fetch. Defaults to negative
+///   infinity. Use [ScoreBound::Inclusive] or [ScoreBound::Exclusive] to specify whether
+///   the minimum score is inclusive or exclusive.
+/// * `max_score` - the maximum score of the elements to fetch. Defaults to positive
+///   infinity. Use [ScoreBound::Inclusive] or [ScoreBound::Exclusive] to specify whether
+///   the maximum score is inclusive or exclusive.
 ///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
@@ -32,7 +40,7 @@ use crate::{
 /// # use momento_test_util::create_doctest_cache_client;
 /// # tokio_test::block_on(async {
 /// use std::convert::TryInto;
-/// use momento::cache::{SortedSetLengthByScoreResponse, SortedSetLengthByScoreRequest};
+/// use momento::cache::{SortedSetLengthByScoreResponse, SortedSetLengthByScoreRequest, ScoreBound};
 /// use momento::MomentoErrorCode;
 /// # let (cache_client, cache_name) = create_doctest_cache_client();
 /// let sorted_set_name = "sorted_set";
@@ -40,8 +48,8 @@ use crate::{
 /// # cache_client.sorted_set_put_elements(&cache_name, sorted_set_name.to_string(), vec![("value1", 1.0), ("value2", 2.0)]).await;
 ///
 /// let length_request = SortedSetLengthByScoreRequest::new(cache_name, sorted_set_name)
-///     .min_score(1.0)
-///     .exclusive_max_score(5.0);
+///     .min_score(ScoreBound::Inclusive(1.0))
+///     .max_score(ScoreBound::Exclusive(5.0));
 ///
 /// let length: u32 = cache_client.send_request(length_request).await?.try_into().expect("Expected a sorted set length!");
 /// # Ok(())
@@ -51,10 +59,8 @@ use crate::{
 pub struct SortedSetLengthByScoreRequest<L: IntoBytes> {
     cache_name: String,
     sorted_set_name: L,
-    min_score: Option<f64>,
-    min_score_exclusive: Option<bool>,
-    max_score: Option<f64>,
-    max_score_exclusive: Option<bool>,
+    min_score: Option<ScoreBound>,
+    max_score: Option<ScoreBound>,
 }
 
 impl<L: IntoBytes> SortedSetLengthByScoreRequest<L> {
@@ -64,45 +70,19 @@ impl<L: IntoBytes> SortedSetLengthByScoreRequest<L> {
             cache_name: cache_name.into(),
             sorted_set_name,
             min_score: None,
-            min_score_exclusive: None,
             max_score: None,
-            max_score_exclusive: None,
         }
     }
 
-    /// Set the inclusive minimum score of the request.
-    pub fn min_score(mut self, min_score: impl Into<Option<f64>>) -> Self {
-        if let Some(min) = min_score.into() {
-            self.min_score = Some(min);
-            self.min_score_exclusive = None;
-        }
+    /// Set the minimum score of the request.
+    pub fn min_score(mut self, min_score: impl Into<Option<ScoreBound>>) -> Self {
+        self.min_score = min_score.into();
         self
     }
 
-    /// Set the exclusive minimum score of the request.
-    pub fn exclusive_min_score(mut self, min_score: impl Into<Option<f64>>) -> Self {
-        if let Some(min) = min_score.into() {
-            self.min_score = Some(min);
-            self.min_score_exclusive = Some(true);
-        }
-        self
-    }
-
-    /// Set the inclusive maximum score of the request.
-    pub fn max_score(mut self, max_score: impl Into<Option<f64>>) -> Self {
-        if let Some(max) = max_score.into() {
-            self.max_score = Some(max);
-            self.max_score_exclusive = None;
-        }
-        self
-    }
-
-    /// Set the exclusive maximum score of the request.
-    pub fn exclusive_max_score(mut self, max_score: impl Into<Option<f64>>) -> Self {
-        if let Some(max) = max_score.into() {
-            self.max_score = Some(max);
-            self.max_score_exclusive = Some(true);
-        }
+    /// Set the maximum score of the request.
+    pub fn max_score(mut self, max_score: impl Into<Option<ScoreBound>>) -> Self {
+        self.max_score = max_score.into();
         self
     }
 }
@@ -114,26 +94,30 @@ impl<L: IntoBytes> MomentoRequest for SortedSetLengthByScoreRequest<L> {
         self,
         cache_client: &CacheClient,
     ) -> MomentoResult<SortedSetLengthByScoreResponse> {
-        let min_score = match (self.min_score, self.min_score_exclusive) {
-            (Some(min_score), Some(true)) => Some(
-                sorted_set_length_by_score_request::Min::ExclusiveMin(min_score),
-            ),
-            (Some(min_score), _) => Some(sorted_set_length_by_score_request::Min::InclusiveMin(
-                min_score,
-            )),
-            (None, _) => Some(sorted_set_length_by_score_request::Min::UnboundedMin(
+        let min_score = match self.min_score {
+            Some(min_score) => match min_score {
+                ScoreBound::Inclusive(score) => {
+                    Some(sorted_set_length_by_score_request::Min::InclusiveMin(score))
+                }
+                ScoreBound::Exclusive(score) => {
+                    Some(sorted_set_length_by_score_request::Min::ExclusiveMin(score))
+                }
+            },
+            None => Some(sorted_set_length_by_score_request::Min::UnboundedMin(
                 Unbounded {},
             )),
         };
 
-        let max_score = match (self.max_score, self.max_score_exclusive) {
-            (Some(max_score), Some(true)) => Some(
-                sorted_set_length_by_score_request::Max::ExclusiveMax(max_score),
-            ),
-            (Some(max_score), _) => Some(sorted_set_length_by_score_request::Max::InclusiveMax(
-                max_score,
-            )),
-            (None, _) => Some(sorted_set_length_by_score_request::Max::UnboundedMax(
+        let max_score = match self.max_score {
+            Some(max_score) => match max_score {
+                ScoreBound::Inclusive(score) => {
+                    Some(sorted_set_length_by_score_request::Max::InclusiveMax(score))
+                }
+                ScoreBound::Exclusive(score) => {
+                    Some(sorted_set_length_by_score_request::Max::ExclusiveMax(score))
+                }
+            },
+            None => Some(sorted_set_length_by_score_request::Max::UnboundedMax(
                 Unbounded {},
             )),
         };
@@ -223,7 +207,7 @@ impl TryFrom<SortedSetLengthByScoreResponse> for u32 {
 
 #[cfg(test)]
 mod test {
-    use super::SortedSetLengthByScoreRequest;
+    use super::{ScoreBound, SortedSetLengthByScoreRequest};
 
     #[tokio::test]
     async fn test_sorted_set_length_by_score_request_with_inclusive_scores() {
@@ -233,29 +217,25 @@ mod test {
 
         // Create the fetch request with options
         let fetch_request = SortedSetLengthByScoreRequest::new(cache_name, sorted_set_name)
-            .min_score(2.0)
-            .max_score(3.0);
+            .min_score(ScoreBound::Inclusive(2.0))
+            .max_score(ScoreBound::Inclusive(3.0));
 
         // Verify the built request
         assert_eq!(fetch_request.cache_name, cache_name);
         assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
-        assert_eq!(fetch_request.min_score, Some(2.0));
-        assert_eq!(fetch_request.min_score_exclusive, None);
-        assert_eq!(fetch_request.max_score, Some(3.0));
-        assert_eq!(fetch_request.max_score_exclusive, None);
+        assert_eq!(fetch_request.min_score, Some(ScoreBound::Inclusive(2.0)));
+        assert_eq!(fetch_request.max_score, Some(ScoreBound::Inclusive(3.0)));
 
         // Now pass in explicit Options to min score and max score
         let fetch_request = SortedSetLengthByScoreRequest::new(cache_name, sorted_set_name)
-            .min_score(Some(1.0))
-            .max_score(Some(5.0));
+            .min_score(ScoreBound::Inclusive(1.0))
+            .max_score(ScoreBound::Inclusive(5.0));
 
         // Verify the built request
         assert_eq!(fetch_request.cache_name, cache_name);
         assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
-        assert_eq!(fetch_request.min_score, Some(1.0));
-        assert_eq!(fetch_request.min_score_exclusive, None);
-        assert_eq!(fetch_request.max_score, Some(5.0));
-        assert_eq!(fetch_request.max_score_exclusive, None);
+        assert_eq!(fetch_request.min_score, Some(ScoreBound::Inclusive(1.0)));
+        assert_eq!(fetch_request.max_score, Some(ScoreBound::Inclusive(5.0)));
 
         // Now pass in explicit None to min score and max score
         let fetch_request = SortedSetLengthByScoreRequest::new(cache_name, sorted_set_name)
@@ -266,9 +246,7 @@ mod test {
         assert_eq!(fetch_request.cache_name, cache_name);
         assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
         assert_eq!(fetch_request.min_score, None);
-        assert_eq!(fetch_request.min_score_exclusive, None);
         assert_eq!(fetch_request.max_score, None);
-        assert_eq!(fetch_request.max_score_exclusive, None);
 
         // Now specify no extra options
         let fetch_request = SortedSetLengthByScoreRequest::new(cache_name, sorted_set_name);
@@ -277,9 +255,7 @@ mod test {
         assert_eq!(fetch_request.cache_name, cache_name);
         assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
         assert_eq!(fetch_request.min_score, None);
-        assert_eq!(fetch_request.min_score_exclusive, None);
         assert_eq!(fetch_request.max_score, None);
-        assert_eq!(fetch_request.max_score_exclusive, None);
     }
 
     #[tokio::test]
@@ -290,89 +266,24 @@ mod test {
 
         // Create the fetch request with options
         let fetch_request = SortedSetLengthByScoreRequest::new(cache_name, sorted_set_name)
-            .exclusive_min_score(2.0)
-            .exclusive_max_score(3.0);
+            .min_score(ScoreBound::Exclusive(2.0))
+            .max_score(ScoreBound::Exclusive(3.0));
 
         // Verify the built request
         assert_eq!(fetch_request.cache_name, cache_name);
         assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
-        assert_eq!(fetch_request.min_score, Some(2.0));
-        assert_eq!(fetch_request.min_score_exclusive, Some(true));
-        assert_eq!(fetch_request.max_score, Some(3.0));
-        assert_eq!(fetch_request.max_score_exclusive, Some(true));
+        assert_eq!(fetch_request.min_score, Some(ScoreBound::Exclusive(2.0)));
+        assert_eq!(fetch_request.max_score, Some(ScoreBound::Exclusive(3.0)));
 
         // Now pass in explicit Options to min score and max score
         let fetch_request = SortedSetLengthByScoreRequest::new(cache_name, sorted_set_name)
-            .exclusive_min_score(Some(1.0))
-            .exclusive_max_score(Some(5.0));
+            .min_score(ScoreBound::Exclusive(1.0))
+            .max_score(ScoreBound::Exclusive(5.0));
 
         // Verify the built request
         assert_eq!(fetch_request.cache_name, cache_name);
         assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
-        assert_eq!(fetch_request.min_score, Some(1.0));
-        assert_eq!(fetch_request.min_score_exclusive, Some(true));
-        assert_eq!(fetch_request.max_score, Some(5.0));
-        assert_eq!(fetch_request.max_score_exclusive, Some(true));
-
-        // Now pass in explicit None to min score and max score
-        let fetch_request = SortedSetLengthByScoreRequest::new(cache_name, sorted_set_name)
-            .exclusive_min_score(None)
-            .exclusive_max_score(None);
-
-        // Verify the built request
-        assert_eq!(fetch_request.cache_name, cache_name);
-        assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
-        assert_eq!(fetch_request.min_score, None);
-        assert_eq!(fetch_request.min_score_exclusive, None);
-        assert_eq!(fetch_request.max_score, None);
-        assert_eq!(fetch_request.max_score_exclusive, None);
-
-        // Now specify no extra options
-        let fetch_request = SortedSetLengthByScoreRequest::new(cache_name, sorted_set_name);
-
-        // Verify the built request
-        assert_eq!(fetch_request.cache_name, cache_name);
-        assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
-        assert_eq!(fetch_request.min_score, None);
-        assert_eq!(fetch_request.min_score_exclusive, None);
-        assert_eq!(fetch_request.max_score, None);
-        assert_eq!(fetch_request.max_score_exclusive, None);
-    }
-
-    #[tokio::test]
-    async fn test_sorted_set_length_by_score_request_with_conflicting_scores() {
-        // Define the cache name and sorted set name
-        let cache_name = "test_cache";
-        let sorted_set_name = "test_sorted_set";
-
-        // Create the fetch request with all score options, but only the last revisions should be used.
-        let fetch_request = SortedSetLengthByScoreRequest::new(cache_name, sorted_set_name)
-            .exclusive_min_score(4.0)
-            .exclusive_max_score(5.0)
-            .min_score(1.0)
-            .max_score(2.0);
-
-        // Verify the built request
-        assert_eq!(fetch_request.cache_name, cache_name);
-        assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
-        assert_eq!(fetch_request.min_score, Some(1.0));
-        assert_eq!(fetch_request.min_score_exclusive, None);
-        assert_eq!(fetch_request.max_score, Some(2.0));
-        assert_eq!(fetch_request.max_score_exclusive, None);
-
-        // Verify exclusive is used when order is switched.
-        let fetch_request = SortedSetLengthByScoreRequest::new(cache_name, sorted_set_name)
-            .min_score(1.0)
-            .max_score(2.0)
-            .exclusive_min_score(4.0)
-            .exclusive_max_score(5.0);
-
-        // Verify the built request
-        assert_eq!(fetch_request.cache_name, cache_name);
-        assert_eq!(fetch_request.sorted_set_name, sorted_set_name);
-        assert_eq!(fetch_request.min_score, Some(4.0));
-        assert_eq!(fetch_request.min_score_exclusive, Some(true));
-        assert_eq!(fetch_request.max_score, Some(5.0));
-        assert_eq!(fetch_request.max_score_exclusive, Some(true));
+        assert_eq!(fetch_request.min_score, Some(ScoreBound::Exclusive(1.0)));
+        assert_eq!(fetch_request.max_score, Some(ScoreBound::Exclusive(5.0)));
     }
 }

--- a/src/cache/messages/data/sorted_set/sorted_set_length_by_score.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_length_by_score.rs
@@ -6,18 +6,10 @@ use momento_protos::{
 };
 
 use crate::{
-    cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoError,
-    MomentoResult,
+    cache::{MomentoRequest, ScoreBound},
+    utils::prep_request_with_timeout,
+    CacheClient, IntoBytes, MomentoError, MomentoResult,
 };
-
-/// Boundary for a sorted set score range.
-#[derive(Debug, PartialEq, Clone)]
-pub enum ScoreBound {
-    /// Include the score in the range.
-    Inclusive(f64),
-    /// Exclude the score from the range.
-    Exclusive(f64),
-}
 
 /// Get the number of entries in a sorted set that fall between a minimum and maximum score.
 ///

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -94,7 +94,7 @@ pub use messages::data::sorted_set::sorted_set_length::{
     SortedSetLengthRequest, SortedSetLengthResponse,
 };
 pub use messages::data::sorted_set::sorted_set_length_by_score::{
-    SortedSetLengthByScoreRequest, SortedSetLengthByScoreResponse,
+    ScoreBound, SortedSetLengthByScoreRequest, SortedSetLengthByScoreResponse,
 };
 pub use messages::data::sorted_set::sorted_set_put_element::{
     SortedSetPutElementRequest, SortedSetPutElementResponse,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -71,9 +71,8 @@ pub use messages::data::set::set_remove_elements::{
     SetRemoveElementsRequest, SetRemoveElementsResponse,
 };
 
-pub use messages::data::sorted_set::sorted_set_fetch_by_rank::{
-    SortedSetFetchByRankRequest, SortedSetOrder,
-};
+pub use messages::data::sorted_set::sorted_set_common::{ScoreBound, SortedSetOrder};
+pub use messages::data::sorted_set::sorted_set_fetch_by_rank::SortedSetFetchByRankRequest;
 pub use messages::data::sorted_set::sorted_set_fetch_by_score::SortedSetFetchByScoreRequest;
 pub use messages::data::sorted_set::sorted_set_fetch_response::{
     SortedSetElements, SortedSetFetchResponse,
@@ -94,7 +93,7 @@ pub use messages::data::sorted_set::sorted_set_length::{
     SortedSetLengthRequest, SortedSetLengthResponse,
 };
 pub use messages::data::sorted_set::sorted_set_length_by_score::{
-    ScoreBound, SortedSetLengthByScoreRequest, SortedSetLengthByScoreResponse,
+    SortedSetLengthByScoreRequest, SortedSetLengthByScoreResponse,
 };
 pub use messages::data::sorted_set::sorted_set_put_element::{
     SortedSetPutElementRequest, SortedSetPutElementResponse,

--- a/tests/cache/sorted_set.rs
+++ b/tests/cache/sorted_set.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use momento::cache::{
-    IntoSortedSetElements, SortedSetAggregateFunction, SortedSetElement, SortedSetElements,
-    SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest, SortedSetFetchResponse,
-    SortedSetGetRankResponse, SortedSetGetScoreResponse, SortedSetLengthByScoreRequest,
-    SortedSetLengthByScoreResponse, SortedSetLengthResponse,
+    IntoSortedSetElements, ScoreBound, SortedSetAggregateFunction, SortedSetElement,
+    SortedSetElements, SortedSetFetchByRankRequest, SortedSetFetchByScoreRequest,
+    SortedSetFetchResponse, SortedSetGetRankResponse, SortedSetGetScoreResponse,
+    SortedSetLengthByScoreRequest, SortedSetLengthByScoreResponse, SortedSetLengthResponse,
     SortedSetOrder::{Ascending, Descending},
     SortedSetPutElementsResponse, SortedSetRemoveElementsResponse, SortedSetUnionStoreRequest,
     SortedSetUnionStoreResponse, SortedSetUnionStoreSource,
@@ -185,8 +185,8 @@ mod sorted_set_fetch_by_score {
         // Full set ascending, end score larger than set
         let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, item.name())
             .order(Ascending)
-            .min_score(0.0)
-            .max_score(9.9);
+            .min_score(ScoreBound::Inclusive(0.0))
+            .max_score(ScoreBound::Inclusive(9.9));
         let result = client.send_request(fetch_request).await?;
         assert_fetched_sorted_set_eq(
             result,
@@ -202,7 +202,7 @@ mod sorted_set_fetch_by_score {
         // Up until score 1.0 (inclusive)
         let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, item.name())
             .order(Ascending)
-            .max_score(1.0);
+            .max_score(ScoreBound::Inclusive(1.0));
         let result = client.send_request(fetch_request).await?;
         assert_fetched_sorted_set_eq(
             result,
@@ -216,14 +216,14 @@ mod sorted_set_fetch_by_score {
         // Up until score 1.0 (exclusive)
         let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, item.name())
             .order(Ascending)
-            .exclusive_max_score(1.0);
+            .max_score(ScoreBound::Exclusive(1.0));
         let result = client.send_request(fetch_request).await?;
         assert_fetched_sorted_set_eq(result, vec![("1".to_string(), 0.0), ("3".to_string(), 0.5)])?;
 
         // From score 1.0 (inclusive)
         let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, item.name())
             .order(Ascending)
-            .min_score(1.0);
+            .min_score(ScoreBound::Inclusive(1.0));
         let result = client.send_request(fetch_request).await?;
         assert_fetched_sorted_set_eq(
             result,
@@ -237,15 +237,15 @@ mod sorted_set_fetch_by_score {
         // From score 1.0 (exclusive)
         let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, item.name())
             .order(Ascending)
-            .exclusive_min_score(1.0);
+            .min_score(ScoreBound::Exclusive(1.0));
         let result = client.send_request(fetch_request).await?;
         assert_fetched_sorted_set_eq(result, vec![("5".to_string(), 1.5), ("4".to_string(), 2.0)])?;
 
         // Partial set descending
         let fetch_request = SortedSetFetchByScoreRequest::new(cache_name, item.name())
             .order(Descending)
-            .min_score(0.1)
-            .max_score(1.9);
+            .min_score(ScoreBound::Inclusive(0.1))
+            .max_score(ScoreBound::Inclusive(1.9));
         let result = client.send_request(fetch_request).await?;
         assert_fetched_sorted_set_eq(
             result,
@@ -829,15 +829,15 @@ mod sorted_set_length_by_score {
 
         // Nonzero length after specifying inclusive min and max score
         let request = SortedSetLengthByScoreRequest::new(cache_name, item.name())
-            .min_score(0.0)
-            .max_score(2.0);
+            .min_score(ScoreBound::Inclusive(0.0))
+            .max_score(ScoreBound::Inclusive(2.0));
         let result = client.send_request(request).await?;
         assert_eq!(result, SortedSetLengthByScoreResponse::Hit { length: 2 });
 
         // Nonzero length after specifying exclusive min and max score
         let request = SortedSetLengthByScoreRequest::new(cache_name, item.name())
-            .exclusive_min_score(0.0)
-            .exclusive_max_score(2.0);
+            .min_score(ScoreBound::Exclusive(0.0))
+            .max_score(ScoreBound::Exclusive(2.0));
         let result = client.send_request(request).await?;
         assert_eq!(result, SortedSetLengthByScoreResponse::Hit { length: 1 });
 


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1230

Exposing support for exclusive min/max scores for `sorted_set_fetch_by_score` and `sorted_set_length_by_score`, which is needed for momento proxy.

Introduces a `ScoreBound` enum to specify inclusive or exclusive bounds.