### PR TITLE
feat: pin version with `PutFunctionConfigRequest`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "momento-protos"
-version = "0.128.2"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b06b41c5c34c07bc99048f38cdf073467414460bb5fa6231fb45971d68dec06"
+checksum = "0da49420d6a1e070d54831d9ed72af16e08f3e67850df566c9f6a6409f29ae62"
 dependencies = [
  "prost",
  "protosocket-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ doc = false
 
 
 [dependencies]
-momento-protos = "0.128.2"
+momento-protos = "0.129.0"
 base64 = "0.22"
 derive_more = { version = "2.0.1", features = ["full"] }
 futures = "0"

--- a/src/functions/function.rs
+++ b/src/functions/function.rs
@@ -313,7 +313,7 @@ pub enum CurrentFunctionVersion {
     /// The latest version
     Latest,
     /// A specific version number
-    Pinned(usize),
+    Pinned(u32),
 }
 
 impl From<CurrentFunctionVersion> for momento_protos::function_types::CurrentFunctionVersion {
@@ -333,7 +333,7 @@ impl From<CurrentFunctionVersion> for momento_protos::function_types::CurrentFun
                     version: Some(
                         momento_protos::function_types::current_function_version::Version::Pinned(
                             momento_protos::function_types::current_function_version::Pinned {
-                                pinned_version: pinned_version as u32,
+                                pinned_version,
                             },
                         ),
                     ),

--- a/src/functions/function.rs
+++ b/src/functions/function.rs
@@ -316,6 +316,12 @@ pub enum CurrentFunctionVersion {
     Pinned(u32),
 }
 
+impl From<u32> for CurrentFunctionVersion {
+    fn from(pinned_version: u32) -> Self {
+        CurrentFunctionVersion::Pinned(pinned_version)
+    }
+}
+
 impl From<CurrentFunctionVersion> for momento_protos::function_types::CurrentFunctionVersion {
     fn from(value: CurrentFunctionVersion) -> Self {
         match value {

--- a/src/functions/function.rs
+++ b/src/functions/function.rs
@@ -308,7 +308,7 @@ impl From<WasmSource> for momento_protos::function::put_function_request::WasmLo
 }
 
 /// The current version to use upon invocation of the Momento Function.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CurrentFunctionVersion {
     /// The latest version
     Latest,

--- a/src/functions/function.rs
+++ b/src/functions/function.rs
@@ -1,4 +1,4 @@
-use momento_protos::function_types::{CurrentFunctionVersion, WasmId};
+use momento_protos::function_types::WasmId;
 
 /// Description of a Function in Momento.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -66,7 +66,7 @@ impl From<momento_protos::function_types::Function> for Function {
             description,
             function_id,
             version: match current_version {
-                Some(CurrentFunctionVersion {
+                Some(momento_protos::function_types::CurrentFunctionVersion {
                     version: Some(version),
                 }) => match version {
                     momento_protos::function_types::current_function_version::Version::Latest(
@@ -303,6 +303,42 @@ impl From<WasmSource> for momento_protos::function::put_function_request::WasmLo
                 id: wasm_id,
                 version,
             }),
+        }
+    }
+}
+
+/// The current version to use upon invocation of the Momento Function.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum CurrentFunctionVersion {
+    /// The latest version
+    Latest,
+    /// A specific version number
+    Pinned(usize),
+}
+
+impl From<CurrentFunctionVersion> for momento_protos::function_types::CurrentFunctionVersion {
+    fn from(value: CurrentFunctionVersion) -> Self {
+        match value {
+            CurrentFunctionVersion::Latest => {
+                momento_protos::function_types::CurrentFunctionVersion {
+                    version: Some(
+                        momento_protos::function_types::current_function_version::Version::Latest(
+                            momento_protos::function_types::current_function_version::Latest {},
+                        ),
+                    ),
+                }
+            }
+            CurrentFunctionVersion::Pinned(pinned_version) => {
+                momento_protos::function_types::CurrentFunctionVersion {
+                    version: Some(
+                        momento_protos::function_types::current_function_version::Version::Pinned(
+                            momento_protos::function_types::current_function_version::Pinned {
+                                pinned_version: pinned_version as u32,
+                            },
+                        ),
+                    ),
+                }
+            }
         }
     }
 }

--- a/src/functions/function.rs
+++ b/src/functions/function.rs
@@ -59,6 +59,7 @@ impl From<momento_protos::function_types::Function> for Function {
             latest_version,
             concurrency_limit,
             last_updated_at,
+            function_limits: _, // TODO implement getter(s) for function limits
         } = proto;
         Self {
             name,

--- a/src/functions/messages/mod.rs
+++ b/src/functions/messages/mod.rs
@@ -3,6 +3,7 @@ mod list_functions;
 mod list_wasms;
 mod momento_request;
 mod put_function;
+mod put_function_config;
 mod put_wasm;
 
 pub use list_function_versions::{ListFunctionVersionsRequest, ListFunctionVersionsStream};
@@ -10,4 +11,5 @@ pub use list_functions::{ListFunctionsRequest, ListFunctionsStream};
 pub use list_wasms::{ListWasmsRequest, ListWasmsStream};
 pub use momento_request::MomentoRequest;
 pub use put_function::PutFunctionRequest;
+pub use put_function_config::PutFunctionConfigRequest;
 pub use put_wasm::PutWasmRequest;

--- a/src/functions/messages/put_function_config.rs
+++ b/src/functions/messages/put_function_config.rs
@@ -34,8 +34,7 @@ use momento_protos::function_types::FunctionKey;
 /// # let function = function_client.send(request).await?;
 /// # println!("Created a function: {function:?}");
 ///
-/// let request = PutFunctionConfigRequest::from_function_name(cache_name, "hello functions")
-///     .current_version(CurrentFunctionVersion::Pinned(0));
+/// let request = PutFunctionConfigRequest::from_function_name(cache_name, "hello functions").current_version(0);
 /// let function = function_client.send(request).await?;
 /// println!("Updated a function's config: {function:?}");
 /// # Ok(())
@@ -76,8 +75,11 @@ impl PutFunctionConfigRequest {
     }
 
     /// Choose the version to use upon invocation
-    pub fn current_version(mut self, current_version: CurrentFunctionVersion) -> Self {
-        self.new_version = Some(current_version.into());
+    pub fn current_version(mut self, current_version: impl Into<CurrentFunctionVersion>) -> Self {
+        let current_version: CurrentFunctionVersion = current_version.into();
+        let current_version: momento_protos::function_types::CurrentFunctionVersion =
+            current_version.into();
+        self.new_version = Some(current_version);
         self
     }
 }

--- a/src/functions/messages/put_function_config.rs
+++ b/src/functions/messages/put_function_config.rs
@@ -1,13 +1,13 @@
 use std::time::Duration;
 
 use crate::{
-    functions::{Function, FunctionClient, MomentoRequest},
+    functions::{CurrentFunctionVersion, Function, FunctionClient, MomentoRequest},
     utils::prep_request_with_timeout,
     MomentoError, MomentoResult,
 };
 
 use momento_protos::function::put_function_config_request::FunctionSpecifier;
-use momento_protos::function_types::{CurrentFunctionVersion, FunctionKey};
+use momento_protos::function_types::FunctionKey;
 
 /// Update a Function's configuration.
 /// The cache is used as a namespace for your Functions.
@@ -23,18 +23,13 @@ use momento_protos::function_types::{CurrentFunctionVersion, FunctionKey};
 /// # fn main() -> anyhow::Result<()> {
 /// # tokio_test::block_on(async {
 /// use momento::{CredentialProvider, FunctionClient};
-/// use momento::functions::PutFunctionConfigRequest;
-/// use momento_protos::function_types::{current_function_version, CurrentFunctionVersion};
+/// use momento::functions::{CurrentFunctionVersion, PutFunctionConfigRequest};
 /// # use momento_test_util::echo_wasm;
 /// # let (function_client, cache_name) = momento_test_util::create_doctest_function_client();
 /// // load your wasm from a .wasm file compiled with wasm32-wasip2
 /// let function_body = echo_wasm();
 ///
-/// let request = PutFunctionConfigRequest::new(cache_name, "hello functions").current_version(CurrentFunctionVersion {
-///     version: Some(current_function_version::Version::Pinned(current_function_version::Pinned {
-///         pinned_version: 0
-///     }))
-/// });
+/// let request = PutFunctionConfigRequest::new(cache_name, "hello functions").current_version(CurrentFunctionVersion::Pinned(0));
 /// let function = function_client.send(request).await?;
 /// println!("Updated a function's config: {function:?}");
 /// # Ok(())
@@ -44,7 +39,7 @@ use momento_protos::function_types::{CurrentFunctionVersion, FunctionKey};
 pub struct PutFunctionConfigRequest {
     cache_name: String,
     function_name: String,
-    new_version: Option<CurrentFunctionVersion>,
+    new_version: Option<momento_protos::function_types::CurrentFunctionVersion>,
 }
 
 impl PutFunctionConfigRequest {
@@ -59,7 +54,7 @@ impl PutFunctionConfigRequest {
 
     /// Choose the version to use upon invocation
     pub fn current_version(mut self, current_version: CurrentFunctionVersion) -> Self {
-        self.new_version = Some(current_version);
+        self.new_version = Some(current_version.into());
         self
     }
 }

--- a/src/functions/messages/put_function_config.rs
+++ b/src/functions/messages/put_function_config.rs
@@ -29,7 +29,7 @@ use momento_protos::function_types::FunctionKey;
 /// // load your wasm from a .wasm file compiled with wasm32-wasip2
 /// let function_body = echo_wasm();
 ///
-/// let request = PutFunctionConfigRequest::new(cache_name, "hello functions").current_version(CurrentFunctionVersion::Pinned(0));
+/// let request = PutFunctionConfigRequest::new(cache_name).function_name("hello functions").current_version(CurrentFunctionVersion::Pinned(0));
 /// let function = function_client.send(request).await?;
 /// println!("Updated a function's config: {function:?}");
 /// # Ok(())
@@ -38,18 +38,33 @@ use momento_protos::function_types::FunctionKey;
 /// ```
 pub struct PutFunctionConfigRequest {
     cache_name: String,
-    function_name: String,
+    function_specifier: Option<FunctionSpecifier>,
     new_version: Option<momento_protos::function_types::CurrentFunctionVersion>,
 }
 
 impl PutFunctionConfigRequest {
     /// Create a new PutFunctionConfigRequest.
-    pub fn new(cache_name: impl Into<String>, function_name: impl Into<String>) -> Self {
+    pub fn new(cache_name: impl Into<String>) -> Self {
         Self {
             cache_name: cache_name.into(),
-            function_name: function_name.into(),
+            function_specifier: None,
             new_version: None,
         }
+    }
+
+    /// Specify the function by name.
+    pub fn function_name(mut self, function_name: impl Into<String>) -> Self {
+        self.function_specifier = Some(FunctionSpecifier::FunctionKey(FunctionKey {
+            cache_name: self.cache_name.clone(),
+            name: function_name.into(),
+        }));
+        self
+    }
+
+    /// Specify the function by ID.
+    pub fn function_id(mut self, function_id: impl Into<String>) -> Self {
+        self.function_specifier = Some(FunctionSpecifier::FunctionId(function_id.into()));
+        self
     }
 
     /// Choose the version to use upon invocation
@@ -67,10 +82,7 @@ impl MomentoRequest for PutFunctionConfigRequest {
             &self.cache_name.to_string(),
             Duration::from_secs(15),
             momento_protos::function::PutFunctionConfigRequest {
-                function_specifier: Some(FunctionSpecifier::FunctionKey(FunctionKey {
-                    cache_name: self.cache_name,
-                    name: self.function_name,
-                })),
+                function_specifier: self.function_specifier,
                 new_version: self.new_version,
             },
         )?;

--- a/src/functions/messages/put_function_config.rs
+++ b/src/functions/messages/put_function_config.rs
@@ -44,7 +44,7 @@ use momento_protos::function_types::FunctionKey;
 pub struct PutFunctionConfigRequest {
     cache_name: String,
     function_specifier: FunctionSpecifier,
-    new_version: Option<momento_protos::function_types::CurrentFunctionVersion>,
+    new_version: Option<CurrentFunctionVersion>,
 }
 
 impl PutFunctionConfigRequest {
@@ -76,10 +76,7 @@ impl PutFunctionConfigRequest {
 
     /// Choose the version to use upon invocation
     pub fn current_version(mut self, current_version: impl Into<CurrentFunctionVersion>) -> Self {
-        let current_version: CurrentFunctionVersion = current_version.into();
-        let current_version: momento_protos::function_types::CurrentFunctionVersion =
-            current_version.into();
-        self.new_version = Some(current_version);
+        self.new_version = Some(current_version.into());
         self
     }
 }
@@ -93,7 +90,9 @@ impl MomentoRequest for PutFunctionConfigRequest {
             Duration::from_secs(15),
             momento_protos::function::PutFunctionConfigRequest {
                 function_specifier: Some(self.function_specifier),
-                new_version: self.new_version,
+                new_version: self
+                    .new_version
+                    .map(momento_protos::function_types::CurrentFunctionVersion::from),
             },
         )?;
 

--- a/src/functions/messages/put_function_config.rs
+++ b/src/functions/messages/put_function_config.rs
@@ -32,7 +32,8 @@ use momento_protos::function_types::FunctionKey;
 /// let function = function_client.send(request).await?;
 /// println!("Created a function: {function:?}");
 ///
-/// let request = PutFunctionConfigRequest::from_function_name(cache_name, "hello functions").current_version(CurrentFunctionVersion::Pinned(0));
+/// let request = PutFunctionConfigRequest::from_function_name(cache_name, "hello functions")
+///     .current_version(CurrentFunctionVersion::Pinned(0));
 /// let function = function_client.send(request).await?;
 /// println!("Updated the function's config: {function:?}");
 /// # Ok(())

--- a/src/functions/messages/put_function_config.rs
+++ b/src/functions/messages/put_function_config.rs
@@ -29,7 +29,7 @@ use momento_protos::function_types::FunctionKey;
 /// // load your wasm from a .wasm file compiled with wasm32-wasip2
 /// let function_body = echo_wasm();
 ///
-/// let request = PutFunctionConfigRequest::new(cache_name).function_name("hello functions").current_version(CurrentFunctionVersion::Pinned(0));
+/// let request = PutFunctionConfigRequest::from_function_name(cache_name, "hello functions").current_version(CurrentFunctionVersion::Pinned(0));
 /// let function = function_client.send(request).await?;
 /// println!("Updated a function's config: {function:?}");
 /// # Ok(())
@@ -38,33 +38,35 @@ use momento_protos::function_types::FunctionKey;
 /// ```
 pub struct PutFunctionConfigRequest {
     cache_name: String,
-    function_specifier: Option<FunctionSpecifier>,
+    function_specifier: FunctionSpecifier,
     new_version: Option<momento_protos::function_types::CurrentFunctionVersion>,
 }
 
 impl PutFunctionConfigRequest {
-    /// Create a new PutFunctionConfigRequest.
-    pub fn new(cache_name: impl Into<String>) -> Self {
+    /// Create a new PutFunctionConfigRequest, specified by function name
+    pub fn from_function_name(
+        cache_name: impl Into<String>,
+        function_name: impl Into<String>,
+    ) -> Self {
+        let cache_name = cache_name.into();
         Self {
-            cache_name: cache_name.into(),
-            function_specifier: None,
+            cache_name: cache_name.clone(),
+            function_specifier: FunctionSpecifier::FunctionKey(FunctionKey {
+                cache_name,
+                name: function_name.into(),
+            }),
             new_version: None,
         }
     }
 
-    /// Specify the function by name.
-    pub fn function_name(mut self, function_name: impl Into<String>) -> Self {
-        self.function_specifier = Some(FunctionSpecifier::FunctionKey(FunctionKey {
-            cache_name: self.cache_name.clone(),
-            name: function_name.into(),
-        }));
-        self
-    }
-
-    /// Specify the function by ID.
-    pub fn function_id(mut self, function_id: impl Into<String>) -> Self {
-        self.function_specifier = Some(FunctionSpecifier::FunctionId(function_id.into()));
-        self
+    /// Create a new PutFunctionConfigRequest, specified by function ID
+    pub fn from_function_id(cache_name: impl Into<String>, function_id: impl Into<String>) -> Self {
+        let cache_name = cache_name.into();
+        Self {
+            cache_name: cache_name.clone(),
+            function_specifier: FunctionSpecifier::FunctionId(function_id.into()),
+            new_version: None,
+        }
     }
 
     /// Choose the version to use upon invocation
@@ -82,7 +84,7 @@ impl MomentoRequest for PutFunctionConfigRequest {
             &self.cache_name.to_string(),
             Duration::from_secs(15),
             momento_protos::function::PutFunctionConfigRequest {
-                function_specifier: self.function_specifier,
+                function_specifier: Some(self.function_specifier),
                 new_version: self.new_version,
             },
         )?;

--- a/src/functions/messages/put_function_config.rs
+++ b/src/functions/messages/put_function_config.rs
@@ -24,11 +24,12 @@ use momento_protos::function_types::FunctionKey;
 /// # tokio_test::block_on(async {
 /// use momento::{CredentialProvider, FunctionClient};
 /// use momento::functions::{CurrentFunctionVersion, PutFunctionConfigRequest};
+/// use momento::functions::PutFunctionRequest;
 /// # use momento_test_util::echo_wasm;
 /// # let (function_client, cache_name) = momento_test_util::create_doctest_function_client();
 /// // put your function first
 /// let function_body = echo_wasm();
-/// let request = PutFunctionRequest::new(cache_name, "hello functions", function_body);
+/// let request = PutFunctionRequest::new(cache_name.clone(), "hello functions", function_body);
 /// let function = function_client.send(request).await?;
 /// println!("Created a function: {function:?}");
 ///

--- a/src/functions/messages/put_function_config.rs
+++ b/src/functions/messages/put_function_config.rs
@@ -24,19 +24,20 @@ use momento_protos::function_types::FunctionKey;
 /// # tokio_test::block_on(async {
 /// use momento::{CredentialProvider, FunctionClient};
 /// use momento::functions::{CurrentFunctionVersion, PutFunctionConfigRequest};
-/// use momento::functions::PutFunctionRequest;
+///
+/// # // put the function first
+/// # use momento::functions::PutFunctionRequest;
 /// # use momento_test_util::echo_wasm;
 /// # let (function_client, cache_name) = momento_test_util::create_doctest_function_client();
-/// // put your function first
-/// let function_body = echo_wasm();
-/// let request = PutFunctionRequest::new(cache_name.clone(), "hello functions", function_body);
-/// let function = function_client.send(request).await?;
-/// println!("Created a function: {function:?}");
+/// # let function_body = echo_wasm();
+/// # let request = PutFunctionRequest::new(cache_name.clone(), "hello functions", function_body);
+/// # let function = function_client.send(request).await?;
+/// # println!("Created a function: {function:?}");
 ///
 /// let request = PutFunctionConfigRequest::from_function_name(cache_name, "hello functions")
 ///     .current_version(CurrentFunctionVersion::Pinned(0));
 /// let function = function_client.send(request).await?;
-/// println!("Updated the function's config: {function:?}");
+/// println!("Updated a function's config: {function:?}");
 /// # Ok(())
 /// # })
 /// # }

--- a/src/functions/messages/put_function_config.rs
+++ b/src/functions/messages/put_function_config.rs
@@ -26,12 +26,15 @@ use momento_protos::function_types::FunctionKey;
 /// use momento::functions::{CurrentFunctionVersion, PutFunctionConfigRequest};
 /// # use momento_test_util::echo_wasm;
 /// # let (function_client, cache_name) = momento_test_util::create_doctest_function_client();
-/// // load your wasm from a .wasm file compiled with wasm32-wasip2
+/// // put your function first
 /// let function_body = echo_wasm();
+/// let request = PutFunctionRequest::new(cache_name, "hello functions", function_body);
+/// let function = function_client.send(request).await?;
+/// println!("Created a function: {function:?}");
 ///
 /// let request = PutFunctionConfigRequest::from_function_name(cache_name, "hello functions").current_version(CurrentFunctionVersion::Pinned(0));
 /// let function = function_client.send(request).await?;
-/// println!("Updated a function's config: {function:?}");
+/// println!("Updated the function's config: {function:?}");
 /// # Ok(())
 /// # })
 /// # }

--- a/src/functions/messages/put_function_config.rs
+++ b/src/functions/messages/put_function_config.rs
@@ -14,8 +14,10 @@ use momento_protos::function_types::FunctionKey;
 ///
 /// # Arguments
 ///
-/// * `cache_name` - The name of the cache to use as a namespace for the Function.
-/// * `function_name` - The name of the Function.
+/// * `cache_name` - The name of the cache being used a namespace for the Function.
+/// * `function_name` or `function_id` - The name or ID of the Function.
+/// * Fields that can be configured / updated:
+///     `current_version` - The current version to use upon invocation of the Function.
 ///
 /// # Example
 ///

--- a/src/functions/messages/put_function_config.rs
+++ b/src/functions/messages/put_function_config.rs
@@ -12,13 +12,6 @@ use momento_protos::function_types::FunctionKey;
 /// Update a Function's configuration.
 /// The cache is used as a namespace for your Functions.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache being used a namespace for the Function.
-/// * `function_name` or `function_id` - The name or ID of the Function.
-/// * Fields that can be configured / updated:
-///     `current_version` - The current version to use upon invocation of the Function.
-///
 /// # Example
 ///
 /// ```rust

--- a/src/functions/messages/put_function_config.rs
+++ b/src/functions/messages/put_function_config.rs
@@ -1,0 +1,96 @@
+use std::time::Duration;
+
+use crate::{
+    functions::{Function, FunctionClient, MomentoRequest},
+    utils::prep_request_with_timeout,
+    MomentoError, MomentoResult,
+};
+
+use momento_protos::function::put_function_config_request::FunctionSpecifier;
+use momento_protos::function_types::{CurrentFunctionVersion, FunctionKey};
+
+/// Update a Function's configuration.
+/// The cache is used as a namespace for your Functions.
+///
+/// # Arguments
+///
+/// * `cache_name` - The name of the cache to use as a namespace for the Function.
+/// * `function_name` - The name of the Function.
+///
+/// # Example
+///
+/// ```rust
+/// # fn main() -> anyhow::Result<()> {
+/// # tokio_test::block_on(async {
+/// use momento::{CredentialProvider, FunctionClient};
+/// use momento::functions::PutFunctionConfigRequest;
+/// use momento_protos::function_types::{current_function_version, CurrentFunctionVersion};
+/// # use momento_test_util::echo_wasm;
+/// # let (function_client, cache_name) = momento_test_util::create_doctest_function_client();
+/// // load your wasm from a .wasm file compiled with wasm32-wasip2
+/// let function_body = echo_wasm();
+///
+/// let request = PutFunctionConfigRequest::new(cache_name, "hello functions").current_version(CurrentFunctionVersion {
+///     version: Some(current_function_version::Version::Pinned(current_function_version::Pinned {
+///         pinned_version: 0
+///     }))
+/// });
+/// let function = function_client.send(request).await?;
+/// println!("Updated a function's config: {function:?}");
+/// # Ok(())
+/// # })
+/// # }
+/// ```
+pub struct PutFunctionConfigRequest {
+    cache_name: String,
+    function_name: String,
+    new_version: Option<CurrentFunctionVersion>,
+}
+
+impl PutFunctionConfigRequest {
+    /// Create a new PutFunctionConfigRequest.
+    pub fn new(cache_name: impl Into<String>, function_name: impl Into<String>) -> Self {
+        Self {
+            cache_name: cache_name.into(),
+            function_name: function_name.into(),
+            new_version: None,
+        }
+    }
+
+    /// Choose the version to use upon invocation
+    pub fn current_version(mut self, current_version: CurrentFunctionVersion) -> Self {
+        self.new_version = Some(current_version);
+        self
+    }
+}
+
+impl MomentoRequest for PutFunctionConfigRequest {
+    type Response = Function;
+
+    async fn send(self, client: &FunctionClient) -> MomentoResult<Function> {
+        let request = prep_request_with_timeout(
+            &self.cache_name.to_string(),
+            Duration::from_secs(15),
+            momento_protos::function::PutFunctionConfigRequest {
+                function_specifier: Some(FunctionSpecifier::FunctionKey(FunctionKey {
+                    cache_name: self.cache_name,
+                    name: self.function_name,
+                })),
+                new_version: self.new_version,
+            },
+        )?;
+
+        let response = client.client().clone().put_function_config(request).await?;
+        let function: Function = response
+            .into_inner()
+            .function
+            .ok_or_else(|| {
+                MomentoError::unknown_error(
+                    "put_function_config",
+                    Some("service did not return a Function description".to_string()),
+                )
+            })?
+            .into();
+        Ok(function)
+    }
+}

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -12,6 +12,6 @@ pub use function_client::FunctionClient;
 pub use function_client_builder::FunctionClientBuilder;
 pub use messages::{
     ListFunctionVersionsRequest, ListFunctionVersionsStream, ListFunctionsRequest,
-    ListFunctionsStream, ListWasmsRequest, ListWasmsStream, MomentoRequest, PutFunctionRequest,
-    PutWasmRequest,
+    ListFunctionsStream, ListWasmsRequest, ListWasmsStream, MomentoRequest,
+    PutFunctionConfigRequest, PutFunctionRequest, PutWasmRequest,
 };

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -6,7 +6,8 @@ mod function_client_builder;
 mod messages;
 
 pub use function::{
-    EnvironmentValue, Function, FunctionVersion, FunctionVersionId, Wasm, WasmSource, WasmVersionId,
+    CurrentFunctionVersion, EnvironmentValue, Function, FunctionVersion, FunctionVersionId, Wasm,
+    WasmSource, WasmVersionId,
 };
 pub use function_client::FunctionClient;
 pub use function_client_builder::FunctionClientBuilder;


### PR DESCRIPTION
This PR implements `PutFunctionConfigRequest`, which so far allows customers to pin their Momento Function to a specific version, instead of always following the latest version.

This feature is currently in beta/preview, alongside the other Functions features.

## Usage Examples

**Setup:**

1. Set your `cache_name`, `function_name`, `function_client`
2. Put your function

**Pin to a specific version:**

```rust
use momento::functions::{CurrentFunctionVersion, PutFunctionConfigRequest};

let request = PutFunctionConfigRequest::from_function_name(cache_name, function_name)
    .current_version(CurrentFunctionVersion::Pinned(0));
let function = function_client.send(request).await?;
```

**Pin to a specific version, concise style:**

```rust
use momento::functions::PutFunctionConfigRequest;

let request = PutFunctionConfigRequest::from_function_name(cache_name, function_name)
    .current_version(1));
let function = function_client.send(request).await?;
```

**Always use/follow the latest version:**

```rust
use momento::functions::{CurrentFunctionVersion, PutFunctionConfigRequest};

let request = PutFunctionConfigRequest::from_function_name(cache_name, function_name)
    .current_version(CurrentFunctionVersion::Latest);
let function = function_client.send(request).await?;
```

## Tests

**Setup:**

```bash
read -s -p "v2 API key: " MOMENTO_API_KEY
read -s -p "v1 API key: " V1_API_KEY
read -p "Endpoint: " MOMENTO_ENDPOINT

export MOMENTO_API_KEY V1_API_KEY MOMENTO_ENDPOINT
export TEST_CACHE_NAME=rust-sdk-test-cache TEST_AUTH_CACHE_NAME=rust-sdk-test-cache-auth
```

**First-time setup:**

```bash
momento cache create $TEST_CACHE_NAME
momento cache create $TEST_AUTH_CACHE_NAME
```

**Run doctests:**

```bash
cargo test --doc PutFunctionConfigRequest
# running 1 test
# test src/functions/messages/put_function_config.rs - functions::messages::put_function_config::PutFunctionConfigRequest (line 22) ... ok
# test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 209 filtered out; finished in 1.04s

make test-doctests
# test result: ok. 210 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 25.37s
```