### PR TITLE
feat: offer eager connection establishment on CacheClient

### DIFF
--- a/src/cache/cache_client_builder.rs
+++ b/src/cache/cache_client_builder.rs
@@ -1,6 +1,7 @@
 use crate::cache::Configuration;
 use crate::grpc::header_interceptor::HeaderInterceptor;
 use crate::{utils, CacheClient, CredentialProvider, MomentoResult};
+use futures::future::try_join_all;
 use std::time::Duration;
 use tonic::codegen::InterceptedService;
 
@@ -127,6 +128,82 @@ impl CacheClientBuilder<ReadyToBuild> {
                 .grpc_configuration
                 .clone(),
         )?;
+
+        let control_interceptor = InterceptedService::new(
+            control_channel,
+            HeaderInterceptor::new(&self.0.credential_provider.auth_token, agent_value),
+        );
+
+        let data_clients: Vec<ScsClient<InterceptedService<Channel, HeaderInterceptor>>> =
+            data_channels
+                .into_iter()
+                .map(|c| {
+                    let data_interceptor = InterceptedService::new(
+                        c,
+                        HeaderInterceptor::new(&self.0.credential_provider.auth_token, agent_value),
+                    );
+                    ScsClient::new(data_interceptor)
+                        .max_decoding_message_size(
+                            self.0
+                                .configuration
+                                .transport_strategy
+                                .grpc_configuration
+                                .max_receive_message_size
+                                .unwrap_or(DEFAULT_MAX_REQUEST_SIZE),
+                        )
+                        .max_encoding_message_size(
+                            self.0
+                                .configuration
+                                .transport_strategy
+                                .grpc_configuration
+                                .max_send_message_size
+                                .unwrap_or(DEFAULT_MAX_REQUEST_SIZE),
+                        )
+                })
+                .collect();
+        let control_client = ScsControlClient::new(control_interceptor);
+
+        Ok(CacheClient::new(
+            data_clients,
+            control_client,
+            self.0.configuration,
+            self.0.default_ttl,
+        ))
+    }
+
+    /// Like [`build`](Self::build), but eagerly establishes all gRPC connections before returning.
+    /// All data channels connect concurrently. Returns an error if any connection fails.
+    pub async fn build_and_connect(self) -> MomentoResult<CacheClient> {
+        let agent_value = &utils::user_agent("cache");
+
+        let data_channel_futs = (0..self
+            .0
+            .configuration
+            .transport_strategy
+            .grpc_configuration
+            .num_channels)
+            .map(|_| {
+                utils::connect_channel_eagerly_configurable(
+                    &self.0.credential_provider.cache_endpoint,
+                    self.0
+                        .configuration
+                        .transport_strategy
+                        .grpc_configuration
+                        .clone(),
+                )
+            });
+
+        let data_channels = try_join_all(data_channel_futs).await?;
+
+        let control_channel = utils::connect_channel_eagerly_configurable(
+            &self.0.credential_provider.control_endpoint,
+            self.0
+                .configuration
+                .transport_strategy
+                .grpc_configuration
+                .clone(),
+        )
+        .await?;
 
         let control_interceptor = InterceptedService::new(
             control_channel,

--- a/src/cache/messages/data/dictionary/dictionary_get_fields.rs
+++ b/src/cache/messages/data/dictionary/dictionary_get_fields.rs
@@ -205,8 +205,7 @@ impl<F: IntoBytesIterable> TryFrom<DictionaryGetFieldsResponse<F>> for HashMap<S
                 fields, responses, ..
             } => {
                 let mut result = HashMap::new();
-                for (field, response) in fields.into_bytes().into_iter().zip(responses.into_iter())
-                {
+                for (field, response) in fields.into_bytes().into_iter().zip(responses) {
                     match response {
                         DictionaryGetFieldResponse::Hit { value } => {
                             let key: String = parse_string(field.into_bytes())?;
@@ -233,8 +232,7 @@ impl<F: IntoBytesIterable> TryFrom<DictionaryGetFieldsResponse<F>> for HashMap<V
                 fields, responses, ..
             } => {
                 let mut result = HashMap::new();
-                for (field, response) in fields.into_bytes().into_iter().zip(responses.into_iter())
-                {
+                for (field, response) in fields.into_bytes().into_iter().zip(responses) {
                     match response {
                         DictionaryGetFieldResponse::Hit { value } => {
                             result.insert(field.into_bytes(), value.into());

--- a/src/cache/messages/data/sorted_set/sorted_set_get_scores.rs
+++ b/src/cache/messages/data/sorted_set/sorted_set_get_scores.rs
@@ -125,8 +125,7 @@ impl<F: IntoBytesIterable + Clone> TryFrom<SortedSetGetScoresResponse<F>>
                 values, responses, ..
             } => {
                 let mut result = Vec::new();
-                for (value, response) in values.into_bytes().into_iter().zip(responses.into_iter())
-                {
+                for (value, response) in values.into_bytes().into_iter().zip(responses) {
                     match response {
                         SortedSetGetScoreResponse::Hit { score } => {
                             let ele = SortedSetElement { score, value };
@@ -158,9 +157,7 @@ impl<F: IntoBytesIterable + Clone> TryFrom<SortedSetGetScoresResponse<F>>
                 values, responses, ..
             } => {
                 let mut result = Vec::new();
-                for (bytes_value, response) in
-                    values.into_bytes().into_iter().zip(responses.into_iter())
-                {
+                for (bytes_value, response) in values.into_bytes().into_iter().zip(responses) {
                     match response {
                         SortedSetGetScoreResponse::Hit { score } => {
                             let value: String = parse_string(bytes_value)?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -183,6 +183,25 @@ pub(crate) fn connect_channel_lazily_configurable(
     Ok(channel_builder.connect_lazy())
 }
 
+pub(crate) async fn connect_channel_eagerly_configurable(
+    uri_string: &str,
+    grpc_config: GrpcConfiguration,
+) -> Result<Channel, ChannelConnectError> {
+    let uri = Uri::try_from(uri_string)?;
+    let mut channel_builder =
+        Channel::builder(uri).tls_config(ClientTlsConfig::default().with_webpki_roots())?;
+    if let Some(keep_alive_while_idle) = grpc_config.keep_alive_while_idle {
+        channel_builder = channel_builder.keep_alive_while_idle(keep_alive_while_idle);
+    }
+    if let Some(keep_alive_interval) = grpc_config.keep_alive_interval {
+        channel_builder = channel_builder.http2_keep_alive_interval(keep_alive_interval);
+    }
+    if let Some(keep_alive_timeout) = grpc_config.keep_alive_timeout {
+        channel_builder = channel_builder.keep_alive_timeout(keep_alive_timeout);
+    }
+    Ok(channel_builder.connect().await?)
+}
+
 pub(crate) fn user_agent(user_agent_name: &str) -> String {
     format!("rust:{user_agent_name}:{VERSION}")
 }
@@ -364,6 +383,26 @@ mod tests {
         };
         let result = connect_channel_lazily_configurable(uri_string, grpc_config);
         assert!(result.is_ok(), "Expected Ok, but got {:?}", result);
+    }
+
+    #[tokio::test]
+    async fn test_connect_channel_eagerly_configurable_bad_uri() {
+        let grpc_config = GrpcConfiguration {
+            keep_alive_while_idle: Some(true),
+            keep_alive_interval: Some(Duration::from_secs(30)),
+            keep_alive_timeout: Some(Duration::from_secs(60)),
+            deadline: Duration::from_secs(30),
+            num_channels: 1,
+            max_send_message_size: None,
+            max_receive_message_size: None,
+        };
+        let result =
+            connect_channel_eagerly_configurable("http://invalid host:50051", grpc_config).await;
+        assert!(
+            matches!(result, Err(ChannelConnectError::BadUri(_))),
+            "Expected BadUri error, got {:?}",
+            result
+        );
     }
 
     #[test]

--- a/tests/cache/control_v2.rs
+++ b/tests/cache/control_v2.rs
@@ -1,8 +1,11 @@
-use momento::cache::{CreateCacheResponse, FlushCacheResponse, GetResponse, SetResponse};
-use momento::MomentoErrorCode;
-use momento::MomentoResult;
-use momento_test_util::CACHE_TEST_STATE;
-use momento_test_util::{unique_cache_name, TestScalar};
+use momento::cache::{
+    configurations, CreateCacheResponse, FlushCacheResponse, GetResponse, SetResponse,
+};
+use momento::{CacheClient, MomentoErrorCode, MomentoResult};
+use momento_test_util::{
+    get_v1_test_credential_provider, unique_cache_name, TestScalar, CACHE_TEST_STATE,
+};
+use std::time::Duration;
 
 mod create_delete_list_cache {
     use super::*;
@@ -100,6 +103,23 @@ mod flush_cache {
         let delete_result = client.delete_cache(cache_name).await?;
         assert_eq!(delete_result, DeleteCacheResponse {});
 
+        Ok(())
+    }
+}
+
+mod build_and_connect {
+    use super::*;
+
+    #[tokio::test]
+    async fn creates_working_client() -> MomentoResult<()> {
+        let client = CacheClient::builder()
+            .default_ttl(Duration::from_secs(5))
+            .configuration(configurations::Laptop::latest())
+            .credential_provider(get_v1_test_credential_provider())
+            .build_and_connect()
+            .await
+            .expect("build_and_connect should succeed");
+        client.list_caches().await?;
         Ok(())
     }
 }


### PR DESCRIPTION
Offer alternative build_and_connect() method to establish active grpc connections up front instead of lazy connections.
