### PR TITLE
docs: update docstrings & naming

### DIFF
--- a/example/rust/README.md
+++ b/example/rust/README.md
@@ -40,7 +40,7 @@ V1_API_KEY=<YOUR V1 API KEY> cargo run --bin=topics
 
 Example Code: [topics.rs](src/bin/topics.rs)
 
-Note: to see a non-null `publisher_id` on a received [`SubscriptionValue`](https://docs.rs/momento/0.46.1/momento/topics/struct.SubscriptionValue.html), you'll need to set the optional `token_id` argument when programmatically creating a [disposable token](https://docs.momentohq.com/cache/develop/api-reference/auth#generatedisposabletoken). An example of this is provided in [topics.rs](src/bin/topics.rs).
+Note: to see a non-null `publisher_id` on a received [`SubscriptionValue`](https://docs.rs/momento/0.46.1/momento/topics/struct.SubscriptionValue.html), you'll need to set the optional `token_id` field when programmatically creating a [disposable token](https://docs.momentohq.com/cache/develop/api-reference/auth#generatedisposabletoken). An example of this is provided in [topics.rs](src/bin/topics.rs).
 
 ----------------------------------------------------------------------------------------
 For more info, visit our website at [https://gomomento.com](https://gomomento.com)!

--- a/example/rust/README.template.md
+++ b/example/rust/README.template.md
@@ -36,6 +36,6 @@ V1_API_KEY=<YOUR V1 API KEY> cargo run --bin=topics
 
 Example Code: [topics.rs](src/bin/topics.rs)
 
-Note: to see a non-null `publisher_id` on a received [`SubscriptionValue`](https://docs.rs/momento/0.46.1/momento/topics/struct.SubscriptionValue.html), you'll need to set the optional `token_id` argument when programmatically creating a [disposable token](https://docs.momentohq.com/cache/develop/api-reference/auth#generatedisposabletoken). An example of this is provided in [topics.rs](src/bin/topics.rs).
+Note: to see a non-null `publisher_id` on a received [`SubscriptionValue`](https://docs.rs/momento/0.46.1/momento/topics/struct.SubscriptionValue.html), you'll need to set the optional `token_id` field when programmatically creating a [disposable token](https://docs.momentohq.com/cache/develop/api-reference/auth#generatedisposabletoken). An example of this is provided in [topics.rs](src/bin/topics.rs).
 
 {{ ossFooter }}

--- a/src/auth/auth_client.rs
+++ b/src/auth/auth_client.rs
@@ -52,9 +52,6 @@ impl AuthClient {
     ///
     /// Note: AuthClient does not take a configuration but this is subject to change.
     ///
-    /// # Arguments
-    /// - `credential_provider` - A [CredentialProvider](crate::CredentialProvider) to use for authenticating with Momento.
-    ///
     /// # Example
     ///
     /// ```

--- a/src/auth/auth_client.rs
+++ b/src/auth/auth_client.rs
@@ -87,12 +87,6 @@ impl AuthClient {
     /// * `scope` - The permission scope that the token will have.
     /// * `expires_in` - The duration for which the token will be valid. Note: disposable tokens must expire within 25 hours.
     ///
-    /// # Optional Arguments
-    /// If you use [send_request](AuthClient::send_request) to generate a token using a
-    /// [GenerateDisposableTokenRequest], you can also provide the following optional arguments:
-    ///
-    /// * `props` - A collection of optional arguments for the request. Currently contains only `token_id`, which can be used to identify which token was used for messages published on Momento Topics.
-    ///
     /// # Example
     /// Assumes that an AuthClient named `auth_client` has been created and is available.
     /// ```
@@ -111,7 +105,8 @@ impl AuthClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](AuthClient::send_request) method to get an item using a [GenerateDisposableTokenRequest].
+    /// You can also use the [send_request](AuthClient::send_request) method to get an item using a [GenerateDisposableTokenRequest],
+    /// which will allow you to set optional fields like [token_id](GenerateDisposableTokenRequest::token_id) as well.
     pub async fn generate_disposable_token(
         &self,
         scope: DisposableTokenScope,

--- a/src/auth/auth_client.rs
+++ b/src/auth/auth_client.rs
@@ -102,7 +102,7 @@ impl AuthClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](AuthClient::send_request) method to get an item using a [GenerateDisposableTokenRequest],
+    /// You can also use the [send_request](AuthClient::send_request) method to generate a token using a [GenerateDisposableTokenRequest],
     /// which will allow you to set optional fields like [token_id](GenerateDisposableTokenRequest::token_id) as well.
     pub async fn generate_disposable_token(
         &self,

--- a/src/auth/auth_client.rs
+++ b/src/auth/auth_client.rs
@@ -121,7 +121,8 @@ impl AuthClient {
     /// you want to set optional fields on a request that are not supported by the short-hand API for
     /// that request type.
     ///
-    /// See [GenerateDisposableTokenRequest] for an example of creating a request with optional fields.
+    /// See [GenerateDisposableTokenRequest] for an example of creating a request with optional fields,
+    /// like [token_id](GenerateDisposableTokenRequest::token_id).
     pub async fn send_request<R: MomentoRequest>(&self, request: R) -> MomentoResult<R::Response> {
         request.send(self).await
     }

--- a/src/auth/auth_client_builder.rs
+++ b/src/auth/auth_client_builder.rs
@@ -16,9 +16,7 @@ pub struct ReadyToBuild {
 }
 
 impl AuthClientBuilder<NeedsCredentialProvider> {
-    /// Constructs a new AuthClientBuilder in the NeedsCredentialProvider state.
-    ///
-    /// A [CredentialProvider](crate::CredentialProvider) to use for authenticating with Momento.
+    /// Sets the [CredentialProvider](crate::CredentialProvider) to use for authenticating with Momento.
     pub fn credential_provider(
         self,
         credential_provider: CredentialProvider,

--- a/src/auth/auth_client_builder.rs
+++ b/src/auth/auth_client_builder.rs
@@ -16,6 +16,9 @@ pub struct ReadyToBuild {
 }
 
 impl AuthClientBuilder<NeedsCredentialProvider> {
+    /// Constructs a new AuthClientBuilder in the NeedsCredentialProvider state.
+    ///
+    /// A [CredentialProvider](crate::CredentialProvider) to use for authenticating with Momento.
     pub fn credential_provider(
         self,
         credential_provider: CredentialProvider,

--- a/src/auth/messages/generate_disposable_token.rs
+++ b/src/auth/messages/generate_disposable_token.rs
@@ -60,7 +60,7 @@ impl GenerateDisposableTokenRequest {
         self
     }
 
-    /// Set the optional `token_id`` field of the optional DisposableTokenProps for the request.
+    /// Set the optional `token_id` field of the optional DisposableTokenProps for the request.
     pub fn token_id(mut self, token_id: String) -> Self {
         self.props = Some(DisposableTokenProps {
             token_id: Some(token_id),

--- a/src/auth/messages/generate_disposable_token.rs
+++ b/src/auth/messages/generate_disposable_token.rs
@@ -11,24 +11,13 @@ use super::{permissions_conversions::permissions_from_disposable_token_scope, Mo
 use base64::{engine::general_purpose, Engine as _};
 use momento_protos::token::generate_disposable_token_request::Expires;
 
-/// Optional arguments for generating a disposable token.
+/// Optional fields for generating a disposable token.
 pub struct DisposableTokenProps {
-    /// Currently, the only optional argument is the `token_id`,
-    /// which can be used to identify which token was used for
-    /// messages published on Momento Topics.
+    /// Identifies which token was used for messages published on Momento Topics.
     pub token_id: Option<String>,
 }
 
 /// Request to generate a new disposable, fine-grained access token.
-///
-/// # Arguments
-///
-/// * `scope` - The permission scope that the token will have.
-/// * `expires_in` - The duration for which the token will be valid.
-///
-/// # Optional Arguments
-///
-/// * `props` - A collection of optional arguments for the request. Currently contains only `token_id`, which can be used to identify which token was used for messages published on Momento Topics.
 ///
 /// # Examples
 /// Assumes that an AuthClient named `auth_client` has been created and is available.

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -2579,7 +2579,9 @@ impl CacheClient {
     /// you want to set optional fields on a request that are not supported by the short-hand API for
     /// that request type.
     ///
-    /// See [SortedSetFetchByScoreRequest] for an example of creating a request with optional fields.
+    /// See [SortedSetFetchByScoreRequest] for an example of creating a request with optional fields
+    /// like [min_score](SortedSetFetchByScoreRequest::min_score), [max_score](SortedSetFetchByScoreRequest::max_score),
+    /// [offset](SortedSetFetchByScoreRequest::offset), and [count](SortedSetFetchByScoreRequest::count).
     pub async fn send_request<R: MomentoRequest>(&self, request: R) -> MomentoResult<R::Response> {
         request.send(self).await
     }

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -92,11 +92,6 @@ static NEXT_DATA_CLIENT_INDEX: AtomicUsize = AtomicUsize::new(0);
 impl CacheClient {
     /// Constructs a CacheClient to use Momento Cache.
     ///
-    /// # Arguments
-    /// - `default_ttl` - Default time-to-live for items in the cache.
-    /// - `configuration` - Prebuilt configurations tuned for different environments are available in the [cache::configurations](crate::cache::configurations) module.
-    /// - `credential_provider` - A [CredentialProvider](crate::CredentialProvider) to use for authenticating with Momento.
-    ///
     /// # Example
     ///
     /// ```

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -268,12 +268,6 @@ impl CacheClient {
     /// * `key` - key of the item whose value we are setting
     /// * `value` - data to stored in the cache item
     ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to set an item using a
-    /// [SetRequest], you can also provide the following optional arguments:
-    ///
-    /// * `ttl` - The time-to-live for the item. If not provided, the client's default time-to-live is used.
-    ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
     /// ```
@@ -296,8 +290,8 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SetRequest]
-    /// which will allow you to set [optional arguments](SetRequest#optional-arguments) as well.
+    /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SetRequest],
+    /// which will allow you to set optional fields like [ttl](SetRequest::ttl) as well.
     pub async fn set(
         &self,
         cache_name: impl Into<String>,
@@ -314,12 +308,6 @@ impl CacheClient {
     ///
     /// * `cache_name` - name of cache
     /// * `items` - HashMap of items to set
-    ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to set an item using a
-    /// [SetBatchRequest], you can also provide the following optional arguments:
-    ///
-    /// * `ttl` - The time-to-live for the items. If not provided, the client's default time-to-live is used.
     ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
@@ -344,7 +332,8 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SetBatchRequest].
+    /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SetBatchRequest],
+    /// which will allow you to set optional fields like [ttl](SetBatchRequest::ttl) as well.
     ///
     /// For more examples of handling the response, see [SetBatchResponse].
     pub async fn set_batch<K: IntoBytes, V: IntoBytes>(
@@ -821,12 +810,6 @@ impl CacheClient {
     /// * `field` - The field to set.
     /// * `value` - The value to set.
     ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to set a field using a
-    /// [DictionarySetFieldRequest], you can also provide the following optional arguments:
-    ///
-    /// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-    ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
     /// ```
@@ -852,8 +835,8 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to set a field using a [DictionarySetFieldRequest]
-    /// which will allow you to set [optional arguments](DictionarySetFieldRequest#optional-arguments) as well.
+    /// You can also use the [send_request](CacheClient::send_request) method to set a field using a [DictionarySetFieldRequest],
+    /// which will allow you to set optional fields like [ttl](DictionarySetFieldRequest::ttl) as well.
     pub async fn dictionary_set_field(
         &self,
         cache_name: impl Into<String>,
@@ -872,12 +855,6 @@ impl CacheClient {
     /// * `cache_name` - The name of the cache containing the dictionary.
     /// * `dictionary_name` - The name of the dictionary to set fields in.
     /// * `elements` - The fields and values to set in the dictionary.
-    ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to set fields using a
-    /// [DictionarySetFieldsRequest], you can also provide the following optional arguments:
-    ///
-    /// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
     ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
@@ -903,7 +880,8 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to set fields using a [DictionarySetFieldsRequest]
+    /// You can also use the [send_request](CacheClient::send_request) method to set fields using a [DictionarySetFieldsRequest],
+    /// which will allow you to set optional fields like [ttl](DictionarySetFieldsRequest::ttl) as well.
     pub async fn dictionary_set_fields<F: IntoBytes, V: IntoBytes>(
         &self,
         cache_name: impl Into<String>,
@@ -921,12 +899,6 @@ impl CacheClient {
     /// * `cache_name` - The name of the cache containing the set.
     /// * `set_name` - The name of the set to add elements to.
     /// * `elements` - The elements to add. Must be able to be converted to a `Vec<u8>`.
-    ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to add an element using a
-    /// [SetAddElementsRequest], you can also provide the following optional arguments:
-    ///
-    /// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
     ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
@@ -953,8 +925,8 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SetAddElementsRequest]
-    /// which will allow you to set [optional arguments](SetAddElementsRequest#optional-arguments) as well.
+    /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SetAddElementsRequest],
+    /// which will allow you to set optional fields like [ttl](SetAddElementsRequest::ttl) as well.
     pub async fn set_add_elements<E: IntoBytesIterable>(
         &self,
         cache_name: impl Into<String>,
@@ -1052,12 +1024,6 @@ impl CacheClient {
     /// * `value` - The value of the element to add. Must be able to be converted to a `Vec<u8>`.
     /// * `score` - The score of the element to add.
     ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to add an element using a
-    /// [SortedSetPutElementRequest], you can also provide the following optional arguments:
-    ///
-    /// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-    ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
     /// ```
@@ -1083,8 +1049,8 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SortedSetPutElementRequest]
-    /// which will allow you to set [optional arguments](SortedSetPutElementRequest#optional-arguments) as well.
+    /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SortedSetPutElementRequest],
+    /// which will allow you to set optional fields like [ttl](SortedSetPutElementRequest::ttl) as well.
     pub async fn sorted_set_put_element(
         &self,
         cache_name: impl Into<String>,
@@ -1104,12 +1070,6 @@ impl CacheClient {
     /// * `cache_name` - The name of the cache containing the sorted set.
     /// * `sorted_set_name` - The name of the sorted set to add an element to.
     /// * `elements` - The values and scores to add. The values must be able to be converted to a `Vec<u8>`.
-    ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to add elements using a
-    /// [SortedSetPutElementsRequest], you can also provide the following optional arguments:
-    ///
-    /// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
     ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
@@ -1135,8 +1095,8 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to put elements using a [SortedSetPutElementsRequest]
-    /// which will allow you to set [optional arguments](SortedSetPutElementsRequest#optional-arguments) as well.
+    /// You can also use the [send_request](CacheClient::send_request) method to put elements using a [SortedSetPutElementsRequest],
+    /// which will allow you to set optional fields like [ttl](SortedSetPutElementsRequest::ttl) as well.
     pub async fn sorted_set_put_elements<V: IntoBytes>(
         &self,
         cache_name: impl Into<String>,
@@ -1227,21 +1187,6 @@ impl CacheClient {
     /// * `sorted_set_name` - The name of the sorted set to add an element to.
     /// * `order` - The order to sort the elements by. [SortedSetOrder::Ascending] or [SortedSetOrder::Descending].
     ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to fetch elements using a
-    /// [SortedSetFetchByScoreRequest], you can also provide the following optional arguments:
-    ///
-    /// * `min_score` - the minimum score of the elements to fetch. Defaults to negative
-    ///   infinity. Use [ScoreBound::Inclusive](crate::cache::ScoreBound::Inclusive) or [ScoreBound::Exclusive](crate::cache::ScoreBound::Exclusive) to specify whether
-    ///   the minimum score is inclusive or exclusive.
-    /// * `max_score` - the maximum score of the elements to fetch. Defaults to positive
-    ///   infinity. Use [ScoreBound::Inclusive](crate::cache::ScoreBound::Inclusive) or [ScoreBound::Exclusive](crate::cache::ScoreBound::Exclusive) to specify whether
-    ///   the maximum score is inclusive or exclusive.
-    /// * `offset` - The number of elements to skip before returning the first element. Defaults to
-    /// 0. Note: this is not the rank of the first element to return, but the number of elements of
-    ///    the result set to skip before returning the first element.
-    /// * `count` - The maximum number of elements to return. Defaults to all elements.
-    ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
     /// ```
@@ -1277,7 +1222,9 @@ impl CacheClient {
     /// # }
     /// ```
     /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SortedSetFetchByScoreRequest]
-    /// which will allow you to set [optional arguments](SortedSetFetchByScoreRequest#optional-arguments) as well.
+    /// which will allow you to set optional fields like [min_score](SortedSetFetchByScoreRequest::min_score),
+    /// [max_score](SortedSetFetchByScoreRequest::max_score), [offset](SortedSetFetchByScoreRequest::offset), and
+    /// [count](SortedSetFetchByScoreRequest::count) as well.
     ///
     /// For more examples of handling the response, see [SortedSetFetchResponse].
     pub async fn sorted_set_fetch_by_score(
@@ -1376,13 +1323,6 @@ impl CacheClient {
     /// * `sorted_set_name` - name of the sorted set
     /// * `value` - the sorted set value to get the rank of
     ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to fetch elements using a
-    /// [SortedSetGetRankRequest], you can also provide the following optional arguments:
-    ///
-    /// * `order` - The order to sort the elements by. [SortedSetOrder::Ascending] or [SortedSetOrder::Descending].
-    ///   Defaults to [SortedSetOrder::Ascending].
-    ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
     /// ```
@@ -1403,7 +1343,8 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to get the rank of an element using a [SortedSetGetRankRequest].
+    /// You can also use the [send_request](CacheClient::send_request) method to get the rank of an element using a [SortedSetGetRankRequest]
+    /// which will allow you to set optional fields like [order](SortedSetGetRankRequest::order) as well.
     ///
     /// For more examples of handling the response, see [SortedSetGetRankResponse].
     pub async fn sorted_set_get_rank(
@@ -1513,12 +1454,6 @@ impl CacheClient {
     /// * `value` - The value of the element to add. Must be able to be converted to a `Vec<u8>`.
     /// * `amount` - The amount to add to the score.
     ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to add an element using a
-    /// [SortedSetIncrementScoreRequest], you can also provide the following optional arguments:
-    ///
-    /// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-    ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
     /// ```
@@ -1538,7 +1473,7 @@ impl CacheClient {
     /// # }
     /// ```
     /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SortedSetIncrementScoreRequest]
-    /// which will allow you to set [optional arguments](SortedSetIncrementScoreRequest#optional-arguments) as well.
+    /// which will allow you to set optional fields like [ttl](SortedSetIncrementScoreRequest::ttl) as well.
     pub async fn sorted_set_increment_score(
         &self,
         cache_name: impl Into<String>,
@@ -1557,17 +1492,6 @@ impl CacheClient {
     ///
     /// * `cache_name` - The name of the cache containing the sorted set.
     /// * `sorted_set_name` - The name of the sorted set to add an element to.
-    ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to fetch elements using a
-    /// [SortedSetLengthByScoreRequest], you can also provide the following optional arguments:
-    ///
-    /// * `min_score` - the minimum score of the elements to fetch. Defaults to negative
-    ///   infinity. Use [ScoreBound::Inclusive](crate::cache::ScoreBound::Inclusive) or [ScoreBound::Exclusive](crate::cache::ScoreBound::Exclusive) to specify whether
-    ///   the minimum score is inclusive or exclusive.
-    /// * `max_score` - the maximum score of the elements to fetch. Defaults to positive
-    ///   infinity. Use [ScoreBound::Inclusive](crate::cache::ScoreBound::Inclusive) or [ScoreBound::Exclusive](crate::cache::ScoreBound::Exclusive) to specify whether
-    ///   the maximum score is inclusive or exclusive.
     ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
@@ -1596,7 +1520,8 @@ impl CacheClient {
     /// # }
     /// ```
     /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SortedSetLengthByScoreRequest]
-    /// which will allow you to set [optional arguments](SortedSetLengthByScoreRequest#optional-arguments) as well.
+    /// which will allow you to set optional fields like [min_score](SortedSetLengthByScoreRequest::min_score) and
+    /// [max_score](SortedSetLengthByScoreRequest::max_score) as well.
     ///
     /// For more examples of handling the response, see [SortedSetLengthByScoreResponse].
     pub async fn sorted_set_length_by_score(
@@ -1615,13 +1540,6 @@ impl CacheClient {
     /// * `cache_name` - The name of the cache containing the sorted set.
     /// * `sorted_set_name` - The name of the destination sorted set. This set is not implicitly included as a source.
     /// * `sources` - The sorted sets to compute the union for.
-    ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to fetch elements using a
-    /// [SortedSetUnionStoreRequest], you can also provide the following optional arguments:
-    ///
-    /// * `aggregate` - The aggregate function to use to determine the final score for an element that exists in multiple source sets. Defaults to [crate::cache::SortedSetAggregateFunction::Sum].
-    /// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
     ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
@@ -1653,7 +1571,8 @@ impl CacheClient {
     /// # }
     /// ```
     /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SortedSetUnionStoreRequest]
-    /// which will allow you to set [optional arguments](SortedSetUnionStoreRequest#optional-arguments) as well.
+    /// which will allow you to set optional fields like [aggregate](SortedSetUnionStoreRequest::aggregate) and
+    /// [ttl](SortedSetUnionStoreRequest::ttl) as well.
     ///
     /// For more examples of handling the response, see [SortedSetUnionStoreResponse].
     pub async fn sorted_set_union_store<
@@ -1752,12 +1671,6 @@ impl CacheClient {
     /// * `key` - the key to increment
     /// * `amount` - the quantity to add to the value. May be positive, negative, or zero. Defaults to 1.
     ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to increment a key using an
-    /// [IncrementRequest], you can also provide the following optional arguments:
-    ///
-    /// * `ttl` - The time-to-live for the item. If not provided, the client's default time-to-live is used.
-    ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
     /// ```
@@ -1781,7 +1694,7 @@ impl CacheClient {
     /// # }
     /// ```
     /// You can also use the [send_request](CacheClient::send_request) method to increment an item using an [IncrementRequest]
-    /// which will allow you to set [optional arguments](IncrementRequest#optional-arguments) as well.
+    /// which will allow you to set optional fields like [ttl](IncrementRequest::ttl) as well.
     pub async fn increment(
         &self,
         cache_name: impl Into<String>,
@@ -1987,12 +1900,6 @@ impl CacheClient {
     /// * `key` - key of the item whose value we are setting
     /// * `value` - data to store
     ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to conditionally set an item using an
-    /// [SetIfAbsentRequest], you can also provide the following optional arguments:
-    ///
-    /// * `ttl` - The time-to-live for the item. If not provided, the client's default time-to-live is used.
-    ///
     /// # Example
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
     /// ```
@@ -2019,7 +1926,8 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to conditionally set an item using a [SetIfAbsentRequest].
+    /// You can also use the [send_request](CacheClient::send_request) method to conditionally set an item using a [SetIfAbsentRequest]
+    /// which will allow you to set optional fields like [ttl](SetIfAbsentRequest::ttl) as well.
     pub async fn set_if_absent(
         &self,
         cache_name: impl Into<String>,
@@ -2037,12 +1945,6 @@ impl CacheClient {
     /// * `cache_name` - The name of the cache to create.
     /// * `key` - key of the item whose value we are setting
     /// * `value` - data to store
-    ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to conditionally set an item using an
-    /// [SetIfPresentRequest], you can also provide the following optional arguments:
-    ///
-    /// * `ttl` - The time-to-live for the item. If not provided, the client's default time-to-live is used.
     ///
     /// # Example
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
@@ -2070,7 +1972,8 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to conditionally set an item using a [SetIfPresentRequest].
+    /// You can also use the [send_request](CacheClient::send_request) method to conditionally set an item using a [SetIfPresentRequest]
+    /// which will allow you to set optional fields like [ttl](SetIfPresentRequest::ttl) as well.
     pub async fn set_if_present(
         &self,
         cache_name: impl Into<String>,
@@ -2090,12 +1993,6 @@ impl CacheClient {
     /// * `key` - key of the item whose value we are setting
     /// * `value` - data to store
     /// * `equal` - data to compare to the cached value
-    ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to conditionally set an item using an
-    /// [SetIfEqualRequest], you can also provide the following optional arguments:
-    ///
-    /// * `ttl` - The time-to-live for the item. If not provided, the client's default time-to-live is used.
     ///
     /// # Example
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
@@ -2123,7 +2020,8 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to conditionally set an item using a [SetIfEqualRequest].
+    /// You can also use the [send_request](CacheClient::send_request) method to conditionally set an item using a [SetIfEqualRequest]
+    /// which will allow you to set optional fields like [ttl](SetIfEqualRequest::ttl) as well.
     pub async fn set_if_equal(
         &self,
         cache_name: impl Into<String>,
@@ -2144,12 +2042,6 @@ impl CacheClient {
     /// * `key` - key of the item whose value we are setting
     /// * `value` - data to store
     /// * `not_equal` - data to compare to the cached value
-    ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to conditionally set an item using an
-    /// [SetIfNotEqualRequest], you can also provide the following optional arguments:
-    ///
-    /// * `ttl` - The time-to-live for the item. If not provided, the client's default time-to-live is used.
     ///
     /// # Example
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
@@ -2177,7 +2069,8 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to conditionally set an item using a [SetIfNotEqualRequest].
+    /// You can also use the [send_request](CacheClient::send_request) method to conditionally set an item using a [SetIfNotEqualRequest]
+    /// which will allow you to set optional fields like [ttl](SetIfNotEqualRequest::ttl) as well.
     pub async fn set_if_not_equal(
         &self,
         cache_name: impl Into<String>,
@@ -2198,12 +2091,6 @@ impl CacheClient {
     /// * `key` - key of the item whose value we are setting
     /// * `value` - data to store
     /// * `not_equal` - data to compare to the cached value
-    ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to conditionally set an item using an
-    /// [SetIfPresentAndNotEqualRequest], you can also provide the following optional arguments:
-    ///
-    /// * `ttl` - The time-to-live for the item. If not provided, the client's default time-to-live is used.
     ///
     /// # Example
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
@@ -2231,7 +2118,8 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to conditionally set an item using a [SetIfPresentAndNotEqualRequest].
+    /// You can also use the [send_request](CacheClient::send_request) method to conditionally set an item using a [SetIfPresentAndNotEqualRequest]
+    /// which will allow you to set optional fields like [ttl](SetIfPresentAndNotEqualRequest::ttl) as well.
     pub async fn set_if_present_and_not_equal(
         &self,
         cache_name: impl Into<String>,
@@ -2252,12 +2140,6 @@ impl CacheClient {
     /// * `key` - key of the item whose value we are setting
     /// * `value` - data to store
     /// * `equal` - data to compare to the cached value
-    ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to conditionally set an item using an
-    /// [SetIfAbsentOrEqualRequest], you can also provide the following optional arguments:
-    ///
-    /// * `ttl` - The time-to-live for the item. If not provided, the client's default time-to-live is used.
     ///
     /// # Example
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
@@ -2285,7 +2167,8 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to conditionally set an item using a [SetIfAbsentOrEqualRequest].
+    /// You can also use the [send_request](CacheClient::send_request) method to conditionally set an item using a [SetIfAbsentOrEqualRequest]
+    /// which will allow you to set optional fields like [ttl](SetIfAbsentOrEqualRequest::ttl) as well.
     pub async fn set_if_absent_or_equal(
         &self,
         cache_name: impl Into<String>,
@@ -2340,13 +2223,6 @@ impl CacheClient {
     /// * `list_name` - name of the list
     /// * `values` - list of values to add to the front of the list
     ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to add elements to the front of a list using a [ListConcatenateFrontRequest],
-    /// you can also provide the following optional arguments:
-    ///
-    /// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-    /// * `truncate_back_to_size` - If the list exceeds this length, remove excess from the back of the list.
-    ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
     /// ```
@@ -2372,7 +2248,8 @@ impl CacheClient {
     /// # }
     /// ```
     /// You can also use the [send_request](CacheClient::send_request) method to concatenate an item using a [ListConcatenateFrontRequest]
-    /// which will allow you to set [optional arguments](ListConcatenateFrontRequest#optional-arguments) as well.
+    /// which will allow you to set optional fields like [ttl](ListConcatenateFrontRequest::ttl) and
+    /// [truncate_back_to_size](ListConcatenateFrontRequest::truncate_back_to_size) as well.
     pub async fn list_concatenate_front(
         &self,
         cache_name: impl Into<String>,
@@ -2389,13 +2266,6 @@ impl CacheClient {
     /// * `cache_name` - name of cache
     /// * `list_name` - name of the list
     /// * `values` - list of values to add to the back of the list
-    ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to add elements to the back of a list using a [ListConcatenateBackRequest],
-    /// you can also provide the following optional arguments:
-    ///
-    /// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-    /// * `truncate_front_to_size` - If the list exceeds this length, remove excess from the front of the list.
     ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
@@ -2422,7 +2292,8 @@ impl CacheClient {
     /// # }
     /// ```
     /// You can also use the [send_request](CacheClient::send_request) method to concatenate an item using a [ListConcatenateBackRequest]
-    /// which will allow you to set [optional arguments](ListConcatenateBackRequest#optional-arguments) as well.
+    /// which will allow you to set optional fields like [ttl](ListConcatenateBackRequest::ttl) and
+    /// [truncate_front_to_size](ListConcatenateBackRequest::truncate_front_to_size) as well.
     pub async fn list_concatenate_back(
         &self,
         cache_name: impl Into<String>,
@@ -2438,13 +2309,6 @@ impl CacheClient {
     /// # Arguments
     /// * `cache_name` - name of cache
     /// * `list_name` - name of the list
-    ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to fetch a list using a [ListFetchRequest],
-    /// you can also provide the following optional arguments:
-    ///
-    /// * `start_index` - The starting inclusive element of the list to fetch. Default is 0.
-    /// * `end_index` - The ending exclusive element of the list to fetch. Default is end of list.
     ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
@@ -2465,7 +2329,8 @@ impl CacheClient {
     /// # }
     /// ```
     /// You can also use the [send_request](CacheClient::send_request) method to fetch a list using a [ListFetchRequest]
-    /// which will allow you to set [optional arguments](ListFetchRequest#optional-arguments) as well.
+    /// which will allow you to set optional fields like [start_index](ListFetchRequest::start_index) and
+    /// [end_index](ListFetchRequest::end_index) as well.
     ///
     /// For more examples of handling the response, see [ListFetchResponse].
     pub async fn list_fetch(
@@ -2594,13 +2459,6 @@ impl CacheClient {
     /// * `list_name` - name of the list
     /// * `value` - value to append to list
     ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to add to a list using a [ListPushBackRequest],
-    /// you can also provide the following optional arguments:
-    ///
-    /// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-    /// * `truncate_front_to_size` - If the list exceeds this length, remove excess from the front of the list.
-    ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
     /// ```
@@ -2620,7 +2478,8 @@ impl CacheClient {
     /// # }
     /// ```
     /// You can also use the [send_request](CacheClient::send_request) method to add to a list using a [ListPushBackRequest]
-    /// which will allow you to set [optional arguments](ListPushBackRequest#optional-arguments) as well.
+    /// which will allow you to set optional fields like [ttl](ListPushBackRequest::ttl) and
+    /// [truncate_front_to_size](ListPushBackRequest::truncate_front_to_size) as well.
     pub async fn list_push_back(
         &self,
         cache_name: impl Into<String>,
@@ -2637,13 +2496,6 @@ impl CacheClient {
     /// * `cache_name` - name of cache
     /// * `list_name` - name of the list
     /// * `value` - value to prepend to list
-    ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to add to a list using a [ListPushFrontRequest],
-    /// you can also provide the following optional arguments:
-    ///
-    /// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-    /// * `truncate_back_to_size` - If the list exceeds this length, remove excess from the back of the list.
     ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
@@ -2664,7 +2516,8 @@ impl CacheClient {
     /// # }
     /// ```
     /// You can also use the [send_request](CacheClient::send_request) method to add to a list using a [ListPushFrontRequest]
-    /// which will allow you to set [optional arguments](ListPushFrontRequest#optional-arguments) as well.
+    /// which will allow you to set optional fields like [ttl](ListPushFrontRequest::ttl) and
+    /// [truncate_back_to_size](ListPushFrontRequest::truncate_back_to_size) as well.
     pub async fn list_push_front(
         &self,
         cache_name: impl Into<String>,
@@ -2682,12 +2535,6 @@ impl CacheClient {
     /// * `list_name` - name of the list
     /// * `start_index` - The starting inclusive element of the list to retain. Default is 0.
     /// * `end_index` - The ending exclusive element of the list to retain. Default is up to and including end of list.
-    ///
-    /// # Optional Arguments
-    /// If you use [send_request](CacheClient::send_request) to retain a list using a [ListRetainRequest],
-    /// you can also provide the following optional arguments:
-    ///
-    /// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
     ///
     /// # Examples
     /// Assumes that a CacheClient named `cache_client` has been created and is available.
@@ -2714,7 +2561,7 @@ impl CacheClient {
     /// # }
     /// ```
     /// You can also use the [send_request](CacheClient::send_request) method to retain a list using a [ListRetainRequest]
-    /// which will allow you to set [optional arguments](ListRetainRequest#optional-arguments) as well.
+    /// which will allow you to set optional fields like [ttl](ListRetainRequest::ttl) as well.
     pub async fn list_retain(
         &self,
         cache_name: impl Into<String>,

--- a/src/cache/cache_client.rs
+++ b/src/cache/cache_client.rs
@@ -285,7 +285,7 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SetRequest],
+    /// You can also use the [send_request](CacheClient::send_request) method to set an item using a [SetRequest],
     /// which will allow you to set optional fields like [ttl](SetRequest::ttl) as well.
     pub async fn set(
         &self,
@@ -327,7 +327,7 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SetBatchRequest],
+    /// You can also use the [send_request](CacheClient::send_request) method to set items using a [SetBatchRequest],
     /// which will allow you to set optional fields like [ttl](SetBatchRequest::ttl) as well.
     ///
     /// For more examples of handling the response, see [SetBatchResponse].
@@ -920,7 +920,7 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SetAddElementsRequest],
+    /// You can also use the [send_request](CacheClient::send_request) method to add elements using a [SetAddElementsRequest],
     /// which will allow you to set optional fields like [ttl](SetAddElementsRequest::ttl) as well.
     pub async fn set_add_elements<E: IntoBytesIterable>(
         &self,
@@ -998,7 +998,7 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to fetch elements using a [SetRemoveElementsRequest].
+    /// You can also use the [send_request](CacheClient::send_request) method to remove elements using a [SetRemoveElementsRequest].
     pub async fn set_remove_elements<E: IntoBytes>(
         &self,
         cache_name: impl Into<String>,
@@ -1044,7 +1044,7 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SortedSetPutElementRequest],
+    /// You can also use the [send_request](CacheClient::send_request) method to put an element using a [SortedSetPutElementRequest],
     /// which will allow you to set optional fields like [ttl](SortedSetPutElementRequest::ttl) as well.
     pub async fn sorted_set_put_element(
         &self,
@@ -1216,7 +1216,7 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SortedSetFetchByScoreRequest]
+    /// You can also use the [send_request](CacheClient::send_request) method to fetch elements using a [SortedSetFetchByScoreRequest]
     /// which will allow you to set optional fields like [min_score](SortedSetFetchByScoreRequest::min_score),
     /// [max_score](SortedSetFetchByScoreRequest::max_score), [offset](SortedSetFetchByScoreRequest::offset), and
     /// [count](SortedSetFetchByScoreRequest::count) as well.
@@ -1467,7 +1467,7 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SortedSetIncrementScoreRequest]
+    /// You can also use the [send_request](CacheClient::send_request) method to increment a score using a [SortedSetIncrementScoreRequest]
     /// which will allow you to set optional fields like [ttl](SortedSetIncrementScoreRequest::ttl) as well.
     pub async fn sorted_set_increment_score(
         &self,
@@ -1514,7 +1514,7 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SortedSetLengthByScoreRequest]
+    /// You can also use the [send_request](CacheClient::send_request) method to get the length using a [SortedSetLengthByScoreRequest]
     /// which will allow you to set optional fields like [min_score](SortedSetLengthByScoreRequest::min_score) and
     /// [max_score](SortedSetLengthByScoreRequest::max_score) as well.
     ///
@@ -1565,7 +1565,7 @@ impl CacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](CacheClient::send_request) method to get an item using a [SortedSetUnionStoreRequest]
+    /// You can also use the [send_request](CacheClient::send_request) method to compute the union using a [SortedSetUnionStoreRequest]
     /// which will allow you to set optional fields like [aggregate](SortedSetUnionStoreRequest::aggregate) and
     /// [ttl](SortedSetUnionStoreRequest::ttl) as well.
     ///

--- a/src/cache/cache_client_builder.rs
+++ b/src/cache/cache_client_builder.rs
@@ -43,16 +43,14 @@ pub struct ReadyToBuild {
 }
 
 impl CacheClientBuilder<NeedsDefaultTtl> {
-    /// Constructs a new CacheClientBuilder in the NeedsDefaultTtl state.
-    ///
-    /// Default time-to-live for items in the cache.
+    /// Sets the default time-to-live for items in the cache.
     pub fn default_ttl(self, default_ttl: Duration) -> CacheClientBuilder<NeedsConfiguration> {
         CacheClientBuilder(NeedsConfiguration { default_ttl })
     }
 }
 
 impl CacheClientBuilder<NeedsConfiguration> {
-    /// Constructs a new CacheClientBuilder in the NeedsConfiguration state.
+    /// Sets the configuration for the CacheClient.
     ///
     /// Prebuilt configurations tuned for different environments are available in the [cache::configurations](crate::cache::configurations) module.
     pub fn configuration(
@@ -67,9 +65,7 @@ impl CacheClientBuilder<NeedsConfiguration> {
 }
 
 impl CacheClientBuilder<NeedsCredentialProvider> {
-    /// Constructs a new CacheClientBuilder in the NeedsCredentialProvider state.
-    ///
-    /// A [CredentialProvider](crate::CredentialProvider) to use for authenticating with Momento.
+    /// Sets the [CredentialProvider](crate::CredentialProvider) to use for authenticating with Momento.
     pub fn credential_provider(
         self,
         credential_provider: CredentialProvider,

--- a/src/cache/cache_client_builder.rs
+++ b/src/cache/cache_client_builder.rs
@@ -44,6 +44,8 @@ pub struct ReadyToBuild {
 
 impl CacheClientBuilder<NeedsDefaultTtl> {
     /// Constructs a new CacheClientBuilder in the NeedsDefaultTtl state.
+    ///
+    /// Default time-to-live for items in the cache.
     pub fn default_ttl(self, default_ttl: Duration) -> CacheClientBuilder<NeedsConfiguration> {
         CacheClientBuilder(NeedsConfiguration { default_ttl })
     }
@@ -51,6 +53,8 @@ impl CacheClientBuilder<NeedsDefaultTtl> {
 
 impl CacheClientBuilder<NeedsConfiguration> {
     /// Constructs a new CacheClientBuilder in the NeedsConfiguration state.
+    ///
+    /// Prebuilt configurations tuned for different environments are available in the [cache::configurations](crate::cache::configurations) module.
     pub fn configuration(
         self,
         configuration: impl Into<Configuration>,
@@ -64,6 +68,8 @@ impl CacheClientBuilder<NeedsConfiguration> {
 
 impl CacheClientBuilder<NeedsCredentialProvider> {
     /// Constructs a new CacheClientBuilder in the NeedsCredentialProvider state.
+    ///
+    /// A [CredentialProvider](crate::CredentialProvider) to use for authenticating with Momento.
     pub fn credential_provider(
         self,
         credential_provider: CredentialProvider,

--- a/src/cache/messages/control/create_cache.rs
+++ b/src/cache/messages/control/create_cache.rs
@@ -7,10 +7,6 @@ use crate::{utils, CacheClient, MomentoResult};
 
 /// Request to create a cache.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache to create.
-///
 /// # Example
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```no_run

--- a/src/cache/messages/control/delete_cache.rs
+++ b/src/cache/messages/control/delete_cache.rs
@@ -6,10 +6,6 @@ use crate::{utils, CacheClient, MomentoResult};
 
 /// Request to delete a cache
 ///
-/// # Arguments
-///
-/// * `name` - The name of the cache to be deleted.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```no_run

--- a/src/cache/messages/control/flush_cache.rs
+++ b/src/cache/messages/control/flush_cache.rs
@@ -6,10 +6,6 @@ use crate::{utils, CacheClient, MomentoResult};
 
 /// Request to flush a cache of its data
 ///
-/// # Arguments
-///
-/// * `name` - The name of the cache to be flushed.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/dictionary/dictionary_fetch.rs
+++ b/src/cache/messages/data/dictionary/dictionary_fetch.rs
@@ -13,11 +13,6 @@ use std::fmt::Debug;
 
 /// Request to fetch a dictionary from a cache.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache containing the dictionary.
-/// * `dictionary_name` - The name of the dictionary to fetch.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/dictionary/dictionary_get_field.rs
+++ b/src/cache/messages/data/dictionary/dictionary_get_field.rs
@@ -10,12 +10,6 @@ use std::convert::{TryFrom, TryInto};
 
 /// Request to get a field from a dictionary.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache containing the dictionary.
-/// * `dictionary_name` - The name of the dictionary to get fields from.
-/// * `field` - The field to get.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/dictionary/dictionary_get_fields.rs
+++ b/src/cache/messages/data/dictionary/dictionary_get_fields.rs
@@ -13,12 +13,6 @@ use std::convert::{TryFrom, TryInto};
 
 /// Request to get multiple fields from a dictionary.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache containing the dictionary.
-/// * `dictionary_name` - The name of the dictionary to get fields from.
-/// * `fields` - The fields to get.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/dictionary/dictionary_increment.rs
+++ b/src/cache/messages/data/dictionary/dictionary_increment.rs
@@ -6,15 +6,6 @@ use crate::{
 
 /// Adds an integer quantity to a field value.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `field` - the field to increment
-/// * `amount` - the quantity to add to the value. May be positive, negative, or zero. Defaults to 1.
-///
-/// # Optional Arguments
-///
-/// * `collection_ttl`: The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -56,6 +47,9 @@ pub struct DictionaryIncrementRequest<D: IntoBytes, F: IntoBytes> {
 
 impl<D: IntoBytes, F: IntoBytes> DictionaryIncrementRequest<D, F> {
     /// Constructs a new DictionaryIncrementRequest.
+    ///
+    /// The quantity/amount (to be added to the field's value)
+    /// may be positive, negative, or zero. Defaults to 1.
     pub fn new(cache_name: impl Into<String>, dictionary_name: D, field: F, amount: i64) -> Self {
         let collection_ttl = CollectionTtl::default();
         Self {
@@ -68,6 +62,8 @@ impl<D: IntoBytes, F: IntoBytes> DictionaryIncrementRequest<D, F> {
     }
 
     /// Set the time-to-live for the collection.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
         self.collection_ttl = collection_ttl.into();
         self

--- a/src/cache/messages/data/dictionary/dictionary_length.rs
+++ b/src/cache/messages/data/dictionary/dictionary_length.rs
@@ -11,10 +11,6 @@ use crate::{
 
 /// Gets the number of elements in the given dictionary.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `dictionary_name` - name of the dictionary
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/dictionary/dictionary_remove_field.rs
+++ b/src/cache/messages/data/dictionary/dictionary_remove_field.rs
@@ -8,11 +8,6 @@ use momento_protos::cache_client::{
 
 /// Remove a field from a dictionary.
 ///
-/// # Arguments
-/// * `cache_name` - The name of the cache containing the dictionary.
-/// * `dictionary_name` - The name of the dictionary to remove field from.
-/// * `field` - The field to remove.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/dictionary/dictionary_remove_fields.rs
+++ b/src/cache/messages/data/dictionary/dictionary_remove_fields.rs
@@ -9,11 +9,6 @@ use momento_protos::cache_client::{
 
 /// Remove multiple fields from a dictionary.
 ///
-/// # Arguments
-/// * `cache_name` - The name of the cache containing the dictionary.
-/// * `dictionary_name` - The name of the dictionary to remove fields from.
-/// * `fields` - The fields to remove.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/dictionary/dictionary_set_field.rs
+++ b/src/cache/messages/data/dictionary/dictionary_set_field.rs
@@ -10,16 +10,6 @@ use momento_protos::cache_client::{
 
 /// Request to set a field in a dictionary.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache containing the dictionary.
-/// * `dictionary_name` - The name of the dictionary to set.
-/// * `field` - The field to set.
-/// * `value` - The value to set.
-///
-/// # Optional Arguments
-/// * `ttl` - The time-to-live for the dictionary. If not provided, the client's default time-to-live is used.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -77,6 +67,8 @@ where
     }
 
     /// Set the time-to-live for the dictionary.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
         self.collection_ttl = collection_ttl.into();
         self

--- a/src/cache/messages/data/dictionary/dictionary_set_fields.rs
+++ b/src/cache/messages/data/dictionary/dictionary_set_fields.rs
@@ -53,16 +53,6 @@ impl<F: IntoBytes, V: IntoBytes> IntoDictionaryFieldValuePairs<F, V> for HashMap
 /// Request to set multiple fields in a dictionary. If the dictionary does not exist, it will be
 /// created. If the dictionary already exists, the fields will be updated.
 ///
-/// # Arguments
-///
-/// - `cache_name`: The name of the cache where the dictionary is stored.
-/// - `dictionary_name`: The name of the dictionary to set fields in.
-/// - `elements`: The fields and values to set in the dictionary.
-///
-/// # Optional Arguments
-///
-/// - `collection_ttl`: The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -125,6 +115,8 @@ where
     }
 
     /// Set the time-to-live for the collection.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
         self.collection_ttl = collection_ttl.into();
         self

--- a/src/cache/messages/data/list/list_concatenate_back.rs
+++ b/src/cache/messages/data/list/list_concatenate_back.rs
@@ -9,16 +9,6 @@ use crate::{
 /// Appends the supplied list to the end of a list. For example, if you have a list [1, 2, 3]
 /// and listConcatenateBack [4, 5, 6], you will create [1, 2, 3, 4, 5, 6].
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `list_name` - name of the list
-/// * `values` - list of values to add to the back of the list
-///
-/// # Optional Arguments
-///
-/// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-/// * `truncate_front_to_size` - If the list exceeds this length, remove excess from the front of the list.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -61,6 +51,8 @@ impl<L: IntoBytes, V: IntoBytesIterable> ListConcatenateBackRequest<L, V> {
     }
 
     /// Set the time-to-live for the collection.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
         self.collection_ttl = collection_ttl.into();
         self

--- a/src/cache/messages/data/list/list_concatenate_front.rs
+++ b/src/cache/messages/data/list/list_concatenate_front.rs
@@ -9,16 +9,6 @@ use crate::{
 /// Prepends the supplied list to the front of a list. For example, if you have a list [1, 2, 3]
 /// and listConcatenateFront [4, 5, 6], you will create [4, 5, 6, 1, 2, 3].
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `list_name` - name of the list
-/// * `values` - list of values to add to the front of the list
-///
-/// # Optional Arguments
-///
-/// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-/// * `truncate_back_to_size` - If the list exceeds this length, remove excess from the back of the list.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -61,6 +51,8 @@ impl<L: IntoBytes, V: IntoBytesIterable> ListConcatenateFrontRequest<L, V> {
     }
 
     /// Set the time-to-live for the collection.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
         self.collection_ttl = collection_ttl.into();
         self

--- a/src/cache/messages/data/list/list_fetch.rs
+++ b/src/cache/messages/data/list/list_fetch.rs
@@ -16,15 +16,6 @@ use crate::{
 
 /// Gets a list item from a cache with optional slices.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `list_name` - name of the list
-///
-/// # Optional Arguments
-///
-/// * `start_index` - The starting inclusive element of the list to fetch. Default is 0.
-/// * `end_index` - The ending exclusive element of the list to fetch. Default is up to and including end of list.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -63,12 +54,16 @@ impl<L: IntoBytes> ListFetchRequest<L> {
     }
 
     /// Set the starting inclusive element of the list to fetch.
+    ///
+    /// Default is 0.
     pub fn start_index(mut self, start_index: impl Into<Option<i32>>) -> Self {
         self.start_index = start_index.into();
         self
     }
 
     /// Set the ending exclusive element of the list to fetch.
+    ///
+    /// Default is up to and including end of list.
     pub fn end_index(mut self, end_index: impl Into<Option<i32>>) -> Self {
         self.end_index = end_index.into();
         self

--- a/src/cache/messages/data/list/list_length.rs
+++ b/src/cache/messages/data/list/list_length.rs
@@ -9,10 +9,6 @@ use crate::{
 
 /// Gets the number of elements in the given list.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `list_name` - name of the list
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/list/list_pop_back.rs
+++ b/src/cache/messages/data/list/list_pop_back.rs
@@ -10,10 +10,6 @@ use crate::{
 
 /// Remove and return the last element from a list item.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `list_name` - name of the list
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/list/list_pop_front.rs
+++ b/src/cache/messages/data/list/list_pop_front.rs
@@ -10,10 +10,6 @@ use crate::{
 
 /// Remove and return the first element from a list item.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `list_name` - name of the list
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/list/list_push_back.rs
+++ b/src/cache/messages/data/list/list_push_back.rs
@@ -6,16 +6,6 @@ use crate::{
 
 /// Adds an element to the back of the given list. Creates the list if it does not already exist.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `list_name` - name of the list
-/// * `value` - value to append to list
-///
-/// # Optional Arguments
-///
-/// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-/// * `truncate_front_to_size` - If the list exceeds this length, remove excess from the front of the list.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -58,6 +48,8 @@ impl<L: IntoBytes, V: IntoBytes> ListPushBackRequest<L, V> {
     }
 
     /// Set the time-to-live for the collection.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
         self.collection_ttl = collection_ttl.into();
         self

--- a/src/cache/messages/data/list/list_push_front.rs
+++ b/src/cache/messages/data/list/list_push_front.rs
@@ -6,16 +6,6 @@ use crate::{
 
 /// Adds an element to the front of the given list. Creates the list if it does not already exist.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `list_name` - name of the list
-/// * `value` - value to prepend to list
-///
-/// # Optional Arguments
-///
-/// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-/// * `truncate_back_to_size` - If the list exceeds this length, remove excess from the back of the list.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -58,12 +48,14 @@ impl<L: IntoBytes, V: IntoBytes> ListPushFrontRequest<L, V> {
     }
 
     /// Set the time-to-live for the collection.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
         self.collection_ttl = collection_ttl.into();
         self
     }
 
-    /// If the list exceeds this length, remove excess from the front of the list.
+    /// If the list exceeds this length, remove excess from the back of the list.
     pub fn truncate_back_to_size(mut self, truncate_back_to_size: impl Into<Option<u32>>) -> Self {
         self.truncate_back_to_size = truncate_back_to_size.into();
         self

--- a/src/cache/messages/data/list/list_remove_value.rs
+++ b/src/cache/messages/data/list/list_remove_value.rs
@@ -6,11 +6,6 @@ use crate::{
 
 /// Remove all elements in a list item equal to a particular value.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `list_name` - name of the list
-/// * `value` - value to remove
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/list/list_retain.rs
+++ b/src/cache/messages/data/list/list_retain.rs
@@ -12,16 +12,6 @@ use std::convert::TryFrom;
 
 /// Retains only slice of the list defined by the provided range. Items outside of this range will be dropped from the list.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `list_name` - name of the list
-///
-/// # Optional Arguments
-///
-/// * `start_index` - The starting inclusive element of the list to retain. Default is 0.
-/// * `end_index` - The ending exclusive element of the list to retain. Default is up to and including end of list.
-/// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -65,18 +55,24 @@ impl<L: IntoBytes> ListRetainRequest<L> {
     }
 
     /// Set the starting inclusive element of the list to retain.
+    ///
+    /// Default is 0.
     pub fn start_index(mut self, start_index: impl Into<Option<i32>>) -> Self {
         self.start_index = start_index.into();
         self
     }
 
     /// Set the ending exclusive element of the list to retain.
+    ///
+    /// Default is up to and including end of list.
     pub fn end_index(mut self, end_index: impl Into<Option<i32>>) -> Self {
         self.end_index = end_index.into();
         self
     }
 
     /// Set the time-to-live for the list.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
         self.collection_ttl = collection_ttl.into();
         self

--- a/src/cache/messages/data/scalar/decrease_ttl.rs
+++ b/src/cache/messages/data/scalar/decrease_ttl.rs
@@ -8,12 +8,7 @@ use crate::{
     cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoResult,
 };
 
-/// Decrease the ttl of an item in the cache.
-///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `key` - the key of the item for which ttl is requested
-/// * `ttl` - The time-to-live that should overwrite the current ttl. Should be less than the current ttl.
+/// Decrease the ttl (time-to-live) of an item in the cache.
 ///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.

--- a/src/cache/messages/data/scalar/delete.rs
+++ b/src/cache/messages/data/scalar/delete.rs
@@ -4,11 +4,6 @@ use crate::{
 
 /// Deletes an item in a Momento Cache
 ///
-/// # Arguments
-///
-/// * `cache_name` - name of cache
-/// * `key` - key of the item to delete
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/scalar/get.rs
+++ b/src/cache/messages/data/scalar/get.rs
@@ -9,11 +9,6 @@ use std::convert::{TryFrom, TryInto};
 
 /// Request to get an item from a cache
 ///
-/// # Arguments
-///
-/// * `cache_name` - name of cache
-/// * `key` - key of entry within the cache.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/scalar/get_batch.rs
+++ b/src/cache/messages/data/scalar/get_batch.rs
@@ -14,11 +14,6 @@ use crate::cache::messages::data::scalar::get::{GetResponse, Value};
 
 /// Request to get a batch of items from a Momento Cache
 ///
-/// # Arguments
-///
-/// * `cache_name` - name of cache
-/// * `keys` - list of keys to fetch
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/scalar/increase_ttl.rs
+++ b/src/cache/messages/data/scalar/increase_ttl.rs
@@ -8,12 +8,7 @@ use crate::{
     cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoResult,
 };
 
-/// Increase the ttl of an item in the cache.
-///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `key` - the key of the item for which ttl is requested
-/// * `ttl` - The time-to-live that should overwrite the current ttl. Should be greater than the current ttl.
+/// Increase the ttl (time-to-live) of an item in the cache.
 ///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.

--- a/src/cache/messages/data/scalar/increment.rs
+++ b/src/cache/messages/data/scalar/increment.rs
@@ -8,15 +8,6 @@ use crate::{
 /// Adds the quantity if and only if the existing value is a UTF-8 string representing a base 10 integer.
 /// If the item does not exist, this method creates it and sets the item's value to the amount to increment by.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `key` - the key to increment
-/// * `amount` - the quantity to add to the value. May be positive, negative, or zero. Defaults to 1.
-///
-/// # Optional Arguments
-///
-/// * `ttl` - The time-to-live for the item. If not provided, the client's default time-to-live is used.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -55,6 +46,9 @@ pub struct IncrementRequest<K: IntoBytes> {
 
 impl<K: IntoBytes> IncrementRequest<K> {
     /// Constructs a new IncrementRequest.
+    ///
+    /// The quantity/amount (to be added to the cache item's value)
+    /// may be positive, negative, or zero. Defaults to 1.
     pub fn new(cache_name: impl Into<String>, key: K, amount: i64) -> Self {
         let ttl = None;
         Self {
@@ -66,6 +60,8 @@ impl<K: IntoBytes> IncrementRequest<K> {
     }
 
     /// Set the time-to-live for the item.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
         self.ttl = ttl.into();
         self

--- a/src/cache/messages/data/scalar/item_get_ttl.rs
+++ b/src/cache/messages/data/scalar/item_get_ttl.rs
@@ -10,10 +10,6 @@ use crate::{
 
 /// Return the remaining ttl of an item in the cache
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `key` - the key of the item for which the remaining ttl is requested
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/scalar/item_get_type.rs
+++ b/src/cache/messages/data/scalar/item_get_type.rs
@@ -9,10 +9,6 @@ use crate::{
 
 /// Return the type of an item in the cache.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `key` - the key of the item to get the type of
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/scalar/key_exists.rs
+++ b/src/cache/messages/data/scalar/key_exists.rs
@@ -4,10 +4,6 @@ use crate::{CacheClient, IntoBytes, MomentoError, MomentoResult};
 
 /// Request to check if a key exists in a cache.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `key` - key to check for existence
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/scalar/keys_exist.rs
+++ b/src/cache/messages/data/scalar/keys_exist.rs
@@ -9,10 +9,6 @@ use crate::{CacheClient, MomentoResult};
 /// Request to check if the provided keys exist in the cache.
 /// Returns an object that is accessible as a list or map of booleans indicating whether each given key was found in the cache.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `keys` - list of keys to check for existence
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 ///

--- a/src/cache/messages/data/scalar/set.rs
+++ b/src/cache/messages/data/scalar/set.rs
@@ -8,16 +8,6 @@ use std::time::Duration;
 
 /// Request to set a value in a cache.
 ///
-/// # Arguments
-///
-/// * `cache_name` - name of the cache
-/// * `key` - key of the item whose value we are setting
-/// * `value` - data to stored in the cache item
-///
-/// # Optional Arguments
-///
-/// * `ttl` - The time-to-live for the item. If not provided, the client's default time-to-live is used.
-///
 /// # Example
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -67,6 +57,8 @@ impl<K: IntoBytes, V: IntoBytes> SetRequest<K, V> {
     }
 
     /// Set the time-to-live for the item.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
         self.ttl = ttl.into();
         self

--- a/src/cache/messages/data/scalar/set_batch.rs
+++ b/src/cache/messages/data/scalar/set_batch.rs
@@ -12,15 +12,6 @@ use crate::cache::messages::data::scalar::set::SetResponse;
 
 /// Request to set a batch of items in a cache.
 ///
-/// # Arguments
-///
-/// * `cache_name` - name of the cache
-/// * `items` - HashMap of (key, value) pairs to set
-///
-/// # Optional Arguments
-///
-/// * `ttl` - The time-to-live for the items. If not provided, the client's default time-to-live is used.
-///
 /// # Example
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -68,6 +59,8 @@ impl<K: IntoBytes, V: IntoBytes> SetBatchRequest<K, V> {
     }
 
     /// Set the time-to-live for the batch of items.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
         self.ttl = ttl.into();
         self

--- a/src/cache/messages/data/scalar/set_if_absent.rs
+++ b/src/cache/messages/data/scalar/set_if_absent.rs
@@ -9,16 +9,6 @@ use std::time::Duration;
 
 /// Request to set associate the given key with the given value if key is not already present in the cache.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache to create.
-/// * `key` - key of the item whose value we are setting
-/// * `value` - data to store
-///
-/// # Optional Arguments
-///
-/// * `ttl` - The time-to-live for the item. If not provided, the client's default time-to-live is used.
-///
 /// # Example
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -71,6 +61,8 @@ impl<K: IntoBytes, V: IntoBytes> SetIfAbsentRequest<K, V> {
     }
 
     /// Set the time-to-live for the item.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
         self.ttl = ttl.into();
         self

--- a/src/cache/messages/data/scalar/set_if_absent_or_equal.rs
+++ b/src/cache/messages/data/scalar/set_if_absent_or_equal.rs
@@ -10,17 +10,6 @@ use std::time::Duration;
 /// Request to associate the given key with the given value if the key does not already
 /// exist in the cache or the value in the cache is equal to the supplied `equal` value.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache to create.
-/// * `key` - key of the item whose value we are setting
-/// * `value` - data to store
-/// * `equal` - data to compare to the cached value
-///
-/// # Optional Arguments
-///
-/// * `ttl` - The time-to-live for the item. If not provided, the client's default time-to-live is used.
-///
 /// # Example
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -76,6 +65,8 @@ impl<K: IntoBytes, V: IntoBytes, E: IntoBytes> SetIfAbsentOrEqualRequest<K, V, E
     }
 
     /// Set the time-to-live for the item.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
         self.ttl = ttl.into();
         self

--- a/src/cache/messages/data/scalar/set_if_equal.rs
+++ b/src/cache/messages/data/scalar/set_if_equal.rs
@@ -10,17 +10,6 @@ use std::time::Duration;
 /// Request to associate the given key with the given value if the key is present
 /// in the cache and its value is equal to the supplied `equal` value.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache to create.
-/// * `key` - key of the item whose value we are setting
-/// * `value` - data to store
-/// * `equal` - data to compare to the cached value
-///
-/// # Optional Arguments
-///
-/// * `ttl` - The time-to-live for the item. If not provided, the client's default time-to-live is used.
-///
 /// # Example
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -76,6 +65,8 @@ impl<K: IntoBytes, V: IntoBytes, E: IntoBytes> SetIfEqualRequest<K, V, E> {
     }
 
     /// Set the time-to-live for the item.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
         self.ttl = ttl.into();
         self

--- a/src/cache/messages/data/scalar/set_if_not_equal.rs
+++ b/src/cache/messages/data/scalar/set_if_not_equal.rs
@@ -10,17 +10,6 @@ use std::time::Duration;
 /// Request to associate the given key with the given value if the key does not already exist
 /// in the cache or the value in the cache is not equal to the value supplied `not_equal` value.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache to create.
-/// * `key` - key of the item whose value we are setting
-/// * `value` - data to store
-/// * `not_equal` - data to compare to the cached value
-///
-/// # Optional Arguments
-///
-/// * `ttl` - The time-to-live for the item. If not provided, the client's default time-to-live is used.
-///
 /// # Example
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -76,6 +65,8 @@ impl<K: IntoBytes, V: IntoBytes, E: IntoBytes> SetIfNotEqualRequest<K, V, E> {
     }
 
     /// Set the time-to-live for the item.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
         self.ttl = ttl.into();
         self

--- a/src/cache/messages/data/scalar/set_if_present.rs
+++ b/src/cache/messages/data/scalar/set_if_present.rs
@@ -9,16 +9,6 @@ use std::time::Duration;
 
 /// Request to set associate the given key with the given value if key is present in the cache.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache to create.
-/// * `key` - key of the item whose value we are setting
-/// * `value` - data to store
-///
-/// # Optional Arguments
-///
-/// * `ttl` - The time-to-live for the item. If not provided, the client's default time-to-live is used.
-///
 /// # Example
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -71,6 +61,8 @@ impl<K: IntoBytes, V: IntoBytes> SetIfPresentRequest<K, V> {
     }
 
     /// Set the time-to-live for the item.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
         self.ttl = ttl.into();
         self

--- a/src/cache/messages/data/scalar/set_if_present_and_not_equal.rs
+++ b/src/cache/messages/data/scalar/set_if_present_and_not_equal.rs
@@ -10,17 +10,6 @@ use std::time::Duration;
 /// Request to associate the given key with the given value if the key exists in the
 /// cache and the value in the cache is not equal to the value supplied `not_equal` value.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache to create.
-/// * `key` - key of the item whose value we are setting
-/// * `value` - data to store
-/// * `not_equal` - data to compare to the cached value
-///
-/// # Optional Arguments
-///
-/// * `ttl` - The time-to-live for the item. If not provided, the client's default time-to-live is used.
-///
 /// # Example
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -76,6 +65,8 @@ impl<K: IntoBytes, V: IntoBytes, E: IntoBytes> SetIfPresentAndNotEqualRequest<K,
     }
 
     /// Set the time-to-live for the item.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
         self.ttl = ttl.into();
         self

--- a/src/cache/messages/data/scalar/update_ttl.rs
+++ b/src/cache/messages/data/scalar/update_ttl.rs
@@ -8,12 +8,7 @@ use crate::{
     cache::MomentoRequest, utils::prep_request_with_timeout, CacheClient, IntoBytes, MomentoResult,
 };
 
-/// Update the ttl of an item in the cache.
-///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `key` - the key of the item for which ttl is requested
-/// * `ttl` - The time-to-live that should overwrite the current ttl.
+/// Update the ttl (time-to-live) of an item in the cache.
 ///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.

--- a/src/cache/messages/data/set/set_add_elements.rs
+++ b/src/cache/messages/data/set/set_add_elements.rs
@@ -8,16 +8,6 @@ use crate::{IntoBytes, IntoBytesIterable, MomentoResult};
 
 /// Request to add elements to the given set. Creates the set if it does not exist.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache containing the set.
-/// * `set_name` - The name of the set to add an element to.
-/// * `elements` - The elements to add. Must be able to be converted to a `Vec<u8>`.
-///
-/// # Optional Arguments
-///
-/// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -51,6 +41,8 @@ pub struct SetAddElementsRequest<S: IntoBytes, E: IntoBytesIterable> {
 
 impl<S: IntoBytes, E: IntoBytesIterable> SetAddElementsRequest<S, E> {
     /// Constructs a new SetAddElementsRequest.
+    ///
+    /// Each element must be able to be converted to a `Vec<u8>`.
     pub fn new(cache_name: impl Into<String>, set_name: S, elements: E) -> Self {
         let collection_ttl = CollectionTtl::default();
         Self {
@@ -62,6 +54,8 @@ impl<S: IntoBytes, E: IntoBytesIterable> SetAddElementsRequest<S, E> {
     }
 
     /// Set the time-to-live for the collection.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
         self.collection_ttl = collection_ttl.into();
         self

--- a/src/cache/messages/data/set/set_fetch.rs
+++ b/src/cache/messages/data/set/set_fetch.rs
@@ -13,11 +13,6 @@ use crate::{
 
 /// Fetch the elements in the given set.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache containing the set.
-/// * `set_name` - The name of the set to fetch.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/set/set_remove_elements.rs
+++ b/src/cache/messages/data/set/set_remove_elements.rs
@@ -12,12 +12,6 @@ use crate::{
 
 /// Removes multiple elements from an existing set. If the set is emptied as a result, the set is deleted.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache containing the set.
-/// * `set_name` - The name of the set to remove elements from.
-/// * `elements` - The elements to remove. Must be able to be converted to a `Vec<u8>`.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -47,6 +41,8 @@ pub struct SetRemoveElementsRequest<S: IntoBytes, E: IntoBytes> {
 
 impl<S: IntoBytes, E: IntoBytes> SetRemoveElementsRequest<S, E> {
     /// Constructs a new SetRemoveElementsRequest.
+    ///
+    /// Each element must be able to be converted to a `Vec<u8>`.
     pub fn new(cache_name: impl Into<String>, set_name: S, elements: Vec<E>) -> Self {
         Self {
             cache_name: cache_name.into(),

--- a/src/cache/messages/data/sorted_set/sorted_set_fetch_by_rank.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_fetch_by_rank.rs
@@ -10,21 +10,6 @@ use crate::{CacheClient, IntoBytes, MomentoResult};
 
 /// Request to fetch the elements in a sorted set by their rank.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache containing the sorted set.
-/// * `sorted_set_name` - The name of the sorted set to add an element to.
-///
-/// # Optional Arguments
-///
-/// * `order` - The order to sort the elements by. [SortedSetOrder::Ascending] or [SortedSetOrder::Descending].
-///   Defaults to Ascending.
-/// * `start_rank` - The rank of the first element to fetch. Defaults to 0. This rank is
-///   inclusive, i.e. the element at this rank will be fetched.
-/// * `end_rank` - The rank of the last element to fetch. This rank is exclusive, i.e. the
-///   element at this rank will not be fetched. Defaults to -1, which fetches up until and
-///   including the last element.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -76,19 +61,27 @@ impl<S: IntoBytes> SortedSetFetchByRankRequest<S> {
         }
     }
 
-    /// Set the start rank of the request.
+    /// Set the rank of the first element to fetch.
+    ///
+    /// Defaults to 0. This rank is inclusive, i.e. the element at this rank will be fetched.
     pub fn start_rank(mut self, start_rank: impl Into<Option<i32>>) -> Self {
         self.start_rank = start_rank.into();
         self
     }
 
-    /// Set the end rank of the request.
+    /// Set the rank of the last element to fetch.
+    ///
+    /// This rank is exclusive, i.e. the element at this rank will not be fetched.
+    /// Defaults to -1, which fetches up until and including the last element.
     pub fn end_rank(mut self, end_rank: impl Into<Option<i32>>) -> Self {
         self.end_rank = end_rank.into();
         self
     }
 
-    /// Set the order of the request.
+    /// Set the order to sort the elements by.
+    ///
+    /// [SortedSetOrder::Ascending] or [SortedSetOrder::Descending].
+    /// Defaults to Ascending.
     pub fn order(mut self, order: impl Into<Option<SortedSetOrder>>) -> Self {
         self.order = order.into().unwrap_or(SortedSetOrder::Ascending);
         self

--- a/src/cache/messages/data/sorted_set/sorted_set_fetch_by_score.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_fetch_by_score.rs
@@ -12,26 +12,6 @@ use super::sorted_set_common::{ScoreBound, SortedSetOrder};
 
 /// Fetch the elements in the given sorted set by their score.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache containing the sorted set.
-/// * `sorted_set_name` - The name of the sorted set to add an element to.
-///
-/// # Optional Arguments
-///
-/// * `order` - The order to sort the elements by. [SortedSetOrder::Ascending] or [SortedSetOrder::Descending].
-///   Defaults to Ascending.
-/// * `min_score` - the minimum score of the elements to fetch. Defaults to negative
-///   infinity. Use [ScoreBound::Inclusive] or [ScoreBound::Exclusive] to specify whether
-///   the minimum score is inclusive or exclusive.
-/// * `max_score` - the maximum score of the elements to fetch. Defaults to positive
-///   infinity. Use [ScoreBound::Inclusive] or [ScoreBound::Exclusive] to specify whether
-///   the maximum score is inclusive or exclusive.
-/// * `offset` - The number of elements to skip before returning the first element. Defaults to
-/// 0. Note: this is not the rank of the first element to return, but the number of elements of
-///    the result set to skip before returning the first element.
-/// * `count` - The maximum number of elements to return. Defaults to all elements.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -87,31 +67,48 @@ impl<S: IntoBytes> SortedSetFetchByScoreRequest<S> {
         }
     }
 
-    /// Set the minimum score of the request.
+    /// Set the minimum score of the elements to fetch.
+    ///
+    /// Defaults to negative infinity.
+    /// Use [ScoreBound::Inclusive] or [ScoreBound::Exclusive]
+    /// to specify whether the minimum score is inclusive or exclusive.
     pub fn min_score(mut self, min_score: impl Into<Option<ScoreBound>>) -> Self {
         self.min_score = min_score.into();
         self
     }
 
-    /// Set the maximum score of the request.
+    /// Set the maximum score of the elements to fetch.
+    ///
+    /// Defaults to positive infinity.
+    /// Use [ScoreBound::Inclusive] or [ScoreBound::Exclusive]
+    /// to specify whether the maximum score is inclusive or exclusive.
     pub fn max_score(mut self, max_score: impl Into<Option<ScoreBound>>) -> Self {
         self.max_score = max_score.into();
         self
     }
 
-    /// Set the order of the request.
+    /// Set the order to sort the elements by.
+    ///
+    /// [SortedSetOrder::Ascending] or [SortedSetOrder::Descending].
+    /// Defaults to Ascending.
     pub fn order(mut self, order: impl Into<Option<SortedSetOrder>>) -> Self {
         self.order = order.into().unwrap_or(SortedSetOrder::Ascending);
         self
     }
 
-    /// Set the offset of the request.
+    /// Set the number of elements to skip before returning the first element.
+    ///
+    /// Defaults to 0.
+    /// Note: this is not the rank of the first element to return, but the number
+    /// of elements of the result set to skip before returning the first element.
     pub fn offset(mut self, offset: impl Into<Option<u32>>) -> Self {
         self.offset = offset.into();
         self
     }
 
-    /// Set the count of the request.
+    /// Set the maximum number of elements to return.
+    ///
+    /// Defaults to all elements.
     pub fn count(mut self, count: impl Into<Option<i32>>) -> Self {
         self.count = count.into();
         self

--- a/src/cache/messages/data/sorted_set/sorted_set_get_rank.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_get_rank.rs
@@ -10,16 +10,6 @@ use crate::{
 
 /// Get the rank (position) of a specific element in a sorted set.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `sorted_set_name` - name of the sorted set
-/// * `value` - the sorted set value to get the rank of
-///
-/// # Optional Arguments
-///
-/// * `order` - The order to sort the elements by. [SortedSetOrder::Ascending] or [SortedSetOrder::Descending].
-///   Defaults to Ascending.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -60,7 +50,10 @@ impl<L: IntoBytes, V: IntoBytes> SortedSetGetRankRequest<L, V> {
         }
     }
 
-    /// Set the rank order of the request.
+    /// Set the rank order to sort the elements by.
+    ///
+    /// [SortedSetOrder::Ascending] or [SortedSetOrder::Descending].
+    /// Defaults to Ascending.
     pub fn order(mut self, order: impl Into<Option<SortedSetOrder>>) -> Self {
         self.order = order.into().unwrap_or(SortedSetOrder::Ascending);
         self

--- a/src/cache/messages/data/sorted_set/sorted_set_get_score.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_get_score.rs
@@ -12,11 +12,6 @@ use crate::{
 
 /// Get the score of a specific element in a sorted set.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `sorted_set_name` - name of the sorted set
-/// * `value` - the sorted set value to get the score of
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/sorted_set/sorted_set_get_scores.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_get_scores.rs
@@ -14,11 +14,6 @@ use crate::{
 
 /// Get the scores of specific elements in a sorted set.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `sorted_set_name` - name of the sorted set
-/// * `values` - the values in the sorted set to the scores of
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/sorted_set/sorted_set_increment_score.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_increment_score.rs
@@ -7,17 +7,6 @@ use crate::{
 
 /// Increments the score of an element in a sorted set.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache containing the sorted set.
-/// * `sorted_set_name` - The name of the sorted set to add an element to.
-/// * `value` - the sorted set value to get the rank of
-/// * `amount` - the amount to increment the score by
-///
-/// # Optional Arguments
-///
-/// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -65,6 +54,8 @@ impl<S: IntoBytes, V: IntoBytes> SortedSetIncrementScoreRequest<S, V> {
     }
 
     /// Set the time-to-live for the collection.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
         self.collection_ttl = collection_ttl.into();
         self

--- a/src/cache/messages/data/sorted_set/sorted_set_length.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_length.rs
@@ -9,10 +9,6 @@ use crate::{
 
 /// Get the number of entries in a sorted set collection.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `sorted_set_name` - name of the sorted set
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```

--- a/src/cache/messages/data/sorted_set/sorted_set_length_by_score.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_length_by_score.rs
@@ -13,18 +13,6 @@ use crate::{
 
 /// Get the number of entries in a sorted set that fall between a minimum and maximum score.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `sorted_set_name` - name of the sorted set
-///
-/// # Optional Arguments
-/// * `min_score` - the minimum score of the elements to fetch. Defaults to negative
-///   infinity. Use [ScoreBound::Inclusive] or [ScoreBound::Exclusive] to specify whether
-///   the minimum score is inclusive or exclusive.
-/// * `max_score` - the maximum score of the elements to fetch. Defaults to positive
-///   infinity. Use [ScoreBound::Inclusive] or [ScoreBound::Exclusive] to specify whether
-///   the maximum score is inclusive or exclusive.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -66,13 +54,21 @@ impl<L: IntoBytes> SortedSetLengthByScoreRequest<L> {
         }
     }
 
-    /// Set the minimum score of the request.
+    /// Set the minimum score of the elements to fetch.
+    ///
+    /// Defaults to negative infinity.
+    /// Use [ScoreBound::Inclusive] or [ScoreBound::Exclusive]
+    /// to specify whether the minimum score is inclusive or exclusive.
     pub fn min_score(mut self, min_score: impl Into<Option<ScoreBound>>) -> Self {
         self.min_score = min_score.into();
         self
     }
 
     /// Set the maximum score of the request.
+    ///
+    /// Defaults to positive infinity.
+    /// Use [ScoreBound::Inclusive] or [ScoreBound::Exclusive]
+    /// to specify whether the maximum score is inclusive or exclusive.
     pub fn max_score(mut self, max_score: impl Into<Option<ScoreBound>>) -> Self {
         self.max_score = max_score.into();
         self

--- a/src/cache/messages/data/sorted_set/sorted_set_length_by_score.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_length_by_score.rs
@@ -64,7 +64,7 @@ impl<L: IntoBytes> SortedSetLengthByScoreRequest<L> {
         self
     }
 
-    /// Set the maximum score of the request.
+    /// Set the maximum score of the elements to fetch.
     ///
     /// Defaults to positive infinity.
     /// Use [ScoreBound::Inclusive] or [ScoreBound::Exclusive]

--- a/src/cache/messages/data/sorted_set/sorted_set_put_element.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_put_element.rs
@@ -8,17 +8,6 @@ use crate::{CacheClient, IntoBytes, MomentoResult};
 /// Request to add an element to a sorted set. If the element already exists, its score is updated.
 /// Creates the sorted set if it does not exist.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache containing the sorted set.
-/// * `sorted_set_name` - The name of the sorted set to add an element to.
-/// * `value` - The value of the element to add. Must be able to be converted to a `Vec<u8>`.
-/// * `score` - The score of the element to add.
-///
-/// # Optional Arguments
-///
-/// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -53,6 +42,8 @@ pub struct SortedSetPutElementRequest<S: IntoBytes, V: IntoBytes> {
 
 impl<S: IntoBytes, V: IntoBytes> SortedSetPutElementRequest<S, V> {
     /// Constructs a new SortedSetPutElementRequest.
+    ///
+    /// The value must be able to be converted to a `Vec<u8>`.
     pub fn new(cache_name: impl Into<String>, sorted_set_name: S, value: V, score: f64) -> Self {
         let collection_ttl = CollectionTtl::default();
         Self {
@@ -65,6 +56,8 @@ impl<S: IntoBytes, V: IntoBytes> SortedSetPutElementRequest<S, V> {
     }
 
     /// Set the time-to-live for the collection.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
         self.collection_ttl = collection_ttl.into();
         self

--- a/src/cache/messages/data/sorted_set/sorted_set_put_elements.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_put_elements.rs
@@ -109,16 +109,6 @@ impl<V: IntoBytes> IntoSortedSetElements<V> for HashMap<V, f64> {
 /// Request to add elements to a sorted set. If an element already exists, its score is updated.
 /// Creates the sorted set if it does not exist.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache containing the sorted set.
-/// * `sorted_set_name` - The name of the sorted set to add an element to.
-/// * `elements` - The values and scores to add.
-///
-/// # Optional Arguments
-///
-/// * `collection_ttl` - The time-to-live for the collection. If not provided, the client's default time-to-live is used.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -166,6 +156,8 @@ impl<S: IntoBytes, V: IntoBytes, E: IntoSortedSetElements<V>> SortedSetPutElemen
     }
 
     /// Set the time-to-live for the collection.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
         self.collection_ttl = collection_ttl.into();
         self

--- a/src/cache/messages/data/sorted_set/sorted_set_remove_elements.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_remove_elements.rs
@@ -7,11 +7,6 @@ use crate::{CacheClient, IntoBytes, IntoBytesIterable, MomentoResult};
 
 /// Remove multiple elements from the sorted set.
 ///
-/// # Arguments
-/// * `cache_name` - The name of the cache containing the sorted set.
-/// * `sorted_set_name` - The name of the sorted set to remove elements from.
-/// * `values` - The values to remove. Must be able to be converted to a `Vec<u8>`.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -44,6 +39,8 @@ pub struct SortedSetRemoveElementsRequest<S: IntoBytes, V: IntoBytesIterable> {
 
 impl<S: IntoBytes, V: IntoBytesIterable> SortedSetRemoveElementsRequest<S, V> {
     /// Constructs a new SortedSetRemoveElementsRequest.
+    ///
+    /// Each value must be able to be converted to a `Vec<u8>`
     pub fn new(cache_name: impl Into<String>, sorted_set_name: S, values: V) -> Self {
         Self {
             cache_name: cache_name.into(),

--- a/src/cache/messages/data/sorted_set/sorted_set_union_store.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_union_store.rs
@@ -81,15 +81,6 @@ impl<S: IntoBytes> IntoSortedSetUnionStoreSources<S> for HashMap<S, f32> {
 
 /// Compute the union of multiple sorted sets and store the result in a destination sorted set.
 ///
-/// # Arguments
-/// * `cache_name` - name of cache
-/// * `sorted_set_name` - name of the destination sorted set. This set is not implicitly included as a source.
-/// * `sources` - the sorted sets to compute the union for.
-///
-/// # Optional Arguments
-/// * `aggregate` - the aggregate function to use to determine the final score for an element that exists in multiple source sets. Defaults to [SortedSetAggregateFunction::Sum].
-/// * `collection_ttl` - the time-to-live for the collection. If not provided, the client's default time-to-live is used.
-///
 /// # Examples
 /// Assumes that a CacheClient named `cache_client` has been created and is available.
 /// ```
@@ -135,6 +126,8 @@ impl<S: IntoBytes, Z: IntoBytes, U: IntoSortedSetUnionStoreSources<Z>>
     SortedSetUnionStoreRequest<S, Z, U>
 {
     /// Constructs a new SortedSetUnionStoreRequest.
+    ///
+    /// Note: The destination set is not implicitly included as a source.
     pub fn new(cache_name: impl Into<String>, sorted_set_name: S, sources: U) -> Self {
         let collection_ttl = CollectionTtl::default();
         Self {
@@ -147,13 +140,18 @@ impl<S: IntoBytes, Z: IntoBytes, U: IntoSortedSetUnionStoreSources<Z>>
         }
     }
 
-    /// Set the aggregate function of the request.
+    /// Set the aggregate function that determines the final score
+    /// for an element that exists in multiple source sets.
+    ///
+    /// Defaults to [SortedSetAggregateFunction::Sum].
     pub fn aggregate(mut self, aggregate: impl Into<Option<SortedSetAggregateFunction>>) -> Self {
         self.aggregate = aggregate.into().unwrap_or(SortedSetAggregateFunction::Sum);
         self
     }
 
     /// Set the time-to-live for the collection.
+    ///
+    /// If not provided, the client's default time-to-live is used.
     pub fn ttl(mut self, collection_ttl: impl Into<Option<CollectionTtl>>) -> Self {
         self.collection_ttl = collection_ttl.into();
         self

--- a/src/functions/function.rs
+++ b/src/functions/function.rs
@@ -17,7 +17,7 @@ impl Function {
         &self.name
     }
 
-    /// Current/active description of the function.
+    /// Currently active description of the function.
     pub fn description(&self) -> &str {
         &self.description
     }

--- a/src/functions/messages/put_function.rs
+++ b/src/functions/messages/put_function.rs
@@ -9,11 +9,6 @@ use crate::{
 /// Create or update a Function.
 /// The cache is used as a namespace for your Functions.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache to use as a namespace for the Function.
-/// * `function_name` - The name of the Function.
-///
 /// # Example
 ///
 /// ```rust

--- a/src/protosocket/cache/cache_client.rs
+++ b/src/protosocket/cache/cache_client.rs
@@ -69,12 +69,6 @@ impl ProtosocketCacheClient {
 
     /// Constructs a ProtosocketCacheClient to use Momento Cache using the protosocket protocol.
     ///
-    /// # Arguments
-    /// - `default_ttl` - Default time-to-live for items in the cache.
-    /// - `configuration` - Prebuilt configurations tuned for different environments are available in the [protosocket::cache::configurations](crate::protosocket::cache::configurations) module.
-    /// - `credential_provider` - A [CredentialProvider](crate::CredentialProvider) to use for authenticating with Momento.
-    /// - `runtime` - A [tokio::runtime::Handle] to use for running the client.
-    ///
     /// # Example
     ///
     /// ```no_run

--- a/src/protosocket/cache/cache_client.rs
+++ b/src/protosocket/cache/cache_client.rs
@@ -153,12 +153,6 @@ impl ProtosocketCacheClient {
     /// * `key` - key of the item whose value we are setting
     /// * `value` - data to stored in the cache item
     ///
-    /// # Optional Arguments
-    /// If you use [send_request](ProtosocketCacheClient::send_request) to set an item using a
-    /// [SetRequest], you can also provide the following optional arguments:
-    ///
-    /// * `ttl` - The time-to-live for the item. If not provided, the client's default time-to-live is used.
-    ///
     /// # Examples
     /// Assumes that a ProtosocketCacheClient named `cache_client` has been created and is available.
     /// ```no_run
@@ -181,8 +175,8 @@ impl ProtosocketCacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](ProtosocketCacheClient::send_request) method to get an item using a [SetRequest]
-    /// which will allow you to set [optional arguments](crate::cache::SetRequest#optional-arguments) as well.
+    /// You can also use the [send_request](ProtosocketCacheClient::send_request) method to get an item using a [SetRequest],
+    /// which will allow you to set optional fields like [ttl](SetRequest::ttl) as well.
     pub async fn set(
         &self,
         cache_name: impl Into<String>,

--- a/src/protosocket/cache/cache_client.rs
+++ b/src/protosocket/cache/cache_client.rs
@@ -169,7 +169,7 @@ impl ProtosocketCacheClient {
     /// # })
     /// # }
     /// ```
-    /// You can also use the [send_request](ProtosocketCacheClient::send_request) method to get an item using a [SetRequest],
+    /// You can also use the [send_request](ProtosocketCacheClient::send_request) method to set an item using a [SetRequest],
     /// which will allow you to set optional fields like [ttl](SetRequest::ttl) as well.
     pub async fn set(
         &self,

--- a/src/protosocket/cache/cache_client.rs
+++ b/src/protosocket/cache/cache_client.rs
@@ -190,6 +190,8 @@ impl ProtosocketCacheClient {
     /// Lower-level API to send any type of MomentoProtosocketRequest to the server. This is used for cases when
     /// you want to set optional fields on a request that are not supported by the short-hand API for
     /// that request type.
+    ///
+    /// See [SetRequest] for an example of creating a request with optional fields, like [ttl](SetRequest::ttl).
     pub async fn send_request<R: MomentoProtosocketRequest>(
         &self,
         request: R,

--- a/src/protosocket/cache/cache_client_builder.rs
+++ b/src/protosocket/cache/cache_client_builder.rs
@@ -57,6 +57,8 @@ pub struct ReadyToBuild {
 
 impl ProtosocketCacheClientBuilder<NeedsDefaultTtl> {
     /// Constructs a new CacheClientBuilder in the NeedsDefaultTtl state.
+    ///
+    /// Default time-to-live for items in the cache.
     pub fn default_ttl(
         self,
         default_ttl: Duration,
@@ -69,6 +71,8 @@ impl ProtosocketCacheClientBuilder<NeedsDefaultTtl> {
 
 impl ProtosocketCacheClientBuilder<NeedsConfiguration> {
     /// Constructs a new CacheClientBuilder in the NeedsConfiguration state.
+    ///
+    /// Prebuilt configurations tuned for different environments are available in the [protosocket::cache::configurations](crate::protosocket::cache::configurations) module.
     pub fn configuration(
         self,
         configuration: impl Into<Configuration>,
@@ -84,6 +88,8 @@ impl ProtosocketCacheClientBuilder<NeedsConfiguration> {
 
 impl ProtosocketCacheClientBuilder<NeedsCredentialProvider> {
     /// Constructs a new CacheClientBuilder in the NeedsCredentialProvider state.
+    ///
+    /// A [CredentialProvider](crate::CredentialProvider) to use for authenticating with Momento.
     pub fn credential_provider(
         self,
         credential_provider: CredentialProvider,
@@ -100,6 +106,8 @@ impl ProtosocketCacheClientBuilder<NeedsCredentialProvider> {
 
 impl ProtosocketCacheClientBuilder<NeedsRuntime> {
     /// Constructs a new CacheClientBuilder in the NeedsRuntime state.
+    ///
+    /// A [tokio::runtime::Handle] to use for running the client.
     pub fn runtime(
         self,
         runtime: tokio::runtime::Handle,

--- a/src/protosocket/cache/cache_client_builder.rs
+++ b/src/protosocket/cache/cache_client_builder.rs
@@ -56,9 +56,7 @@ pub struct ReadyToBuild {
 }
 
 impl ProtosocketCacheClientBuilder<NeedsDefaultTtl> {
-    /// Constructs a new CacheClientBuilder in the NeedsDefaultTtl state.
-    ///
-    /// Default time-to-live for items in the cache.
+    /// Sets the default time-to-live for items in the cache.
     pub fn default_ttl(
         self,
         default_ttl: Duration,
@@ -70,7 +68,7 @@ impl ProtosocketCacheClientBuilder<NeedsDefaultTtl> {
 }
 
 impl ProtosocketCacheClientBuilder<NeedsConfiguration> {
-    /// Constructs a new CacheClientBuilder in the NeedsConfiguration state.
+    /// Sets the configuration for the ProtosocketCacheClient.
     ///
     /// Prebuilt configurations tuned for different environments are available in the [protosocket::cache::configurations](crate::protosocket::cache::configurations) module.
     pub fn configuration(
@@ -87,9 +85,7 @@ impl ProtosocketCacheClientBuilder<NeedsConfiguration> {
 }
 
 impl ProtosocketCacheClientBuilder<NeedsCredentialProvider> {
-    /// Constructs a new CacheClientBuilder in the NeedsCredentialProvider state.
-    ///
-    /// A [CredentialProvider](crate::CredentialProvider) to use for authenticating with Momento.
+    /// Sets the [CredentialProvider](crate::CredentialProvider) to use for authenticating with Momento.
     pub fn credential_provider(
         self,
         credential_provider: CredentialProvider,
@@ -105,9 +101,7 @@ impl ProtosocketCacheClientBuilder<NeedsCredentialProvider> {
 }
 
 impl ProtosocketCacheClientBuilder<NeedsRuntime> {
-    /// Constructs a new CacheClientBuilder in the NeedsRuntime state.
-    ///
-    /// A [tokio::runtime::Handle] to use for running the client.
+    /// Sets the [tokio::runtime::Handle] to use for running the client.
     pub fn runtime(
         self,
         runtime: tokio::runtime::Handle,

--- a/src/topics/messages/publish.rs
+++ b/src/topics/messages/publish.rs
@@ -9,12 +9,6 @@ use crate::{
 /// The cache is used as a namespace for your topics, and it needs to exist.
 /// You don't create topics, you just start using them.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache to use as a namespace for the topic.
-/// * `topic` - The name of the topic to publish to.
-/// * `value` - The value to publish to the topic.
-///
 /// # Example
 ///
 /// ```

--- a/src/topics/messages/subscribe.rs
+++ b/src/topics/messages/subscribe.rs
@@ -8,15 +8,6 @@ use crate::{
 /// The cache is used as a namespace for your topics, and it needs to exist.
 /// You don't create topics, you just start using them.
 ///
-/// # Arguments
-///
-/// * `cache_name` - The name of the cache to use as a namespace for the topic.
-/// * `topic` - The name of the topic to publish to.
-///
-/// # Optional Arguments
-///
-/// * `resume_at_topic_sequence_number` - The sequence number to resume from. If not provided, the subscription will start from the latest message or from zero if starting a new subscription.
-///
 /// # Example
 ///
 /// ```no_run
@@ -55,6 +46,10 @@ pub struct SubscribeRequest {
 
 impl SubscribeRequest {
     /// Create a new SubscribeRequest.
+    ///
+    /// If you don't set `resume_at_topic_sequence_number` or `resume_at_sequence_page`,
+    /// the subscription will start from the latest message
+    /// or from zero if starting a new subscription.
     pub fn new(
         cache_name: impl Into<String>,
         topic: impl Into<String>,

--- a/src/topics/topic_client.rs
+++ b/src/topics/topic_client.rs
@@ -55,10 +55,6 @@ pub struct TopicClient {
 impl TopicClient {
     /// Constructs a TopicClient to use Momento Topics
     ///
-    /// # Arguments
-    /// - `configuration` - Prebuilt configurations tuned for different environments are available in the [topics::configurations](crate::topics::configurations) module.
-    /// - `credential_provider` - A [CredentialProvider](crate::CredentialProvider) to use for authenticating with Momento.
-    ///
     /// # Example
     ///
     /// ```

--- a/src/topics/topic_client_builder.rs
+++ b/src/topics/topic_client_builder.rs
@@ -29,6 +29,7 @@ pub struct ReadyToBuild {
 }
 
 impl TopicClientBuilder<NeedsConfiguration> {
+    /// Prebuilt configurations tuned for different environments are available in the [topics::configurations](crate::topics::configurations) module.
     pub fn configuration(
         self,
         configuration: impl Into<Configuration>,
@@ -40,6 +41,7 @@ impl TopicClientBuilder<NeedsConfiguration> {
 }
 
 impl TopicClientBuilder<NeedsCredentialProvider> {
+    /// A [CredentialProvider](crate::CredentialProvider) to use for authenticating with Momento.
     pub fn credential_provider(
         self,
         credential_provider: CredentialProvider,

--- a/src/topics/topic_client_builder.rs
+++ b/src/topics/topic_client_builder.rs
@@ -29,7 +29,7 @@ pub struct ReadyToBuild {
 }
 
 impl TopicClientBuilder<NeedsConfiguration> {
-    /// Constructs a new TopicClientBuilder in the NeedsConfiguration state.
+    /// Sets the configuration for the TopicClient.
     ///
     /// Prebuilt configurations tuned for different environments are available in the [topics::configurations](crate::topics::configurations) module.
     pub fn configuration(
@@ -43,9 +43,7 @@ impl TopicClientBuilder<NeedsConfiguration> {
 }
 
 impl TopicClientBuilder<NeedsCredentialProvider> {
-    /// Constructs a new TopicClientBuilder in the NeedsCredentialProvider state.
-    ///
-    /// A [CredentialProvider](crate::CredentialProvider) to use for authenticating with Momento.
+    /// Sets the [CredentialProvider](crate::CredentialProvider) to use for authenticating with Momento.
     pub fn credential_provider(
         self,
         credential_provider: CredentialProvider,

--- a/src/topics/topic_client_builder.rs
+++ b/src/topics/topic_client_builder.rs
@@ -29,6 +29,8 @@ pub struct ReadyToBuild {
 }
 
 impl TopicClientBuilder<NeedsConfiguration> {
+    /// Constructs a new TopicClientBuilder in the NeedsConfiguration state.
+    ///
     /// Prebuilt configurations tuned for different environments are available in the [topics::configurations](crate::topics::configurations) module.
     pub fn configuration(
         self,
@@ -41,6 +43,8 @@ impl TopicClientBuilder<NeedsConfiguration> {
 }
 
 impl TopicClientBuilder<NeedsCredentialProvider> {
+    /// Constructs a new TopicClientBuilder in the NeedsCredentialProvider state.
+    ///
     /// A [CredentialProvider](crate::CredentialProvider) to use for authenticating with Momento.
     pub fn credential_provider(
         self,

--- a/tests/cache/list.rs
+++ b/tests/cache/list.rs
@@ -60,7 +60,7 @@ mod list_concatenate_back {
     }
 
     #[tokio::test]
-    async fn happy_path_with_optional_arguments() -> MomentoResult<()> {
+    async fn happy_path_with_optional_fields() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = &CACHE_TEST_STATE.cache_name;
         let test_list = TestList::default();
@@ -130,7 +130,7 @@ mod list_concatenate_front {
     }
 
     #[tokio::test]
-    async fn happy_path_with_optional_arguments() -> MomentoResult<()> {
+    async fn happy_path_with_optional_fields() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = &CACHE_TEST_STATE.cache_name;
         let test_list = TestList::default();
@@ -444,7 +444,7 @@ mod list_push_back {
     }
 
     #[tokio::test]
-    async fn happy_path_with_optional_arguments() -> MomentoResult<()> {
+    async fn happy_path_with_optional_fields() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = &CACHE_TEST_STATE.cache_name;
         let test_list = TestList::default();
@@ -523,7 +523,7 @@ mod list_push_front {
     }
 
     #[tokio::test]
-    async fn happy_path_with_optional_arguments() -> MomentoResult<()> {
+    async fn happy_path_with_optional_fields() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = &CACHE_TEST_STATE.cache_name;
         let test_list = TestList::default();

--- a/tests/cache/list_v2.rs
+++ b/tests/cache/list_v2.rs
@@ -60,7 +60,7 @@ mod list_concatenate_back {
     }
 
     #[tokio::test]
-    async fn happy_path_with_optional_arguments() -> MomentoResult<()> {
+    async fn happy_path_with_optional_fields() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client_v2;
         let cache_name = &CACHE_TEST_STATE.cache_name;
         let test_list = TestList::default();
@@ -130,7 +130,7 @@ mod list_concatenate_front {
     }
 
     #[tokio::test]
-    async fn happy_path_with_optional_arguments() -> MomentoResult<()> {
+    async fn happy_path_with_optional_fields() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client_v2;
         let cache_name = &CACHE_TEST_STATE.cache_name;
         let test_list = TestList::default();
@@ -444,7 +444,7 @@ mod list_push_back {
     }
 
     #[tokio::test]
-    async fn happy_path_with_optional_arguments() -> MomentoResult<()> {
+    async fn happy_path_with_optional_fields() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client_v2;
         let cache_name = &CACHE_TEST_STATE.cache_name;
         let test_list = TestList::default();
@@ -523,7 +523,7 @@ mod list_push_front {
     }
 
     #[tokio::test]
-    async fn happy_path_with_optional_arguments() -> MomentoResult<()> {
+    async fn happy_path_with_optional_fields() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client_v2;
         let cache_name = &CACHE_TEST_STATE.cache_name;
         let test_list = TestList::default();

--- a/tests/cache/set.rs
+++ b/tests/cache/set.rs
@@ -87,12 +87,12 @@ mod set_add_elements {
     }
 
     #[tokio::test]
-    async fn happy_path_with_optional_arguments() -> MomentoResult<()> {
+    async fn happy_path_with_optional_fields() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client;
         let cache_name = &CACHE_TEST_STATE.cache_name;
         let test_set = TestSet::default();
 
-        // add elements with optional ttl argument
+        // add elements with optional ttl field
         let request =
             SetAddElementsRequest::new(cache_name, test_set.name(), test_set.value().to_vec())
                 .ttl(CollectionTtl::new(Some(Duration::from_secs(10)), false));

--- a/tests/cache/set_v2.rs
+++ b/tests/cache/set_v2.rs
@@ -87,12 +87,12 @@ mod set_add_elements {
     }
 
     #[tokio::test]
-    async fn happy_path_with_optional_arguments() -> MomentoResult<()> {
+    async fn happy_path_with_optional_fields() -> MomentoResult<()> {
         let client = &CACHE_TEST_STATE.client_v2;
         let cache_name = &CACHE_TEST_STATE.cache_name;
         let test_set = TestSet::default();
 
-        // add elements with optional ttl argument
+        // add elements with optional ttl field
         let request =
             SetAddElementsRequest::new(cache_name, test_set.name(), test_set.value().to_vec())
                 .ttl(CollectionTtl::new(Some(Duration::from_secs(10)), false));


### PR DESCRIPTION
Aligns our Rust SDK docs with Rust implementation/terminology, mainly by moving/removing "arguments" from struct docstrings (suggested in https://github.com/momentohq/client-sdk-rust/pull/530#discussion_r3090030243).

To see why I made each edit and where I moved each comment moved to/from, I recommend viewing my individual commits.

Feel free to commit any related, non-breaking edits/fixes/removals. (Or if you prefer, comment as usual and I'll get to it :) )

_For reference, SDK docs available here:
https://docs.rs/momento/latest/momento/_