### PR TITLE
feat: protosocket with tls and connection pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,17 +236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bb8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d8b8e1a22743d9241575c6ba822cf9c8fef34771c86ab7e477a4fbfd254e5"
-dependencies = [
- "futures-util",
- "parking_lot",
- "tokio",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libloading"
@@ -858,7 +847,6 @@ dependencies = [
  "anyhow",
  "base64",
  "base64-url",
- "bb8",
  "derive_more",
  "env_logger",
  "futures",
@@ -867,7 +855,7 @@ dependencies = [
  "log",
  "momento-protos",
  "momento-test-util",
- "protosocket 0.9.0",
+ "protosocket",
  "protosocket-prost",
  "protosocket-rpc",
  "rand",
@@ -884,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "momento-protos"
-version = "0.127.2"
+version = "0.127.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6fc8ff84d20ee53b20b71986fa98ec1a7c55f2622bc8bd0d10f50ab470eef8"
+checksum = "be2b09b8df95deb923a28d60506e3a8b37c7507046cdf9a367b470c75a5ddbff"
 dependencies = [
  "prost",
  "protosocket-rpc",
@@ -1071,23 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "protosocket"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ba254fa72615bfeaf1ef7515735726764657775fc340623fe1388468f62239"
-dependencies = [
- "bytes",
- "futures",
- "log",
- "thiserror 1.0.69",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "protosocket"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75769d64f845347af49a595b19838ab3bdea21ee629216adde5219962dd2e13a"
+checksum = "5fbf8b19016c53102de17972e1d069913029c684155c07fa62ad6c4928219081"
 dependencies = [
  "bytes",
  "futures",
@@ -1099,28 +1073,29 @@ dependencies = [
 
 [[package]]
 name = "protosocket-prost"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "530a1f6a35d3686ef7e58675ef768af94efb4aa119765a04fbeb32d4fd132fda"
+checksum = "ccde7a2d275d23e3450f5ff09da0b9faa5b33c31f00fa13a3cb93a85d7730d63"
 dependencies = [
  "bytes",
  "log",
  "prost",
- "protosocket 0.10.0",
+ "protosocket",
  "thiserror 1.0.69",
  "tokio",
 ]
 
 [[package]]
 name = "protosocket-rpc"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c8022612cf26d9e1f1d483b470e4beaf46bce366f8bdfb44abf7c363b95fb"
+checksum = "f74c2a60d26c35244a8802659c130e8989aca23a5f2c65127a8d68448a8ca088"
 dependencies = [
  "futures",
  "k-lock",
  "log",
- "protosocket 0.10.0",
+ "protosocket",
+ "rand",
  "rustls-pki-types",
  "socket2 0.6.0",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,7 +864,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
- "tokio-rustls",
  "tokio-test",
  "tonic",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bb8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d8b8e1a22743d9241575c6ba822cf9c8fef34771c86ab7e477a4fbfd254e5"
+dependencies = [
+ "futures-util",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,7 +664,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -847,6 +858,7 @@ dependencies = [
  "anyhow",
  "base64",
  "base64-url",
+ "bb8",
  "derive_more",
  "env_logger",
  "futures",
@@ -855,7 +867,7 @@ dependencies = [
  "log",
  "momento-protos",
  "momento-test-util",
- "protosocket",
+ "protosocket 0.9.0",
  "protosocket-prost",
  "protosocket-rpc",
  "rand",
@@ -872,8 +884,9 @@ dependencies = [
 
 [[package]]
 name = "momento-protos"
-version = "0.1.0"
-source = "git+https://github.com/momentohq/client-protos.git?branch=chore%2Fpin-protosocket#ce968ac4ddb979f1a4b3d454594a5b05b7b4df84"
+version = "0.127.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6fc8ff84d20ee53b20b71986fa98ec1a7c55f2622bc8bd0d10f50ab470eef8"
 dependencies = [
  "prost",
  "protosocket-rpc",
@@ -1058,8 +1071,23 @@ dependencies = [
 
 [[package]]
 name = "protosocket"
-version = "0.8.0"
-source = "git+https://github.com/kvc0/protosocket.git?rev=c9d7a186b#c9d7a186b9fb8d5c186dcb79791b8979151fb545"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81ba254fa72615bfeaf1ef7515735726764657775fc340623fe1388468f62239"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "protosocket"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75769d64f845347af49a595b19838ab3bdea21ee629216adde5219962dd2e13a"
 dependencies = [
  "bytes",
  "futures",
@@ -1071,27 +1099,30 @@ dependencies = [
 
 [[package]]
 name = "protosocket-prost"
-version = "0.8.0"
-source = "git+https://github.com/kvc0/protosocket.git?rev=c9d7a186b#c9d7a186b9fb8d5c186dcb79791b8979151fb545"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "530a1f6a35d3686ef7e58675ef768af94efb4aa119765a04fbeb32d4fd132fda"
 dependencies = [
  "bytes",
  "log",
  "prost",
- "protosocket",
+ "protosocket 0.10.0",
  "thiserror 1.0.69",
  "tokio",
 ]
 
 [[package]]
 name = "protosocket-rpc"
-version = "0.8.0"
-source = "git+https://github.com/kvc0/protosocket.git?rev=c9d7a186b#c9d7a186b9fb8d5c186dcb79791b8979151fb545"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2c8022612cf26d9e1f1d483b470e4beaf46bce366f8bdfb44abf7c363b95fb"
 dependencies = [
  "futures",
  "k-lock",
  "log",
- "protosocket",
+ "protosocket 0.10.0",
  "rustls-pki-types",
+ "socket2 0.6.0",
  "thiserror 1.0.69",
  "tokio",
  "tokio-rustls",
@@ -1338,6 +1369,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,7 +1456,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -1498,7 +1539,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tokio-rustls",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b8ff6c09cd57b16da53641caa860168b88c172a5ee163b0288d3d6eea12786"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e44d16778acaf6a9ec9899b92cebd65580b83f685446bf2e1f5d3d732f99dcd"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +236,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,10 +285,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -283,6 +355,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -324,6 +402,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -442,6 +526,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -598,6 +688,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -672,6 +771,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +813,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -744,10 +859,12 @@ dependencies = [
  "protosocket-prost",
  "protosocket-rpc",
  "rand",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-rustls",
  "tokio-test",
  "tonic",
  "uuid",
@@ -756,9 +873,8 @@ dependencies = [
 
 [[package]]
 name = "momento-protos"
-version = "0.127.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c49bdf3b4938d4249bd0010c3ef39ec9cde45aebdd697a32bf7fbe0a0d2f395"
+version = "0.1.0"
+source = "git+https://github.com/momentohq/client-protos.git?branch=chore%2Fpin-protosocket#ce968ac4ddb979f1a4b3d454594a5b05b7b4df84"
 dependencies = [
  "prost",
  "protosocket-rpc",
@@ -775,6 +891,16 @@ dependencies = [
  "scopeguard",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -890,6 +1016,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,7 +1051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -924,8 +1060,7 @@ dependencies = [
 [[package]]
 name = "protosocket"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "073f39accdeb6f1b0368905d1b9de629193c363e1b4c1335ca239c119ebdc3e1"
+source = "git+https://github.com/kvc0/protosocket.git?rev=c9d7a186b#c9d7a186b9fb8d5c186dcb79791b8979151fb545"
 dependencies = [
  "bytes",
  "futures",
@@ -938,8 +1073,7 @@ dependencies = [
 [[package]]
 name = "protosocket-prost"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb7cb2eff7fcd6c6e65ac292bfdc6e83cbca48e5adf8d4bf5e9aa1969f9d45e"
+source = "git+https://github.com/kvc0/protosocket.git?rev=c9d7a186b#c9d7a186b9fb8d5c186dcb79791b8979151fb545"
 dependencies = [
  "bytes",
  "log",
@@ -952,16 +1086,18 @@ dependencies = [
 [[package]]
 name = "protosocket-rpc"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aadd0055bcec8a5ed0a421863746a1bcc245422a829547a5cca38222f05d9f"
+source = "git+https://github.com/kvc0/protosocket.git?rev=c9d7a186b#c9d7a186b9fb8d5c186dcb79791b8979151fb545"
 dependencies = [
  "futures",
  "k-lock",
  "log",
  "protosocket",
+ "rustls-pki-types",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
@@ -1073,11 +1209,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustls"
 version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -1102,6 +1245,7 @@ version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.13", features = ["tls-ring", "tls-webpki-roots"] }
 zstd = "0.13.3"
 rustls-pki-types = "1"
-tokio-rustls = { version = "0.26" }
 
 [dev-dependencies]
 momento-test-util = { path = "test-util" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,19 +31,16 @@ doc = false
 
 
 [dependencies]
-momento-protos = { git = "https://github.com/momentohq/client-protos.git", branch = "chore/pin-protosocket" }
-# momento-protos = { git = "https://github.com/momentohq/client-protos.git", rev = "ce968ac4ddb979f1a4b3d454594a5b05b7b4df84" }
-
+momento-protos = "0.127.2"
 base64 = "0.22"
 derive_more = { version = "2.0.1", features = ["full"] }
 futures = "0"
 h2 = { version = "0.4" }
 hyper = { version = "1.6" }
 log = "0.4"
-# TODO: revert back to released versions
-protosocket             = { git = "https://github.com/kvc0/protosocket.git", rev = "c9d7a186b" }
-protosocket-prost       = { git = "https://github.com/kvc0/protosocket.git", rev = "c9d7a186b" }
-protosocket-rpc = { git = "https://github.com/kvc0/protosocket.git", rev = "c9d7a186b" }
+protosocket = "0.9.0"
+protosocket-prost = "0.9.0"
+protosocket-rpc = "0.9.0"
 rand = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -52,6 +49,7 @@ tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.13", features = ["tls-ring", "tls-webpki-roots"] }
 zstd = "0.13.3"
 rustls-pki-types = "1"
+bb8 = "0.9.0"
 
 [dev-dependencies]
 momento-test-util = { path = "test-util" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,8 @@ doc = false
 
 
 [dependencies]
-momento-protos = "0.127.1"
+momento-protos = { git = "https://github.com/momentohq/client-protos.git", branch = "chore/pin-protosocket" }
+# momento-protos = { git = "https://github.com/momentohq/client-protos.git", rev = "ce968ac4ddb979f1a4b3d454594a5b05b7b4df84" }
 
 base64 = "0.22"
 derive_more = { version = "2.0.1", features = ["full"] }
@@ -39,9 +40,10 @@ futures = "0"
 h2 = { version = "0.4" }
 hyper = { version = "1.6" }
 log = "0.4"
-protosocket = "0"
-protosocket-prost = "0"
-protosocket-rpc = "0"
+# TODO: revert back to released versions
+protosocket             = { git = "https://github.com/kvc0/protosocket.git", rev = "c9d7a186b" }
+protosocket-prost       = { git = "https://github.com/kvc0/protosocket.git", rev = "c9d7a186b" }
+protosocket-rpc = { git = "https://github.com/kvc0/protosocket.git", rev = "c9d7a186b" }
 rand = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -49,6 +51,8 @@ thiserror = "2.0"
 tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.13", features = ["tls-ring", "tls-webpki-roots"] }
 zstd = "0.13.3"
+rustls-pki-types = "1.12.0"
+tokio-rustls = { version = "0.26" }
 
 [dev-dependencies]
 momento-test-util = { path = "test-util" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ thiserror = "2.0"
 tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.13", features = ["tls-ring", "tls-webpki-roots"] }
 zstd = "0.13.3"
-rustls-pki-types = "1.12.0"
+rustls-pki-types = "1"
 tokio-rustls = { version = "0.26" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,16 +31,16 @@ doc = false
 
 
 [dependencies]
-momento-protos = "0.127.2"
+momento-protos = "0.127.3"
 base64 = "0.22"
 derive_more = { version = "2.0.1", features = ["full"] }
 futures = "0"
 h2 = { version = "0.4" }
 hyper = { version = "1.6" }
 log = "0.4"
-protosocket = "0.9.0"
-protosocket-prost = "0.9.0"
-protosocket-rpc = "0.9.0"
+protosocket = "0.11.0"
+protosocket-prost = "0.11.0"
+protosocket-rpc = "0.11.0"
 rand = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -49,7 +49,6 @@ tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.13", features = ["tls-ring", "tls-webpki-roots"] }
 zstd = "0.13.3"
 rustls-pki-types = "1"
-bb8 = "0.9.0"
 
 [dev-dependencies]
 momento-test-util = { path = "test-util" }

--- a/src/credential_provider.rs
+++ b/src/credential_provider.rs
@@ -11,6 +11,13 @@ struct V1Token {
     pub endpoint: String,
 }
 
+#[derive(PartialEq, Eq, Clone)]
+pub(crate) enum EndpointSecurity {
+    Insecure,
+    Unverified,
+    Tls,
+}
+
 /// Provides information that the client needs in order to establish a connection to and
 /// authenticate with the Momento service.
 #[derive(PartialEq, Eq, Clone)]
@@ -19,6 +26,7 @@ pub struct CredentialProvider {
     pub(crate) control_endpoint: String,
     pub(crate) cache_endpoint: String,
     pub(crate) token_endpoint: String,
+    pub(crate) endpoint_security: EndpointSecurity,
 }
 
 impl Display for CredentialProvider {
@@ -133,6 +141,24 @@ impl CredentialProvider {
         self.token_endpoint = endpoint.to_string();
         self
     }
+
+    /// Allows the user to set a non-TLS endpoint for the control, cache, and token endpoints
+    pub fn insecure_endpoint_override(mut self, endpoint: &str) -> CredentialProvider {
+        self.control_endpoint = endpoint.to_string();
+        self.cache_endpoint = endpoint.to_string();
+        self.token_endpoint = endpoint.to_string();
+        self.endpoint_security = EndpointSecurity::Insecure;
+        self
+    }
+
+    /// Allows the user to set an unverified TLS endpoint for the control, cache, and token endpoints
+    pub fn unverified_tls_endpoint_override(mut self, endpoint: &str) -> CredentialProvider {
+        self.control_endpoint = endpoint.to_string();
+        self.cache_endpoint = endpoint.to_string();
+        self.token_endpoint = endpoint.to_string();
+        self.endpoint_security = EndpointSecurity::Unverified;
+        self
+    }
 }
 
 fn decode_auth_token(auth_token: String) -> MomentoResult<CredentialProvider> {
@@ -151,6 +177,7 @@ fn process_v1_token(auth_token_bytes: Vec<u8>) -> MomentoResult<CredentialProvid
         cache_endpoint: https_endpoint(get_cache_endpoint(&json.endpoint)),
         control_endpoint: https_endpoint(get_control_endpoint(&json.endpoint)),
         token_endpoint: https_endpoint(get_token_endpoint(&json.endpoint)),
+        endpoint_security: EndpointSecurity::Tls,
     })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,5 +153,6 @@ pub use functions::FunctionClient;
 /// Contains the [ProtosocketCacheClient] for interacting with Momento Cache using the Protosocket protocol.
 pub mod protosocket;
 pub use protosocket::cache::{
-    ProtosocketCacheClient, ProtosocketCacheClientBuilder, ReadyToAuthenticate,
+    ProtosocketCacheClient, ProtosocketCacheClientBuilder,
+    ReadyToBuild as ProtosocketClientReadyToBuild,
 };

--- a/src/protosocket/cache/cache_client.rs
+++ b/src/protosocket/cache/cache_client.rs
@@ -36,8 +36,6 @@ use std::time::Duration;
 ///     )
 ///     .runtime(tokio::runtime::Handle::current())
 ///     .build()
-///     .await?
-///     .authenticate()
 ///     .await
 /// {
 ///     Ok(client) => client,
@@ -95,8 +93,6 @@ impl ProtosocketCacheClient {
     ///     )
     ///     .runtime(tokio::runtime::Handle::current())
     ///     .build()
-    ///     .await?
-    ///     .authenticate()
     ///     .await
     /// {
     ///     Ok(client) => client,

--- a/src/protosocket/cache/cache_client.rs
+++ b/src/protosocket/cache/cache_client.rs
@@ -203,24 +203,12 @@ impl ProtosocketCacheClient {
     }
 
     pub(crate) async fn protosocket_connection(&self) -> MomentoResult<ProtosocketConnection> {
-        // how long does it take to get the client?
-        // let start_time = std::time::Instant::now();
-
         let pooled_client = self
             .client_pool
             .get()
             .await
             .map_err(|e| MomentoError::unknown_error("get_client", Some(e.to_string())))?;
-        let client = pooled_client.clone();
-
-        // let end_time = std::time::Instant::now();
-        // log::info!(
-        //     "Time taken to get client with ID {}: {:?}",
-        //     client.id(),
-        //     end_time.duration_since(start_time)
-        // );
-
-        Ok(client)
+        Ok(pooled_client.clone())
     }
 
     pub(crate) fn expand_ttl_ms(&self, ttl: Option<Duration>) -> MomentoResult<u64> {

--- a/src/protosocket/cache/cache_client.rs
+++ b/src/protosocket/cache/cache_client.rs
@@ -137,7 +137,7 @@ impl ProtosocketCacheClient {
     ///
     /// For more examples of handling the response, see [GetResponse](crate::cache::GetResponse).
     pub async fn get(
-        &mut self,
+        &self,
         cache_name: impl Into<String>,
         key: impl IntoBytes,
     ) -> MomentoResult<crate::cache::GetResponse> {
@@ -184,7 +184,7 @@ impl ProtosocketCacheClient {
     /// You can also use the [send_request](ProtosocketCacheClient::send_request) method to get an item using a [SetRequest]
     /// which will allow you to set [optional arguments](crate::cache::SetRequest#optional-arguments) as well.
     pub async fn set(
-        &mut self,
+        &self,
         cache_name: impl Into<String>,
         key: impl IntoBytes,
         value: impl IntoBytes,

--- a/src/protosocket/cache/cache_client_builder.rs
+++ b/src/protosocket/cache/cache_client_builder.rs
@@ -104,25 +104,8 @@ impl ProtosocketCacheClientBuilder<NeedsRuntime> {
 impl ProtosocketCacheClientBuilder<ReadyToBuild> {
     /// Constructs a new CacheClientBuilder in the ReadyToBuild state.
     pub async fn build(self) -> MomentoResult<ProtosocketCacheClient> {
-        // let unauthenticated_client = create_protosocket_connection(
-        //     self.0.credential_provider.clone(),
-        //     self.0.runtime.clone(),
-        // )
-        // .await?;
-
-        // let (client, message_id) = authenticate_protosocket_client(
-        //     unauthenticated_client,
-        //     self.0.credential_provider.clone(),
-        // )
-        // .await?;
-
-        let manager = ProtosocketConnectionManager::new(
-            // ProtosocketConnection::new(client, message_id),
-            self.0.credential_provider,
-            self.0.runtime,
-        )?;
-
-        // log::info!("manually made a connection and manager");
+        let manager =
+            ProtosocketConnectionManager::new(self.0.credential_provider, self.0.runtime)?;
 
         let client_pool = bb8::Pool::builder()
             .max_size(self.0.configuration.max_connections())
@@ -130,11 +113,6 @@ impl ProtosocketCacheClientBuilder<ReadyToBuild> {
             .build(manager)
             .await
             .map_err(|e| MomentoError::unknown_error("build", Some(e.to_string())))?;
-        log::info!(
-            "created client pool with {} connections and {} idle connections",
-            client_pool.state().connections,
-            client_pool.state().idle_connections
-        );
 
         Ok(ProtosocketCacheClient::new(
             client_pool,

--- a/src/protosocket/cache/cache_client_builder.rs
+++ b/src/protosocket/cache/cache_client_builder.rs
@@ -17,7 +17,6 @@ use rustls_pki_types::ServerName;
 use std::convert::TryFrom;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
-use tokio_rustls::rustls::crypto::aws_lc_rs::default_provider;
 
 pub type Serializer = ProstSerializer<CacheResponse, CacheCommand>;
 
@@ -184,9 +183,6 @@ impl ProtosocketCacheClientBuilder<ReadyToBuild> {
                 MomentoError::unknown_error("build", Some(e.to_string()))
             })?;
 
-        tokio_rustls::rustls::crypto::CryptoProvider::install_default(default_provider())
-            .map_err(|_| MomentoError::unknown_error("build", None))?;
-
         match self.0.credential_provider.endpoint_security {
             EndpointSecurity::Tls => {
                 // TODO: use a default value or panic here?
@@ -195,8 +191,15 @@ impl ProtosocketCacheClientBuilder<ReadyToBuild> {
                     .next()
                     .unwrap_or("localhost")
                     .to_string();
-                let server_name = ServerName::try_from(hostname)
-                    .map_err(|_| MomentoError::unknown_error("build", None))?;
+                let server_name = ServerName::try_from(hostname.clone()).map_err(|_| {
+                    MomentoError::unknown_error(
+                        "build",
+                        Some(format!(
+                            "Error creating server name from hostname: {}",
+                            hostname
+                        )),
+                    )
+                })?;
                 let with_tls = WebpkiTlsStreamConnector::new(server_name);
                 let (client, connection) = protosocket_rpc::client::connect::<
                     Serializer,
@@ -226,8 +229,15 @@ impl ProtosocketCacheClientBuilder<ReadyToBuild> {
                     .next()
                     .unwrap_or("localhost")
                     .to_string();
-                let server_name = ServerName::try_from(hostname)
-                    .map_err(|_| MomentoError::unknown_error("build", None))?;
+                let server_name = ServerName::try_from(hostname.clone()).map_err(|_| {
+                    MomentoError::unknown_error(
+                        "build",
+                        Some(format!(
+                            "Error creating server name from hostname: {}",
+                            hostname
+                        )),
+                    )
+                })?;
                 let with_tls = UnverifiedTlsStreamConnector::new(server_name);
                 let (client, connection) = protosocket_rpc::client::connect::<
                     Serializer,

--- a/src/protosocket/cache/cache_client_builder.rs
+++ b/src/protosocket/cache/cache_client_builder.rs
@@ -1,3 +1,4 @@
+use crate::credential_provider::EndpointSecurity;
 use crate::protosocket::cache::Configuration;
 use crate::{CredentialProvider, MomentoError, MomentoResult, ProtosocketCacheClient};
 use momento_protos::protosocket::cache::cache_command::RpcKind;
@@ -8,9 +9,15 @@ use momento_protos::protosocket::cache::{
     AuthenticateCommand, AuthenticateResponse, CacheCommand, CacheResponse,
 };
 use protosocket_prost::ProstSerializer;
+use protosocket_rpc::client::{
+    TcpStreamConnector, UnverifiedTlsStreamConnector, WebpkiTlsStreamConnector,
+};
 use protosocket_rpc::ProtosocketControlCode;
+use rustls_pki_types::ServerName;
+use std::convert::TryFrom;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
+use tokio_rustls::rustls::crypto::aws_lc_rs::default_provider;
 
 pub type Serializer = ProstSerializer<CacheResponse, CacheCommand>;
 
@@ -169,7 +176,7 @@ impl ProtosocketCacheClientBuilder<ReadyToBuild> {
     /// Constructs a new CacheClientBuilder in the ReadyToBuild state.
     pub async fn build(self) -> MomentoResult<ProtosocketCacheClientBuilder<ReadyToAuthenticate>> {
         // Note: expects socket address, not DNS name
-        let endpoint = &self.0.credential_provider.cache_endpoint;
+        let endpoint = self.0.credential_provider.clone().cache_endpoint;
         let address = endpoint
             .to_string()
             .parse()
@@ -177,27 +184,97 @@ impl ProtosocketCacheClientBuilder<ReadyToBuild> {
                 MomentoError::unknown_error("build", Some(e.to_string()))
             })?;
 
-        let (client, connection) = protosocket_rpc::client::connect::<Serializer, Serializer>(
-            address,
-            &protosocket_rpc::client::Configuration::default(),
-        )
-        .await
-        .map_err(|e: protosocket_rpc::Error| {
-            MomentoError::unknown_error("build", Some(e.to_string()))
-        })?;
+        tokio_rustls::rustls::crypto::CryptoProvider::install_default(default_provider())
+            .map_err(|_| MomentoError::unknown_error("build", None))?;
 
-        // SDK expects to be run on a Tokio runtime, so we can go ahead and spawn a driver
-        // task into the provided Tokio runtime to continually process protosocket requests.
-        self.0.runtime.spawn(connection);
+        match self.0.credential_provider.endpoint_security {
+            EndpointSecurity::Tls => {
+                // TODO: use a default value or panic here?
+                let hostname = endpoint
+                    .split(":")
+                    .next()
+                    .unwrap_or("localhost")
+                    .to_string();
+                let server_name = ServerName::try_from(hostname)
+                    .map_err(|_| MomentoError::unknown_error("build", None))?;
+                let with_tls = WebpkiTlsStreamConnector::new(server_name);
+                let (client, connection) = protosocket_rpc::client::connect::<
+                    Serializer,
+                    Serializer,
+                    WebpkiTlsStreamConnector,
+                >(
+                    address,
+                    &protosocket_rpc::client::Configuration::new(with_tls),
+                )
+                .await?;
+                // SDK expects to be run on a Tokio runtime, so we can go ahead and spawn a driver
+                // task into the provided Tokio runtime to continually process protosocket requests.
+                self.0.runtime.spawn(connection);
 
-        Ok(ProtosocketCacheClientBuilder(ReadyToAuthenticate {
-            unauthenticated_client: UnauthenticatedClient::new(
-                client,
-                self.0.default_ttl,
-                self.0.configuration,
-            ),
-            credential_provider: self.0.credential_provider,
-        }))
+                Ok(ProtosocketCacheClientBuilder(ReadyToAuthenticate {
+                    unauthenticated_client: UnauthenticatedClient::new(
+                        client,
+                        self.0.default_ttl,
+                        self.0.configuration,
+                    ),
+                    credential_provider: self.0.credential_provider,
+                }))
+            }
+            EndpointSecurity::Unverified => {
+                let hostname = endpoint
+                    .split(":")
+                    .next()
+                    .unwrap_or("localhost")
+                    .to_string();
+                let server_name = ServerName::try_from(hostname)
+                    .map_err(|_| MomentoError::unknown_error("build", None))?;
+                let with_tls = UnverifiedTlsStreamConnector::new(server_name);
+                let (client, connection) = protosocket_rpc::client::connect::<
+                    Serializer,
+                    Serializer,
+                    UnverifiedTlsStreamConnector,
+                >(
+                    address,
+                    &protosocket_rpc::client::Configuration::new(with_tls),
+                )
+                .await?;
+                // SDK expects to be run on a Tokio runtime, so we can go ahead and spawn a driver
+                // task into the provided Tokio runtime to continually process protosocket requests.
+                self.0.runtime.spawn(connection);
+
+                Ok(ProtosocketCacheClientBuilder(ReadyToAuthenticate {
+                    unauthenticated_client: UnauthenticatedClient::new(
+                        client,
+                        self.0.default_ttl,
+                        self.0.configuration,
+                    ),
+                    credential_provider: self.0.credential_provider,
+                }))
+            }
+            EndpointSecurity::Insecure => {
+                // TODO: seems to hang when credential provider uses insecure endpoint with server expecting one of the other options,
+                // probably dropping an error or need to set a timeout somewhere
+                let without_tls = TcpStreamConnector {};
+                let (client, connection) =
+                    protosocket_rpc::client::connect::<Serializer, Serializer, TcpStreamConnector>(
+                        address,
+                        &protosocket_rpc::client::Configuration::new(without_tls),
+                    )
+                    .await?;
+                // SDK expects to be run on a Tokio runtime, so we can go ahead and spawn a driver
+                // task into the provided Tokio runtime to continually process protosocket requests.
+                self.0.runtime.spawn(connection);
+
+                Ok(ProtosocketCacheClientBuilder(ReadyToAuthenticate {
+                    unauthenticated_client: UnauthenticatedClient::new(
+                        client,
+                        self.0.default_ttl,
+                        self.0.configuration,
+                    ),
+                    credential_provider: self.0.credential_provider,
+                }))
+            }
+        }
     }
 }
 

--- a/src/protosocket/cache/cache_client_builder.rs
+++ b/src/protosocket/cache/cache_client_builder.rs
@@ -1,7 +1,4 @@
-use crate::protosocket::cache::utils::{
-    // authenticate_protosocket_client, create_protosocket_connection, ProtosocketConnection,
-    ProtosocketConnectionManager,
-};
+use crate::protosocket::cache::utils::ProtosocketConnectionManager;
 use crate::protosocket::cache::Configuration;
 use crate::{CredentialProvider, MomentoResult, ProtosocketCacheClient};
 use momento_protos::protosocket::cache::CacheCommand;

--- a/src/protosocket/cache/config/configuration.rs
+++ b/src/protosocket/cache/config/configuration.rs
@@ -24,10 +24,8 @@ use std::time::Duration;
 pub struct Configuration {
     /// The duration the client will wait before terminating an RPC with a DeadlineExceeded error.
     pub(crate) timeout: Duration,
-    /// The maximum number of connections to keep in the pool.
-    pub(crate) max_connections: u32,
-    /// The minimum number of idle connections to keep in the pool.
-    pub(crate) min_connections: u32,
+    /// The number of connections to keep in the connection pool.
+    pub(crate) connection_count: usize,
 }
 
 impl Configuration {
@@ -41,30 +39,15 @@ impl Configuration {
         self.timeout
     }
 
-    /// Returns the maximum number of connections to keep in the pool.
-    pub fn max_connections(&self) -> u32 {
-        self.max_connections
+    /// Returns the number of connections to keep in the connection pool.
+    pub fn connection_count(&self) -> usize {
+        self.connection_count
     }
 
-    /// Returns the minimum number of idle connections to keep in the pool.
-    pub fn min_connections(&self) -> u32 {
-        self.min_connections
-    }
-
-    /// Set the maximum number of connections to keep in the pool.
-    pub fn set_max_connections(&self, max_connections: u32) -> Self {
+    /// Set the number of connections to keep in the connection pool.
+    pub fn set_connection_count(&self, connection_count: usize) -> Self {
         Self {
-            max_connections,
-            min_connections: self.min_connections,
-            timeout: self.timeout,
-        }
-    }
-
-    /// Set the minimum number of idle connections to keep in the pool.
-    pub fn set_min_connections(&self, min_connections: u32) -> Self {
-        Self {
-            max_connections: self.max_connections,
-            min_connections,
+            connection_count,
             timeout: self.timeout,
         }
     }
@@ -76,17 +59,37 @@ pub struct ConfigurationBuilder<State>(State);
 /// The state of the ConfigurationBuilder when it is waiting for a timeout.
 pub struct NeedsTimeout(());
 
+/// The state of the ConfigurationBuilder when it is waiting for a connection count.
+pub struct NeedsConnectionCount {
+    timeout: Duration,
+}
+
 /// The state of the ConfigurationBuilder when it is ready to build a Configuration.
 pub struct ReadyToBuild {
     timeout: Duration,
+    connection_count: usize,
 }
 
 impl ConfigurationBuilder<NeedsTimeout> {
     /// Sets the transport strategy for the Configuration and returns
     /// the ConfigurationBuilder in the ReadyToBuild state.
-    pub fn timeout(self, timeout: impl Into<Duration>) -> ConfigurationBuilder<ReadyToBuild> {
-        ConfigurationBuilder(ReadyToBuild {
+    pub fn timeout(
+        self,
+        timeout: impl Into<Duration>,
+    ) -> ConfigurationBuilder<NeedsConnectionCount> {
+        ConfigurationBuilder(NeedsConnectionCount {
             timeout: timeout.into(),
+        })
+    }
+}
+
+impl ConfigurationBuilder<NeedsConnectionCount> {
+    /// Sets the transport strategy for the Configuration and returns
+    /// the ConfigurationBuilder in the ReadyToBuild state.
+    pub fn connection_count(self, connection_count: u32) -> ConfigurationBuilder<ReadyToBuild> {
+        ConfigurationBuilder(ReadyToBuild {
+            timeout: self.0.timeout,
+            connection_count: connection_count as usize,
         })
     }
 }
@@ -96,9 +99,7 @@ impl ConfigurationBuilder<ReadyToBuild> {
     pub fn build(self) -> Configuration {
         Configuration {
             timeout: self.0.timeout,
-            // TODO: make these configurable
-            max_connections: 1,
-            min_connections: 1,
+            connection_count: self.0.connection_count,
         }
     }
 }

--- a/src/protosocket/cache/config/configuration.rs
+++ b/src/protosocket/cache/config/configuration.rs
@@ -50,6 +50,24 @@ impl Configuration {
     pub fn min_connections(&self) -> u32 {
         self.min_connections
     }
+
+    /// Set the maximum number of connections to keep in the pool.
+    pub fn set_max_connections(&self, max_connections: u32) -> Self {
+        Self {
+            max_connections,
+            min_connections: self.min_connections,
+            timeout: self.timeout,
+        }
+    }
+
+    /// Set the minimum number of idle connections to keep in the pool.
+    pub fn set_min_connections(&self, min_connections: u32) -> Self {
+        Self {
+            max_connections: self.max_connections,
+            min_connections,
+            timeout: self.timeout,
+        }
+    }
 }
 
 /// The initial state of the ConfigurationBuilder.

--- a/src/protosocket/cache/config/configuration.rs
+++ b/src/protosocket/cache/config/configuration.rs
@@ -24,6 +24,10 @@ use std::time::Duration;
 pub struct Configuration {
     /// The duration the client will wait before terminating an RPC with a DeadlineExceeded error.
     pub(crate) timeout: Duration,
+    /// The maximum number of connections to keep in the pool.
+    pub(crate) max_connections: u32,
+    /// The minimum number of idle connections to keep in the pool.
+    pub(crate) min_connections: u32,
 }
 
 impl Configuration {
@@ -35,6 +39,16 @@ impl Configuration {
     /// Returns the duration the client will wait before terminating an RPC with a DeadlineExceeded error.
     pub fn timeout(&self) -> Duration {
         self.timeout
+    }
+
+    /// Returns the maximum number of connections to keep in the pool.
+    pub fn max_connections(&self) -> u32 {
+        self.max_connections
+    }
+
+    /// Returns the minimum number of idle connections to keep in the pool.
+    pub fn min_connections(&self) -> u32 {
+        self.min_connections
     }
 }
 
@@ -64,6 +78,9 @@ impl ConfigurationBuilder<ReadyToBuild> {
     pub fn build(self) -> Configuration {
         Configuration {
             timeout: self.0.timeout,
+            // TODO: make these configurable
+            max_connections: 1,
+            min_connections: 1,
         }
     }
 }

--- a/src/protosocket/cache/config/configurations.rs
+++ b/src/protosocket/cache/config/configurations.rs
@@ -23,7 +23,9 @@ impl Laptop {
     /// configurations. This is useful for users who want to ensure that their application's
     /// behavior does not change unexpectedly.
     pub fn v1() -> impl Into<Configuration> {
-        Configuration::builder().timeout(Duration::from_millis(15000))
+        Configuration::builder()
+            .timeout(Duration::from_millis(15000))
+            .connection_count(1)
     }
 }
 
@@ -49,7 +51,9 @@ impl InRegion {
     /// behavior does not change unexpectedly.
     #[allow(dead_code)]
     pub fn v1() -> impl Into<Configuration> {
-        Configuration::builder().timeout(Duration::from_millis(1100))
+        Configuration::builder()
+            .timeout(Duration::from_millis(1100))
+            .connection_count(1)
     }
 }
 
@@ -75,7 +79,9 @@ impl LowLatency {
     /// configurations. This is useful for users who want to ensure that their application's
     /// behavior does not change unexpectedly.
     pub fn v1() -> impl Into<Configuration> {
-        Configuration::builder().timeout(Duration::from_millis(500))
+        Configuration::builder()
+            .timeout(Duration::from_millis(500))
+            .connection_count(1)
     }
 }
 
@@ -109,6 +115,8 @@ impl Lambda {
     /// configurations. This is useful for users who want to ensure that their application's
     /// behavior does not change unexpectedly.
     pub fn v1() -> impl Into<Configuration> {
-        Configuration::builder().timeout(Duration::from_millis(1100))
+        Configuration::builder()
+            .timeout(Duration::from_millis(1100))
+            .connection_count(1)
     }
 }

--- a/src/protosocket/cache/messages/scalar/get.rs
+++ b/src/protosocket/cache/messages/scalar/get.rs
@@ -28,11 +28,11 @@ impl<K: IntoBytes> GetRequest<K> {
         self,
         client: &ProtosocketCacheClient,
     ) -> MomentoResult<crate::cache::GetResponse> {
-        let connection = client.protosocket_connection().await?;
-        let completion = connection
-            .client()
+        let completion = client
+            .protosocket_connection()
+            .await?
             .send_unary(CacheCommand {
-                message_id: connection.message_id(),
+                message_id: client.message_id(),
                 control_code: ProtosocketControlCode::Normal as u32,
                 rpc_kind: Some(RpcKind::Unary(Unary {
                     command: Some(Command::Get(GetCommand {

--- a/src/protosocket/cache/messages/scalar/get.rs
+++ b/src/protosocket/cache/messages/scalar/get.rs
@@ -30,6 +30,7 @@ impl<K: IntoBytes> GetRequest<K> {
     ) -> MomentoResult<crate::cache::GetResponse> {
         let completion = client
             .protosocket_client()
+            .await?
             .send_unary(CacheCommand {
                 message_id: client.message_id(),
                 control_code: ProtosocketControlCode::Normal as u32,

--- a/src/protosocket/cache/messages/scalar/get.rs
+++ b/src/protosocket/cache/messages/scalar/get.rs
@@ -28,11 +28,11 @@ impl<K: IntoBytes> GetRequest<K> {
         self,
         client: &ProtosocketCacheClient,
     ) -> MomentoResult<crate::cache::GetResponse> {
-        let completion = client
-            .protosocket_client()
-            .await?
+        let connection = client.protosocket_connection().await?;
+        let completion = connection
+            .client()
             .send_unary(CacheCommand {
-                message_id: client.message_id(),
+                message_id: connection.message_id(),
                 control_code: ProtosocketControlCode::Normal as u32,
                 rpc_kind: Some(RpcKind::Unary(Unary {
                     command: Some(Command::Get(GetCommand {

--- a/src/protosocket/cache/messages/scalar/set.rs
+++ b/src/protosocket/cache/messages/scalar/set.rs
@@ -28,6 +28,7 @@ impl<K: IntoBytes, V: IntoBytes> SetRequest<K, V> {
     ) -> MomentoResult<crate::cache::SetResponse> {
         let completion = client
             .protosocket_client()
+            .await?
             .send_unary(CacheCommand {
                 message_id: client.message_id(),
                 control_code: ProtosocketControlCode::Normal as u32,

--- a/src/protosocket/cache/messages/scalar/set.rs
+++ b/src/protosocket/cache/messages/scalar/set.rs
@@ -26,11 +26,11 @@ impl<K: IntoBytes, V: IntoBytes> SetRequest<K, V> {
         self,
         client: &ProtosocketCacheClient,
     ) -> MomentoResult<crate::cache::SetResponse> {
-        let completion = client
-            .protosocket_client()
-            .await?
+        let connection = client.protosocket_connection().await?;
+        let completion = connection
+            .client()
             .send_unary(CacheCommand {
-                message_id: client.message_id(),
+                message_id: connection.message_id(),
                 control_code: ProtosocketControlCode::Normal as u32,
                 rpc_kind: Some(RpcKind::Unary(Unary {
                     command: Some(Command::Set(SetCommand {

--- a/src/protosocket/cache/messages/scalar/set.rs
+++ b/src/protosocket/cache/messages/scalar/set.rs
@@ -26,11 +26,11 @@ impl<K: IntoBytes, V: IntoBytes> SetRequest<K, V> {
         self,
         client: &ProtosocketCacheClient,
     ) -> MomentoResult<crate::cache::SetResponse> {
-        let connection = client.protosocket_connection().await?;
-        let completion = connection
-            .client()
+        let completion = client
+            .protosocket_connection()
+            .await?
             .send_unary(CacheCommand {
-                message_id: connection.message_id(),
+                message_id: client.message_id(),
                 control_code: ProtosocketControlCode::Normal as u32,
                 rpc_kind: Some(RpcKind::Unary(Unary {
                     command: Some(Command::Set(SetCommand {

--- a/src/protosocket/cache/mod.rs
+++ b/src/protosocket/cache/mod.rs
@@ -10,3 +10,5 @@ pub use config::configurations;
 
 mod messages;
 pub use messages::MomentoProtosocketRequest;
+
+mod utils;

--- a/src/protosocket/cache/mod.rs
+++ b/src/protosocket/cache/mod.rs
@@ -2,7 +2,7 @@ mod cache_client;
 pub use cache_client::ProtosocketCacheClient;
 
 mod cache_client_builder;
-pub use cache_client_builder::{ProtosocketCacheClientBuilder, ReadyToAuthenticate};
+pub use cache_client_builder::{ProtosocketCacheClientBuilder, ReadyToBuild};
 
 mod config;
 pub use config::configuration::Configuration;

--- a/src/protosocket/cache/utils.rs
+++ b/src/protosocket/cache/utils.rs
@@ -4,6 +4,7 @@ use std::{
         atomic::{AtomicU64, Ordering},
         Arc,
     },
+    time::Duration,
 };
 
 use crate::{
@@ -81,6 +82,9 @@ impl HealthyProtosocket {
 
         // Need to create a new connection - clear the old one first
         *client_guard = None;
+
+        // Sleep for a bit
+        tokio::time::sleep(Duration::from_millis(100)).await;
 
         // Create and authenticate new connection
         let endpoint = &self.credential_provider.cache_endpoint;

--- a/src/protosocket/cache/utils.rs
+++ b/src/protosocket/cache/utils.rs
@@ -75,7 +75,7 @@ impl ClientConnector for ProtosocketConnectionManager {
         let client = authenticate_protosocket_client(
             unauthenticated_client,
             self.credential_provider.clone(),
-            rand::random::<u64>(), // TODO: use something other than random u64?
+            0xDEADBEEF,
         )
         .await
         .map_err(|e| {

--- a/src/protosocket/cache/utils.rs
+++ b/src/protosocket/cache/utils.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, sync::Arc};
+use std::convert::TryFrom;
 
 use crate::{
     credential_provider::EndpointSecurity, protosocket::cache::cache_client_builder::Serializer,
@@ -70,10 +70,7 @@ impl ClientConnector for ProtosocketConnectionManager {
         )
         .await
         .map_err(|e| {
-            protosocket_rpc::Error::IoFailure(Arc::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                e.to_string(),
-            )))
+            protosocket_rpc::Error::IoFailure(std::io::Error::other(e.to_string()).into())
         })?;
         let client = authenticate_protosocket_client(
             unauthenticated_client,
@@ -82,10 +79,7 @@ impl ClientConnector for ProtosocketConnectionManager {
         )
         .await
         .map_err(|e| {
-            protosocket_rpc::Error::IoFailure(Arc::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                e.to_string(),
-            )))
+            protosocket_rpc::Error::IoFailure(std::io::Error::other(e.to_string()).into())
         })?;
         Ok(client)
     }

--- a/src/protosocket/cache/utils.rs
+++ b/src/protosocket/cache/utils.rs
@@ -1,0 +1,224 @@
+use std::{
+    convert::TryFrom,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+use crate::{
+    credential_provider::EndpointSecurity, protosocket::cache::cache_client_builder::Serializer,
+    CredentialProvider,
+};
+use momento_protos::protosocket::cache::{
+    cache_command::RpcKind, cache_response::Kind, unary::Command, AuthenticateCommand,
+    AuthenticateResponse, CacheCommand, CacheResponse, Unary,
+};
+use protosocket_rpc::{
+    client::{TcpStreamConnector, UnverifiedTlsStreamConnector, WebpkiTlsStreamConnector},
+    ProtosocketControlCode,
+};
+use rustls_pki_types::ServerName;
+use tokio::sync::Mutex;
+
+use crate::{MomentoError, MomentoResult};
+
+#[derive(Clone, Debug)]
+pub(crate) struct HealthyProtosocket {
+    client: Arc<Mutex<Option<protosocket_rpc::client::RpcClient<CacheCommand, CacheResponse>>>>,
+    message_id: Arc<AtomicU64>,
+    credential_provider: CredentialProvider,
+    runtime: tokio::runtime::Handle,
+}
+
+#[allow(clippy::expect_used)]
+impl HealthyProtosocket {
+    pub fn new(
+        client: protosocket_rpc::client::RpcClient<CacheCommand, CacheResponse>,
+        message_id: AtomicU64,
+        credential_provider: CredentialProvider,
+        runtime: tokio::runtime::Handle,
+    ) -> Self {
+        Self {
+            client: Arc::new(Mutex::new(Some(client))),
+            message_id: Arc::new(message_id),
+            credential_provider,
+            runtime,
+        }
+    }
+
+    pub fn message_id(&self) -> u64 {
+        self.message_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    pub async fn get_client(
+        &self,
+    ) -> MomentoResult<protosocket_rpc::client::RpcClient<CacheCommand, CacheResponse>> {
+        let mut client_guard = self.client.lock().await;
+        match &*client_guard {
+            Some(client) => {
+                if client.is_alive() {
+                    Ok(client.clone())
+                } else {
+                    *client_guard = None;
+                    let endpoint = self.credential_provider.clone().cache_endpoint;
+                    log::info!("getting protosocket client for endpoint {endpoint}");
+                    let client_result = create_protosocket_connection(
+                        self.credential_provider.clone(),
+                        self.runtime.clone(),
+                    )
+                    .await?;
+                    let (client, message_id) = authenticate_protosocket_client(
+                        client_result,
+                        self.credential_provider.clone(),
+                    )
+                    .await?;
+                    *client_guard = Some(client.clone());
+                    self.message_id
+                        .store(message_id.load(Ordering::Relaxed), Ordering::Relaxed);
+                    Ok(client)
+                }
+            }
+            None => {
+                let endpoint = self.credential_provider.clone().cache_endpoint;
+                log::info!("getting protosocket client for endpoint {endpoint}");
+                let client_result = create_protosocket_connection(
+                    self.credential_provider.clone(),
+                    self.runtime.clone(),
+                )
+                .await?;
+                let (client, message_id) = authenticate_protosocket_client(
+                    client_result,
+                    self.credential_provider.clone(),
+                )
+                .await?;
+                *client_guard = Some(client.clone());
+                self.message_id
+                    .store(message_id.load(Ordering::Relaxed), Ordering::Relaxed);
+                Ok(client)
+            }
+        }
+    }
+}
+
+pub(crate) async fn create_protosocket_connection(
+    credential_provider: CredentialProvider,
+    runtime: tokio::runtime::Handle,
+) -> MomentoResult<protosocket_rpc::client::RpcClient<CacheCommand, CacheResponse>> {
+    let endpoint = credential_provider.clone().cache_endpoint;
+    let address = endpoint
+        .to_string()
+        .parse()
+        .map_err(|e: std::net::AddrParseError| {
+            MomentoError::unknown_error("build", Some(e.to_string()))
+        })?;
+
+    match credential_provider.endpoint_security {
+        EndpointSecurity::Tls => {
+            // TODO: use a default value or panic here?
+            let hostname = endpoint
+                .split(":")
+                .next()
+                .unwrap_or("localhost")
+                .to_string();
+            let server_name = ServerName::try_from(hostname.clone()).map_err(|_| {
+                MomentoError::unknown_error(
+                    "build",
+                    Some(format!(
+                        "Error creating server name from hostname: {}",
+                        hostname
+                    )),
+                )
+            })?;
+            let with_tls = WebpkiTlsStreamConnector::new(server_name);
+            let (client, connection) = protosocket_rpc::client::connect::<
+                Serializer,
+                Serializer,
+                WebpkiTlsStreamConnector,
+            >(
+                address,
+                &protosocket_rpc::client::Configuration::new(with_tls),
+            )
+            .await?;
+            // SDK expects to be run on a Tokio runtime, so we can go ahead and spawn a driver
+            // task into the provided Tokio runtime to continually process protosocket requests.
+            runtime.spawn(connection);
+
+            Ok(client)
+        }
+        EndpointSecurity::Unverified => {
+            let hostname = endpoint
+                .split(":")
+                .next()
+                .unwrap_or("localhost")
+                .to_string();
+            let server_name = ServerName::try_from(hostname.clone()).map_err(|_| {
+                MomentoError::unknown_error(
+                    "build",
+                    Some(format!(
+                        "Error creating server name from hostname: {}",
+                        hostname
+                    )),
+                )
+            })?;
+            let with_tls = UnverifiedTlsStreamConnector::new(server_name);
+            let (client, connection) = protosocket_rpc::client::connect::<
+                Serializer,
+                Serializer,
+                UnverifiedTlsStreamConnector,
+            >(
+                address,
+                &protosocket_rpc::client::Configuration::new(with_tls),
+            )
+            .await?;
+            // SDK expects to be run on a Tokio runtime, so we can go ahead and spawn a driver
+            // task into the provided Tokio runtime to continually process protosocket requests.
+            runtime.spawn(connection);
+
+            Ok(client)
+        }
+        EndpointSecurity::Insecure => {
+            // TODO: seems to hang when credential provider uses insecure endpoint with server expecting one of the other options,
+            // probably dropping an error or need to set a timeout somewhere
+            let without_tls = TcpStreamConnector {};
+            let (client, connection) =
+                protosocket_rpc::client::connect::<Serializer, Serializer, TcpStreamConnector>(
+                    address,
+                    &protosocket_rpc::client::Configuration::new(without_tls),
+                )
+                .await?;
+            // SDK expects to be run on a Tokio runtime, so we can go ahead and spawn a driver
+            // task into the provided Tokio runtime to continually process protosocket requests.
+            runtime.spawn(connection);
+
+            Ok(client)
+        }
+    }
+}
+
+pub(crate) async fn authenticate_protosocket_client(
+    client: protosocket_rpc::client::RpcClient<CacheCommand, CacheResponse>,
+    credential_provider: CredentialProvider,
+) -> MomentoResult<(
+    protosocket_rpc::client::RpcClient<CacheCommand, CacheResponse>,
+    AtomicU64,
+)> {
+    let message_id = AtomicU64::new(0);
+    let completion = client
+        .send_unary(CacheCommand {
+            message_id: message_id.fetch_add(1, Ordering::Relaxed),
+            control_code: ProtosocketControlCode::Normal as u32,
+            rpc_kind: Some(RpcKind::Unary(Unary {
+                command: Some(Command::Auth(AuthenticateCommand {
+                    token: credential_provider.clone().auth_token,
+                })),
+            })),
+        })
+        .await?;
+    let response = completion.await?;
+    match response.kind {
+        Some(Kind::Auth(AuthenticateResponse {})) => Ok((client, message_id)),
+        Some(Kind::Error(error)) => Err(MomentoError::protosocket_command_error(error)),
+        _ => Err(MomentoError::protosocket_unexpected_kind_error()),
+    }
+}

--- a/test-util/src/test_utils.rs
+++ b/test-util/src/test_utils.rs
@@ -84,10 +84,7 @@ pub async fn create_doctest_protosocket_cache_client() -> (ProtosocketCacheClien
         .runtime(tokio::runtime::Handle::current())
         .build()
         .await
-        .expect("cache client should be created")
-        .authenticate()
-        .await
-        .expect("cache client should be authenticated");
+        .expect("cache client should be created");
     (client, cache_name)
 }
 


### PR DESCRIPTION
Closes https://github.com/momentohq/mr2rs/issues/2428

Uses protosocket-rpc v0.11.0 which includes TLS, TCP keepalive and so_reuseaddr settings, and connection pool management.

Updates protosocket client in sdk accordingly and exposes connection_count as a config option.
