### PR TITLE
chore: add direct connect handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +341,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +376,17 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -402,6 +435,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs_extra"
@@ -505,8 +547,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -516,9 +560,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -626,6 +672,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +707,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -651,12 +715,121 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -678,6 +851,22 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -781,6 +970,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +990,12 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchit"
@@ -851,6 +1052,7 @@ dependencies = [
  "env_logger",
  "futures",
  "h2",
+ "http",
  "hyper",
  "log",
  "momento-protos",
@@ -859,6 +1061,7 @@ dependencies = [
  "protosocket-prost",
  "protosocket-rpc",
  "rand",
+ "reqwest",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -923,6 +1126,12 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "parking_lot"
@@ -1004,6 +1213,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1106,6 +1324,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.12",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.10",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,6 +1467,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,11 +1548,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1269,10 +1594,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.1",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -1302,6 +1659,18 @@ checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1354,6 +1723,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,6 +1750,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "thiserror"
@@ -1415,6 +1804,31 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1545,6 +1959,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,6 +2050,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,6 +2135,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,6 +2180,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,6 +2216,12 @@ checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
@@ -1766,6 +2254,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1884,6 +2381,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,10 +2431,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,12 +36,14 @@ base64 = "0.22"
 derive_more = { version = "2.0.1", features = ["full"] }
 futures = "0"
 h2 = { version = "0.4" }
+http = { version = "1" }
 hyper = { version = "1.6" }
 log = "0.4"
 protosocket = "0.11.0"
 protosocket-prost = "0.11.0"
 protosocket-rpc = "0.11.0"
 rand = "0.9"
+reqwest = { version = "0.12", default-features = false, features = ["http2", "json", "rustls-tls-native-roots"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/src/protosocket/cache/address_provider.rs
+++ b/src/protosocket/cache/address_provider.rs
@@ -1,0 +1,127 @@
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
+
+use crate::CredentialProvider;
+
+// Todo: should make the connections try to balance better than random
+#[derive(serde::Deserialize, serde::Serialize, Debug, Default)]
+pub(crate) struct Addresses {
+    #[serde(flatten)]
+    azs: HashMap<AzId, Vec<Address>>,
+}
+
+impl Addresses {
+    /// Get a list of socket addresses, optionally filtered by availability zone ID.
+    /// If an az_id is provided, only addresses in that availability zone will be returned,
+    pub fn for_az(&self, az_id: Option<&str>) -> Vec<SocketAddr> {
+        if let Some(az_id) = az_id {
+            if let Some(addresses) = self.azs.get(&AzId(az_id.to_string())) {
+                if !addresses.is_empty() {
+                    return addresses.iter().map(|a| a.socket_address).collect();
+                }
+            }
+        }
+        self.azs
+            .values()
+            .flat_map(|addresses| addresses.iter().map(|a| a.socket_address))
+            .collect()
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Debug, Eq, PartialEq, Hash)]
+pub(crate) struct AzId(String);
+
+#[derive(serde::Deserialize, serde::Serialize, Debug)]
+pub(crate) struct Address {
+    socket_address: SocketAddr,
+}
+
+#[derive(Debug)]
+pub(crate) struct AddressProvider {
+    addresses: Mutex<Arc<Addresses>>,
+    client: reqwest::Client,
+    credential_provider: CredentialProvider,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum RefreshError {
+    Reqwest(#[from] reqwest::Error),
+    Json(#[from] serde_json::Error),
+    Uri(#[from] http::uri::InvalidUri),
+    BadStatus((reqwest::StatusCode, String)),
+}
+impl std::fmt::Display for RefreshError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RefreshError::Reqwest(e) => write!(f, "Reqwest error: {e}"),
+            RefreshError::Json(e) => write!(f, "JSON error: {e}"),
+            RefreshError::Uri(e) => write!(f, "URI error: {e}"),
+            RefreshError::BadStatus((status, text)) => write!(f, "Bad status: {status}, {text}"),
+        }
+    }
+}
+
+impl AddressProvider {
+    /// Looks for an address list from the provided endpoint.
+    #[allow(clippy::expect_used)]
+    pub fn new(credential_provider: CredentialProvider) -> Self {
+        let client = reqwest::Client::builder()
+            .tls_built_in_native_certs(true)
+            .tls_built_in_root_certs(true)
+            .build()
+            .expect("must be able to build client");
+        Self {
+            addresses: Default::default(),
+            client,
+            credential_provider,
+        }
+    }
+
+    #[allow(clippy::expect_used)]
+    pub fn get_addresses(&self) -> impl std::ops::Deref<Target = Addresses> {
+        self.addresses
+            .lock()
+            .expect("local mutex must not be poisoned")
+            .clone()
+    }
+
+    #[allow(clippy::expect_used)]
+    pub async fn try_refresh_addresses(&self) -> Result<(), RefreshError> {
+        let request = self
+            .client
+            .get(format!(
+                "{}/endpoints",
+                self.credential_provider
+                    .cache_http_endpoint()
+                    .trim_end_matches('/')
+            ))
+            .header("authorization", &self.credential_provider.auth_token)
+            .build()?;
+        let response = self.client.execute(request).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await?;
+            return Err(RefreshError::BadStatus((status, text)));
+        }
+
+        let response = response.text().await?;
+        let addresses = match serde_json::from_str(&response) {
+            Ok(addresses) => addresses,
+            Err(e) => {
+                log::warn!("error parsing address list JSON: {response}");
+                return Err(RefreshError::Json(e));
+            }
+        };
+        log::debug!("refreshed address list: {addresses:?}");
+        let addresses = Arc::new(addresses);
+        *self
+            .addresses
+            .lock()
+            .expect("local mutex must not be poisoned") = addresses;
+        Ok(())
+    }
+}

--- a/src/protosocket/cache/cache_client.rs
+++ b/src/protosocket/cache/cache_client.rs
@@ -3,7 +3,7 @@ use protosocket_rpc::client::{ConnectionPool, RpcClient};
 
 use crate::cache::{GetRequest, SetRequest};
 use crate::protosocket::cache::cache_client_builder::NeedsDefaultTtl;
-use crate::protosocket::cache::utils::ProtosocketConnectionManager;
+use crate::protosocket::cache::connection_manager::ProtosocketConnectionManager;
 use crate::protosocket::cache::{Configuration, MomentoProtosocketRequest};
 use crate::{utils, IntoBytes, MomentoError, MomentoResult, ProtosocketCacheClientBuilder};
 use std::convert::TryInto;
@@ -103,7 +103,7 @@ impl ProtosocketCacheClient {
     /// # }
     /// ```
     pub fn builder() -> ProtosocketCacheClientBuilder<NeedsDefaultTtl> {
-        ProtosocketCacheClientBuilder(NeedsDefaultTtl(()))
+        super::cache_client_builder::initial()
     }
 
     /// Gets an item from a Momento Cache
@@ -211,7 +211,7 @@ impl ProtosocketCacheClient {
         &self,
     ) -> MomentoResult<RpcClient<CacheCommand, CacheResponse>> {
         let pooled_client = self.client_pool.get_connection().await.map_err(|e| {
-            MomentoError::unknown_error("protosocket_connection", Some(e.to_string()))
+            MomentoError::unknown_error("protosocket_connection", Some(format!("{e:?}")))
         })?;
         Ok(pooled_client.clone())
     }

--- a/src/protosocket/cache/config/configurations.rs
+++ b/src/protosocket/cache/config/configurations.rs
@@ -25,7 +25,8 @@ impl Laptop {
     pub fn v1() -> impl Into<Configuration> {
         Configuration::builder()
             .timeout(Duration::from_millis(15000))
-            .connection_count(1)
+            .connection_count(default_connections())
+            .az_id(None)
     }
 }
 
@@ -49,11 +50,16 @@ impl InRegion {
     /// Versioning the prebuilt configurations allows users to opt-in to changes in the default
     /// configurations. This is useful for users who want to ensure that their application's
     /// behavior does not change unexpectedly.
+    ///
+    /// You can set your availability zone ID by setting the `MOMENTO_AWS_AZ_ID` environment variable.
+    /// See https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html for more information
+    /// about availability zone IDs.
     #[allow(dead_code)]
     pub fn v1() -> impl Into<Configuration> {
         Configuration::builder()
             .timeout(Duration::from_millis(1100))
-            .connection_count(1)
+            .connection_count(default_connections())
+            .az_id(az_id_from_env())
     }
 }
 
@@ -78,10 +84,15 @@ impl LowLatency {
     /// Versioning the prebuilt configurations allows users to opt-in to changes in the default
     /// configurations. This is useful for users who want to ensure that their application's
     /// behavior does not change unexpectedly.
+    ///
+    /// You can set your availability zone ID by setting the `MOMENTO_AWS_AZ_ID` environment variable.
+    /// See https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html for more information
+    /// about availability zone IDs.
     pub fn v1() -> impl Into<Configuration> {
         Configuration::builder()
             .timeout(Duration::from_millis(500))
-            .connection_count(1)
+            .connection_count(default_connections())
+            .az_id(az_id_from_env())
     }
 }
 
@@ -114,9 +125,24 @@ impl Lambda {
     /// Versioning the prebuilt configurations allows users to opt-in to changes in the default
     /// configurations. This is useful for users who want to ensure that their application's
     /// behavior does not change unexpectedly.
+    ///
+    /// You can set your availability zone ID by setting the `MOMENTO_AWS_AZ_ID` environment variable.
+    /// See https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html for more information
+    /// about availability zone IDs.
     pub fn v1() -> impl Into<Configuration> {
         Configuration::builder()
             .timeout(Duration::from_millis(1100))
             .connection_count(1)
+            .az_id(az_id_from_env())
     }
+}
+
+fn az_id_from_env() -> Option<String> {
+    std::env::var("MOMENTO_AWS_AZ_ID")
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+fn default_connections() -> u32 {
+    (std::thread::available_parallelism().map_or(1, |n| n.get()) / 2).clamp(1, 16) as u32
 }

--- a/src/protosocket/cache/connection_manager.rs
+++ b/src/protosocket/cache/connection_manager.rs
@@ -1,7 +1,16 @@
-use std::convert::TryFrom;
+use std::{
+    convert::TryFrom,
+    str::FromStr,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize},
+        Arc,
+    },
+    time::Duration,
+};
 
 use crate::{
-    credential_provider::EndpointSecurity, protosocket::cache::cache_client_builder::Serializer,
+    credential_provider::EndpointSecurity,
+    protosocket::cache::{address_provider::AddressProvider, cache_client_builder::Serializer},
     CredentialProvider,
 };
 use momento_protos::protosocket::cache::{
@@ -22,35 +31,77 @@ use crate::{MomentoError, MomentoResult};
 pub(crate) struct ProtosocketConnectionManager {
     credential_provider: CredentialProvider,
     runtime: tokio::runtime::Handle,
-    endpoint_address: std::net::SocketAddr,
     hostname: String,
+    address_provider: Arc<AddressProvider>,
+    alive: Arc<AtomicBool>,
+    az_id: Option<String>,
+    connection_sequence: Arc<AtomicUsize>,
 }
 
 impl ProtosocketConnectionManager {
+    /// You should make one of these and clone it as needed for connection pools.
+    /// It spawns a background task to refresh the address list every 30 seconds.
+    /// This manager can be cloned and shared across connection pools.
+    ///
+    /// If you provide an `az_id`, connections will be preferentially made to
+    /// addresses in that availability zone, if any are available.
     pub fn new(
         credential_provider: CredentialProvider,
         runtime: tokio::runtime::Handle,
+        az_id: Option<String>,
     ) -> MomentoResult<Self> {
-        let endpoint = &credential_provider.cache_endpoint;
-        let endpoint_address =
-            endpoint
-                .to_string()
-                .parse()
-                .map_err(|e: std::net::AddrParseError| {
-                    MomentoError::unknown_error("build", Some(e.to_string()))
-                })?;
+        let endpoint = match http::Uri::from_str(&credential_provider.cache_endpoint) {
+            Ok(endpoint) => endpoint,
+            Err(e) => {
+                return Err(MomentoError::unknown_error(
+                    "protosocket_connection_manager::new",
+                    Some(format!(
+                        "Error parsing endpoint URI from credential provider: {}: {:?}",
+                        &credential_provider.cache_endpoint, e
+                    )),
+                ));
+            }
+        };
 
-        let hostname = endpoint
-            .split(":")
-            .next()
-            .unwrap_or("localhost")
-            .to_string();
+        let hostname = match endpoint.host() {
+            Some(hostname) => hostname.to_string(),
+            None => {
+                return Err(MomentoError::unknown_error(
+                    "protosocket_connection_manager::new",
+                    Some(format!(
+                        "Could not extract hostname from endpoint URI: {}",
+                        &credential_provider.cache_endpoint
+                    )),
+                ));
+            }
+        };
+
+        let address_provider = Arc::new(AddressProvider::new(credential_provider.clone()));
+        let alive = Arc::new(AtomicBool::new(true));
+
+        runtime.spawn(refresh_addresses_forever(
+            alive.clone(),
+            address_provider.clone(),
+            Duration::from_secs(30),
+        ));
+
         Ok(Self {
             credential_provider,
             runtime,
-            endpoint_address,
             hostname,
+            address_provider,
+            alive,
+            az_id,
+            connection_sequence: Default::default(),
         })
+    }
+}
+
+impl Drop for ProtosocketConnectionManager {
+    fn drop(&mut self) {
+        if self.alive.swap(false, std::sync::atomic::Ordering::Relaxed) {
+            log::info!("shutting down address refresher task");
+        }
     }
 }
 
@@ -62,15 +113,46 @@ impl ClientConnector for ProtosocketConnectionManager {
         self,
     ) -> protosocket_rpc::Result<protosocket_rpc::client::RpcClient<Self::Request, Self::Response>>
     {
+        if self
+            .address_provider
+            .get_addresses()
+            .for_az(self.az_id.as_deref())
+            .is_empty()
+        {
+            if let Err(e) = self.address_provider.try_refresh_addresses().await {
+                log::warn!("error refreshing address list: {e:?}");
+            }
+        }
+        let addresses = self
+            .address_provider
+            .get_addresses()
+            .for_az(self.az_id.as_deref());
+        if addresses.is_empty() {
+            return Err(protosocket_rpc::Error::IoFailure(
+                std::io::Error::new(
+                    std::io::ErrorKind::AddrNotAvailable,
+                    "No addresses available from address provider",
+                )
+                .into(),
+            ));
+        }
+        let address = addresses[self
+            .connection_sequence
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            % addresses.len()];
+        log::debug!("connecting over protosocket to {address}");
+
         let unauthenticated_client = create_protosocket_connection(
             self.credential_provider.clone(),
             self.runtime.clone(),
-            self.endpoint_address,
+            address,
             &self.hostname,
         )
         .await
         .map_err(|e| {
-            protosocket_rpc::Error::IoFailure(std::io::Error::other(e.to_string()).into())
+            protosocket_rpc::Error::IoFailure(
+                std::io::Error::other(format!("could not connect {e:?}")).into(),
+            )
         })?;
         let client = authenticate_protosocket_client(
             unauthenticated_client,
@@ -79,9 +161,34 @@ impl ClientConnector for ProtosocketConnectionManager {
         )
         .await
         .map_err(|e| {
-            protosocket_rpc::Error::IoFailure(std::io::Error::other(e.to_string()).into())
+            protosocket_rpc::Error::IoFailure(
+                std::io::Error::other(format!("could not authenticate {e:?}")).into(),
+            )
         })?;
         Ok(client)
+    }
+}
+
+async fn refresh_addresses_forever(
+    alive: Arc<AtomicBool>,
+    address_provider: Arc<AddressProvider>,
+    interval: std::time::Duration,
+) {
+    let mut interval = tokio::time::interval(interval);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        interval.tick().await;
+        if !alive.load(std::sync::atomic::Ordering::Relaxed) {
+            break;
+        }
+        match address_provider.try_refresh_addresses().await {
+            Ok(_) => {
+                log::trace!("successfully refreshed address list");
+            }
+            Err(e) => {
+                log::warn!("error refreshing address list: {e:?}");
+            }
+        }
     }
 }
 
@@ -93,6 +200,7 @@ async fn create_protosocket_connection(
 ) -> MomentoResult<protosocket_rpc::client::RpcClient<CacheCommand, CacheResponse>> {
     match credential_provider.endpoint_security {
         EndpointSecurity::Tls => {
+            log::debug!("creating TLS connection to {address}");
             let server_name = ServerName::try_from(hostname.to_string()).map_err(|_| {
                 MomentoError::unknown_error(
                     "build",
@@ -106,6 +214,7 @@ async fn create_protosocket_connection(
             create_connection_with_connector(address, connector, runtime).await
         }
         EndpointSecurity::Unverified => {
+            log::debug!("creating unverified TLS connection to {address}");
             let server_name = ServerName::try_from(hostname.to_string()).map_err(|_| {
                 MomentoError::unknown_error(
                     "build",
@@ -119,9 +228,10 @@ async fn create_protosocket_connection(
             create_connection_with_connector(address, connector, runtime).await
         }
         EndpointSecurity::Insecure => {
+            log::debug!("creating tcp connection to {address}");
             // TODO: seems to hang when credential provider uses insecure endpoint with server expecting one of the other options,
             // probably dropping an error or need to set a timeout somewhere
-            let connector = TcpStreamConnector {};
+            let connector = TcpStreamConnector;
             create_connection_with_connector(address, connector, runtime).await
         }
     }

--- a/src/protosocket/cache/mod.rs
+++ b/src/protosocket/cache/mod.rs
@@ -8,7 +8,9 @@ mod config;
 pub use config::configuration::Configuration;
 pub use config::configurations;
 
+mod connection_manager;
+
+mod address_provider;
+
 mod messages;
 pub use messages::MomentoProtosocketRequest;
-
-mod utils;


### PR DESCRIPTION
Momento direct connect uses an http+json -> protosocket negotiation
handshake. The http connection retrieves a list of socket addresses
that can be used with the connection-oriented protosocket rpc
protocol.

The ProtosocketCacheClient queries the address list on initial
connection, and updates the local list in the background. When a new
connection is required, for example due to a disconnect, the local
list is used to choose a new socket address for that "slot."

Direct connections are lighter than grpc connections, but currently
have some compromises. For example, they do not currently support
graceful GOAWAY mechanism. Also, the cached local address list may
be out of date with reality for a few seconds, causing some possible
re-connect attempts to fail until list refresh.

This connection scheme will be improved over time, and is expected
to outperform grpc for both cost & latency now, and match grpc
practically for resilience in the future.
