### PR TITLE
feat: support `FunctionVersion` descriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,9 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "momento-protos"
-version = "0.129.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da49420d6a1e070d54831d9ed72af16e08f3e67850df566c9f6a6409f29ae62"
+version = "0.1.0"
 dependencies = [
  "prost",
  "protosocket-rpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "momento-protos"
-version = "0.1.0"
+version = "0.130.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64297cbc2d3946a4a64365db65cdfb6df6c65fec66af7bfa3a3cc71da94b6a11"
 dependencies = [
  "prost",
  "protosocket-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ doc = false
 
 
 [dependencies]
-momento-protos = "0.129.0"
+momento-protos = { path = "../client-protos/rust/momento-protos" }
 base64 = "0.22"
 derive_more = { version = "2.0.1", features = ["full"] }
 futures = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ doc = false
 
 
 [dependencies]
-momento-protos = { path = "../client-protos/rust/momento-protos" }
+momento-protos = "0.130.0"
 base64 = "0.22"
 derive_more = { version = "2.0.1", features = ["full"] }
 futures = "0"

--- a/src/functions/function.rs
+++ b/src/functions/function.rs
@@ -4,6 +4,7 @@ use momento_protos::function_types::WasmId;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Function {
     name: String,
+    /// TODO: deprecate this when we have fully migrated to FunctionVersion descriptions
     description: String,
     function_id: String,
     version: u32,
@@ -90,6 +91,8 @@ impl From<momento_protos::function_types::Function> for Function {
 pub struct FunctionVersion {
     /// The unique identifier for this function version.
     version_id: FunctionVersionId,
+    // The description of the function or this specific version/implementation.
+    description: String,
     /// The wasm ID this function uses.
     wasm_version_id: WasmVersionId,
     /// The environment variables available to this function via the WASI environment interface.
@@ -99,6 +102,11 @@ impl FunctionVersion {
     /// The unique identifier for this function version.
     pub fn version_id(&self) -> &FunctionVersionId {
         &self.version_id
+    }
+
+    /// Description of this function version.
+    pub fn description(&self) -> &str {
+        &self.description
     }
 
     /// The wasm ID this function uses.
@@ -116,6 +124,7 @@ impl From<momento_protos::function_types::FunctionVersion> for FunctionVersion {
     fn from(proto: momento_protos::function_types::FunctionVersion) -> Self {
         let momento_protos::function_types::FunctionVersion {
             id,
+            description,
             wasm_id,
             environment,
         } = proto;
@@ -126,6 +135,7 @@ impl From<momento_protos::function_types::FunctionVersion> for FunctionVersion {
                 id: id.id,
                 version: id.version,
             },
+            description,
             wasm_version_id: WasmVersionId {
                 id: wasm_id.id,
                 version: wasm_id.version,

--- a/src/functions/messages/put_function.rs
+++ b/src/functions/messages/put_function.rs
@@ -57,7 +57,7 @@ impl PutFunctionRequest {
         }
     }
 
-    /// Set the Function's description
+    /// Set the description for the Function or this specific version/implementation
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.description = description.into();
         self


### PR DESCRIPTION
Prepares for migration from overall `Function` description to specific `FunctionVersion` descriptions, which can, for example, note the GitHub release associated with each function version and allow for quick selection for rollback / pinning.

(work towards https://github.com/momentohq/momento-cli/pull/371)