### PR TITLE
docs: don't deprecate `Function` description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "momento-protos"
-version = "0.130.0"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64297cbc2d3946a4a64365db65cdfb6df6c65fec66af7bfa3a3cc71da94b6a11"
+checksum = "e522903f13088da517d053096450fdd8073f889674e0490ba479118607f88282"
 dependencies = [
  "prost",
  "protosocket-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ doc = false
 
 
 [dependencies]
-momento-protos = "0.130.0"
+momento-protos = "0.130.1"
 base64 = "0.22"
 derive_more = { version = "2.0.1", features = ["full"] }
 futures = "0"

--- a/src/functions/function.rs
+++ b/src/functions/function.rs
@@ -4,7 +4,6 @@ use momento_protos::function_types::WasmId;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Function {
     name: String,
-    /// TODO: deprecate this when we have fully migrated to FunctionVersion descriptions
     description: String,
     function_id: String,
     version: u32,
@@ -18,7 +17,7 @@ impl Function {
         &self.name
     }
 
-    /// Description of the function.
+    /// Current/active description of the function.
     pub fn description(&self) -> &str {
         &self.description
     }
@@ -91,7 +90,7 @@ impl From<momento_protos::function_types::Function> for Function {
 pub struct FunctionVersion {
     /// The unique identifier for this function version.
     version_id: FunctionVersionId,
-    // The description of the function or this specific version/implementation.
+    /// The description of the function or this specific version/implementation.
     description: String,
     /// The wasm ID this function uses.
     wasm_version_id: WasmVersionId,
@@ -104,7 +103,7 @@ impl FunctionVersion {
         &self.version_id
     }
 
-    /// Description of this function version.
+    /// The description of the function or this specific version/implementation.
     pub fn description(&self) -> &str {
         &self.description
     }


### PR DESCRIPTION
Gets populated with the `description` from its current/active `FunctionVersion`