### PR TITLE
chore: add functions rpcs

### DIFF
--- a/src/functions/messages/list_function_versions.rs
+++ b/src/functions/messages/list_function_versions.rs
@@ -32,7 +32,7 @@ pub struct ListFunctionVersionsRequest {
 }
 
 impl ListFunctionVersionsRequest {
-    /// Create a new ListFunctionsRequest.
+    /// Create a new ListFunctionVersionsRequest.
     pub fn new(cache_name: impl Into<String>) -> Self {
         Self {
             function_id: cache_name.into(),

--- a/src/functions/messages/list_function_versions.rs
+++ b/src/functions/messages/list_function_versions.rs
@@ -1,0 +1,92 @@
+use std::time::Duration;
+
+use futures::StreamExt;
+
+use crate::{
+    functions::{function::FunctionVersion, FunctionClient, MomentoRequest},
+    utils::prep_request_with_timeout,
+    MomentoError, MomentoResult,
+};
+
+/// List the Functions within a cache namespace.
+///
+/// # Example
+///
+/// ```rust
+/// # fn main() -> anyhow::Result<()> {
+/// # tokio_test::block_on(async {
+/// use momento::{CredentialProvider, FunctionClient};
+/// use momento::functions::ListFunctionVersionsRequest;
+/// use futures::StreamExt;
+/// # let (function_client, cache_name) = momento_test_util::create_doctest_function_client();
+///
+/// let request = ListFunctionVersionsRequest::new("function-id");
+/// let versions = function_client.send(request).await?.collect::<Vec<_>>();
+/// println!("Function versions: {versions:?}");
+/// # Ok(())
+/// # })
+/// # }
+/// ```
+pub struct ListFunctionVersionsRequest {
+    function_id: String,
+}
+
+impl ListFunctionVersionsRequest {
+    /// Create a new ListFunctionsRequest.
+    pub fn new(cache_name: impl Into<String>) -> Self {
+        Self {
+            function_id: cache_name.into(),
+        }
+    }
+}
+
+impl MomentoRequest for ListFunctionVersionsRequest {
+    type Response = ListFunctionVersionsStream;
+
+    async fn send(self, client: &FunctionClient) -> MomentoResult<Self::Response> {
+        let request = prep_request_with_timeout(
+            &self.function_id.to_string(),
+            Duration::from_secs(15),
+            momento_protos::function::ListFunctionVersionsRequest {
+                function_id: self.function_id,
+            },
+        )?;
+
+        let response = client
+            .client()
+            .clone()
+            .list_function_versions(request)
+            .await?;
+        Ok(ListFunctionVersionsStream::new(response.into_inner()))
+    }
+}
+
+/// A stream of responses from a ListFunctionsRequest.
+/// You can iterate the stream or collect it into a Vec using `futures::StreamExt`.
+#[derive(Debug)]
+pub struct ListFunctionVersionsStream {
+    stream: tonic::Streaming<momento_protos::function_types::FunctionVersion>,
+}
+impl ListFunctionVersionsStream {
+    /// Create a new Stream from a tonic Streaming object.
+    pub(crate) fn new(
+        stream: tonic::Streaming<momento_protos::function_types::FunctionVersion>,
+    ) -> Self {
+        Self { stream }
+    }
+}
+
+impl futures::Stream for ListFunctionVersionsStream {
+    type Item = MomentoResult<FunctionVersion>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        context: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        match futures::ready!(self.stream.poll_next_unpin(context)) {
+            Some(Ok(item)) => std::task::Poll::Ready(Some(Ok(item.into()))),
+            Some(Err(e)) => std::task::Poll::Ready(Some(Err(MomentoError::from(e)))),
+            None => std::task::Poll::Ready(None),
+        }
+    }
+}

--- a/src/functions/messages/list_function_versions.rs
+++ b/src/functions/messages/list_function_versions.rs
@@ -61,7 +61,7 @@ impl MomentoRequest for ListFunctionVersionsRequest {
     }
 }
 
-/// A stream of responses from a ListFunctionsRequest.
+/// A stream of responses from a ListFunctionVersionsRequest.
 /// You can iterate the stream or collect it into a Vec using `futures::StreamExt`.
 #[derive(Debug)]
 pub struct ListFunctionVersionsStream {

--- a/src/functions/messages/list_functions.rs
+++ b/src/functions/messages/list_functions.rs
@@ -1,0 +1,86 @@
+use std::time::Duration;
+
+use futures::StreamExt;
+
+use crate::{
+    functions::{Function, FunctionClient, MomentoRequest},
+    utils::prep_request_with_timeout,
+    MomentoError, MomentoResult,
+};
+
+/// List the Functions within a cache namespace.
+///
+/// # Example
+///
+/// ```rust
+/// # fn main() -> anyhow::Result<()> {
+/// # tokio_test::block_on(async {
+/// use momento::{CredentialProvider, FunctionClient};
+/// use momento::functions::ListFunctionsRequest;
+/// use futures::StreamExt;
+/// # let (function_client, cache_name) = momento_test_util::create_doctest_function_client();
+///
+/// let request = ListFunctionsRequest::new(cache_name);
+/// let functions = function_client.send(request).await?.collect::<Vec<_>>();
+/// println!("Functions: {functions:?}");
+/// # Ok(())
+/// # })
+/// # }
+/// ```
+pub struct ListFunctionsRequest {
+    cache_name: String,
+}
+
+impl ListFunctionsRequest {
+    /// Create a new ListFunctionsRequest.
+    pub fn new(cache_name: impl Into<String>) -> Self {
+        Self {
+            cache_name: cache_name.into(),
+        }
+    }
+}
+
+impl MomentoRequest for ListFunctionsRequest {
+    type Response = ListFunctionsStream;
+
+    async fn send(self, client: &FunctionClient) -> MomentoResult<Self::Response> {
+        let request = prep_request_with_timeout(
+            &self.cache_name.to_string(),
+            Duration::from_secs(15),
+            momento_protos::function::ListFunctionsRequest {
+                cache_name: self.cache_name,
+            },
+        )?;
+
+        let response = client.client().clone().list_functions(request).await?;
+        Ok(ListFunctionsStream::new(response.into_inner()))
+    }
+}
+
+/// A stream of responses from a ListFunctionsRequest.
+/// You can iterate the stream or collect it into a Vec using `futures::StreamExt`.
+#[derive(Debug)]
+pub struct ListFunctionsStream {
+    stream: tonic::Streaming<momento_protos::function_types::Function>,
+}
+impl ListFunctionsStream {
+    /// Create a new Stream from a tonic Streaming object.
+    pub(crate) fn new(stream: tonic::Streaming<momento_protos::function_types::Function>) -> Self {
+        Self { stream }
+    }
+}
+
+impl futures::Stream for ListFunctionsStream {
+    type Item = MomentoResult<Function>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        context: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        match futures::ready!(self.stream.poll_next_unpin(context)) {
+            Some(Ok(item)) => std::task::Poll::Ready(Some(Ok(item.into()))),
+            Some(Err(e)) => std::task::Poll::Ready(Some(Err(MomentoError::from(e)))),
+            None => std::task::Poll::Ready(None),
+        }
+    }
+}

--- a/src/functions/messages/list_wasms.rs
+++ b/src/functions/messages/list_wasms.rs
@@ -51,7 +51,7 @@ impl MomentoRequest for ListWasmsRequest {
     }
 }
 
-/// A stream of responses from a ListFunctionsRequest.
+/// A stream of responses from a ListWasmsRequest.
 /// You can iterate the stream or collect it into a Vec using `futures::StreamExt`.
 #[derive(Debug)]
 pub struct ListWasmsStream {

--- a/src/functions/messages/list_wasms.rs
+++ b/src/functions/messages/list_wasms.rs
@@ -1,0 +1,81 @@
+use std::time::Duration;
+
+use futures::StreamExt;
+
+use crate::{
+    functions::{FunctionClient, MomentoRequest, Wasm},
+    utils::prep_request_with_timeout,
+    MomentoError, MomentoResult,
+};
+
+/// List the wasm archives you have.
+///
+/// # Example
+///
+/// ```rust
+/// # fn main() -> anyhow::Result<()> {
+/// # tokio_test::block_on(async {
+/// use momento::{CredentialProvider, FunctionClient};
+/// use momento::functions::ListWasmsRequest;
+/// use futures::StreamExt;
+/// # let (function_client, cache_name) = momento_test_util::create_doctest_function_client();
+///
+/// let request = ListWasmsRequest::new();
+/// let wasms = function_client.send(request).await?.collect::<Vec<_>>();
+/// println!("Wasms: {wasms:?}");
+/// # Ok(())
+/// # })
+/// # }
+/// ```
+pub struct ListWasmsRequest {}
+
+impl ListWasmsRequest {
+    /// Create a new ListFunctionsRequest.
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl MomentoRequest for ListWasmsRequest {
+    type Response = ListWasmsStream;
+
+    async fn send(self, client: &FunctionClient) -> MomentoResult<Self::Response> {
+        let request = prep_request_with_timeout(
+            "inapplicable",
+            Duration::from_secs(15),
+            momento_protos::function::ListWasmsRequest {},
+        )?;
+
+        let response = client.client().clone().list_wasms(request).await?;
+        Ok(ListWasmsStream::new(response.into_inner()))
+    }
+}
+
+/// A stream of responses from a ListFunctionsRequest.
+/// You can iterate the stream or collect it into a Vec using `futures::StreamExt`.
+#[derive(Debug)]
+pub struct ListWasmsStream {
+    stream: tonic::Streaming<momento_protos::function_types::Wasm>,
+}
+impl ListWasmsStream {
+    /// Create a new Stream from a tonic Streaming object.
+    pub(crate) fn new(stream: tonic::Streaming<momento_protos::function_types::Wasm>) -> Self {
+        Self { stream }
+    }
+}
+
+impl futures::Stream for ListWasmsStream {
+    type Item = MomentoResult<Wasm>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        context: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        match futures::ready!(self.stream.poll_next_unpin(context)) {
+            Some(Ok(item)) => std::task::Poll::Ready(Some(Ok(item.into()))),
+            Some(Err(e)) => std::task::Poll::Ready(Some(Err(MomentoError::from(e)))),
+            None => std::task::Poll::Ready(None),
+        }
+    }
+}

--- a/src/functions/messages/list_wasms.rs
+++ b/src/functions/messages/list_wasms.rs
@@ -29,7 +29,7 @@ use crate::{
 pub struct ListWasmsRequest {}
 
 impl ListWasmsRequest {
-    /// Create a new ListFunctionsRequest.
+    /// Create a new ListWasmsRequest.
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {}

--- a/src/functions/messages/mod.rs
+++ b/src/functions/messages/mod.rs
@@ -1,5 +1,13 @@
+mod list_function_versions;
+mod list_functions;
+mod list_wasms;
 mod momento_request;
 mod put_function;
+mod put_wasm;
 
+pub use list_function_versions::{ListFunctionVersionsRequest, ListFunctionVersionsStream};
+pub use list_functions::{ListFunctionsRequest, ListFunctionsStream};
+pub use list_wasms::{ListWasmsRequest, ListWasmsStream};
 pub use momento_request::MomentoRequest;
 pub use put_function::PutFunctionRequest;
+pub use put_wasm::PutWasmRequest;

--- a/src/functions/messages/put_wasm.rs
+++ b/src/functions/messages/put_wasm.rs
@@ -1,0 +1,85 @@
+use std::time::Duration;
+
+use crate::{
+    functions::{FunctionClient, MomentoRequest, Wasm},
+    utils::prep_request_with_timeout,
+    MomentoError, MomentoResult,
+};
+
+/// Create or update a wasm.
+/// This doesn't create a Function, but rather a wasm archive that can be used in a Function.
+///
+/// # Example
+///
+/// ```rust
+/// # fn main() -> anyhow::Result<()> {
+/// # tokio_test::block_on(async {
+/// use momento::{CredentialProvider, FunctionClient};
+/// use momento::functions::PutWasmRequest;
+/// # use momento_test_util::echo_wasm;
+/// # let (function_client, cache_name) = momento_test_util::create_doctest_function_client();
+/// // load your wasm from a .wasm file compiled with wasm32-wasip2
+/// let function_body = echo_wasm();
+///
+/// let request = PutWasmRequest::new(cache_name, function_body);
+/// let wasm = function_client.send(request).await?;
+/// println!("Created a wasm: {wasm:?}");
+/// # Ok(())
+/// # })
+/// # }
+/// ```
+pub struct PutWasmRequest {
+    wasm_name: String,
+    description: String,
+    wasm_source: Vec<u8>,
+}
+
+impl PutWasmRequest {
+    /// Create a new PublishRequest.
+    pub fn new(wasm_name: impl Into<String>, wasm_source: impl Into<Vec<u8>>) -> Self {
+        Self {
+            wasm_name: wasm_name.into(),
+            description: String::new(),
+            wasm_source: wasm_source.into(),
+        }
+    }
+
+    /// Set the Function's description
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = description.into();
+        self
+    }
+}
+
+impl MomentoRequest for PutWasmRequest {
+    type Response = Wasm;
+
+    async fn send(self, client: &FunctionClient) -> MomentoResult<Self::Response> {
+        let request = prep_request_with_timeout(
+            "inapplicable",
+            Duration::from_secs(15),
+            momento_protos::function::PutWasmRequest {
+                name: self.wasm_name,
+                description: self.description,
+                wasm_put_kind: Some(
+                    momento_protos::function::put_wasm_request::WasmPutKind::Inline(
+                        self.wasm_source,
+                    ),
+                ),
+            },
+        )?;
+
+        let response = client.client().clone().put_wasm(request).await?;
+        let wasm: Wasm = response
+            .into_inner()
+            .wasm
+            .ok_or_else(|| {
+                MomentoError::unknown_error(
+                    "put_wasm",
+                    Some("service did not return a wasm description".to_string()),
+                )
+            })?
+            .into();
+        Ok(wasm)
+    }
+}

--- a/src/functions/messages/put_wasm.rs
+++ b/src/functions/messages/put_wasm.rs
@@ -35,7 +35,7 @@ pub struct PutWasmRequest {
 }
 
 impl PutWasmRequest {
-    /// Create a new PublishRequest.
+    /// Create a new PutWasmRequest.
     pub fn new(wasm_name: impl Into<String>, wasm_source: impl Into<Vec<u8>>) -> Self {
         Self {
             wasm_name: wasm_name.into(),

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -5,7 +5,13 @@ mod function_client;
 mod function_client_builder;
 mod messages;
 
-pub use function::{EnvironmentValue, Function, WasmSource};
+pub use function::{
+    EnvironmentValue, Function, FunctionVersion, FunctionVersionId, Wasm, WasmSource, WasmVersionId,
+};
 pub use function_client::FunctionClient;
 pub use function_client_builder::FunctionClientBuilder;
-pub use messages::{MomentoRequest, PutFunctionRequest};
+pub use messages::{
+    ListFunctionVersionsRequest, ListFunctionVersionsStream, ListFunctionsRequest,
+    ListFunctionsStream, ListWasmsRequest, ListWasmsStream, MomentoRequest, PutFunctionRequest,
+    PutWasmRequest,
+};


### PR DESCRIPTION
boilerplate to add these rpcs:

list_function_versions
list_functions
list_wasms
put_wasm

Since the list* rpcs are streaming, I wrote stream response types
for each, to keep things static and clean-looking.
