### PR TITLE
feat: update client protos with ability to set function metrics CW delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "momento-protos"
-version = "0.130.1"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e522903f13088da517d053096450fdd8073f889674e0490ba479118607f88282"
+checksum = "c5cdb80e6857610decc80ff9473e889aad71e1aa3b7bf37df73472e88bb99cc9"
 dependencies = [
  "prost",
  "protosocket-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ doc = false
 
 
 [dependencies]
-momento-protos = "0.130.1"
+momento-protos = "0.132.0"
 base64 = "0.22"
 derive_more = { version = "2.0.1", features = ["full"] }
 futures = "0"

--- a/src/functions/function.rs
+++ b/src/functions/function.rs
@@ -10,6 +10,7 @@ pub struct Function {
     latest_version: u32,
     concurrency_limit: u32,
     last_updated_at: String,
+    metrics_config: Option<FunctionMetricsConfig>,
 }
 impl Function {
     /// Name of the function.
@@ -47,6 +48,15 @@ impl Function {
     pub fn last_updated_at(&self) -> &str {
         &self.last_updated_at
     }
+
+    /// Configuration for delivering this function's metrics to your own
+    /// CloudWatch account.
+    ///
+    /// Returns `None` when no configuration is set for this function, in which case it follows
+    /// your account-wide default.
+    pub fn metrics_config(&self) -> Option<&FunctionMetricsConfig> {
+        self.metrics_config.as_ref()
+    }
 }
 
 impl From<momento_protos::function_types::Function> for Function {
@@ -60,11 +70,13 @@ impl From<momento_protos::function_types::Function> for Function {
             concurrency_limit,
             last_updated_at,
             function_limits: _, // TODO implement getter(s) for function limits
+            metrics_config,
         } = proto;
         Self {
             name,
             description,
             function_id,
+            metrics_config: metrics_config.and_then(metrics_config_from_proto),
             version: match current_version {
                 Some(momento_protos::function_types::CurrentFunctionVersion {
                     version: Some(version),
@@ -81,6 +93,105 @@ impl From<momento_protos::function_types::Function> for Function {
             latest_version,
             concurrency_limit,
             last_updated_at,
+        }
+    }
+}
+
+/// Per-function configuration for delivering this function's metrics to your own
+/// CloudWatch account.
+///
+/// Set this on a [`PutFunctionRequest`](crate::functions::PutFunctionRequest) or
+/// [`PutFunctionConfigRequest`](crate::functions::PutFunctionConfigRequest) to configure metrics
+/// for just this function, taking precedence over your account-wide default. When read back from a
+/// [`Function`], `None` (an absent configuration) means the function follows your account-wide
+/// default.
+///
+/// Reach out to us at support@momentohq.com to get set up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FunctionMetricsConfig {
+    /// Do not deliver this function's metrics to your CloudWatch account.
+    Disabled,
+    /// Deliver this function's metrics to your CloudWatch account.
+    Enabled {
+        /// The IAM role Momento should assume to publish metrics into your account.
+        customer_iam_role: String,
+    },
+}
+
+impl FunctionMetricsConfig {
+    /// Enable metrics delivery, assuming the given IAM role to publish into your account.
+    pub fn enabled(customer_iam_role: impl Into<String>) -> Self {
+        FunctionMetricsConfig::Enabled {
+            customer_iam_role: customer_iam_role.into(),
+        }
+    }
+}
+
+impl From<FunctionMetricsConfig> for momento_protos::function_types::FunctionMetricsConfig {
+    fn from(value: FunctionMetricsConfig) -> Self {
+        use momento_protos::function_types::function_metrics_config::{Disabled, Enabled, Kind};
+        let kind = match value {
+            FunctionMetricsConfig::Disabled => Kind::Disabled(Disabled {}),
+            FunctionMetricsConfig::Enabled { customer_iam_role } => {
+                Kind::Enabled(Enabled { customer_iam_role })
+            }
+        };
+        Self { kind: Some(kind) }
+    }
+}
+
+/// Convert a wire-level metrics config into the SDK representation. Returns `None` when the
+/// config carries no configuration (an absent inner `kind`), meaning the function follows the
+/// account-wide default. A free function rather than a `From` impl because the orphan rule
+/// forbids implementing `From<_> for Option<_>` on a foreign source type.
+pub(crate) fn metrics_config_from_proto(
+    proto: momento_protos::function_types::FunctionMetricsConfig,
+) -> Option<FunctionMetricsConfig> {
+    use momento_protos::function_types::function_metrics_config::Kind;
+    match proto.kind {
+        Some(Kind::Disabled(_)) => Some(FunctionMetricsConfig::Disabled),
+        Some(Kind::Enabled(enabled)) => Some(FunctionMetricsConfig::Enabled {
+            customer_iam_role: enabled.customer_iam_role,
+        }),
+        None => None,
+    }
+}
+
+/// A change to a function's per-function metrics-delivery configuration, supplied to
+/// [`PutFunctionRequest`](crate::functions::PutFunctionRequest) or
+/// [`PutFunctionConfigRequest`](crate::functions::PutFunctionConfigRequest).
+///
+/// Setting a [`FunctionMetricsConfig`] (via the `From` conversion) configures metrics for just
+/// this function, taking precedence over your account-wide default;
+/// [`Remove`](FunctionMetricsConfigChange::Remove) clears any existing configuration so the
+/// function follows your account-wide default again.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FunctionMetricsConfigChange {
+    /// Remove any per-function configuration so the function follows your account-wide default.
+    Remove,
+    /// Set an explicit per-function configuration (enabled or disabled).
+    Set(FunctionMetricsConfig),
+}
+
+impl From<FunctionMetricsConfig> for FunctionMetricsConfigChange {
+    fn from(config: FunctionMetricsConfig) -> Self {
+        FunctionMetricsConfigChange::Set(config)
+    }
+}
+
+impl From<FunctionMetricsConfigChange>
+    for momento_protos::function_types::FunctionMetricsConfigChange
+{
+    fn from(value: FunctionMetricsConfigChange) -> Self {
+        use momento_protos::function_types::function_metrics_config_change::{
+            Change, RemoveOverride,
+        };
+        let change = match value {
+            FunctionMetricsConfigChange::Remove => Change::RemoveOverride(RemoveOverride {}),
+            FunctionMetricsConfigChange::Set(config) => Change::MetricsConfig(config.into()),
+        };
+        Self {
+            change: Some(change),
         }
     }
 }

--- a/src/functions/messages/put_function.rs
+++ b/src/functions/messages/put_function.rs
@@ -1,7 +1,10 @@
 use std::{collections::HashMap, iter::FromIterator, time::Duration};
 
 use crate::{
-    functions::{EnvironmentValue, Function, FunctionClient, MomentoRequest, WasmSource},
+    functions::{
+        EnvironmentValue, Function, FunctionClient, FunctionMetricsConfigChange, MomentoRequest,
+        WasmSource,
+    },
     utils::prep_request_with_timeout,
     MomentoError, MomentoResult,
 };
@@ -34,6 +37,7 @@ pub struct PutFunctionRequest {
     description: String,
     environment: HashMap<String, EnvironmentValue>,
     wasm_source: WasmSource,
+    metrics_config: Option<FunctionMetricsConfigChange>,
 }
 
 impl PutFunctionRequest {
@@ -49,6 +53,7 @@ impl PutFunctionRequest {
             description: String::new(),
             environment: HashMap::new(),
             wasm_source: wasm_source.into(),
+            metrics_config: None,
         }
     }
 
@@ -88,6 +93,33 @@ impl PutFunctionRequest {
             .insert(key.into().unwrap_or_default().into(), value.into());
         self
     }
+
+    /// Change delivery of this function's metrics to your own CloudWatch account.
+    ///
+    /// Pass a [`FunctionMetricsConfig`](crate::functions::FunctionMetricsConfig) to configure
+    /// metrics for just this function, taking precedence over your account-wide default, or
+    /// [`FunctionMetricsConfigChange::Remove`](crate::functions::FunctionMetricsConfigChange::Remove)
+    /// to clear an existing configuration so the function follows your account-wide default. Omit it
+    /// to leave the account-wide default in place.
+    /// ```rust
+    /// # use momento::functions::{FunctionMetricsConfig, FunctionMetricsConfigChange, PutFunctionRequest};
+    /// # fn example(request: PutFunctionRequest) {
+    /// // Set the configuration for this function:
+    /// let request = request
+    ///     .metrics_config(FunctionMetricsConfig::enabled("arn:aws:iam::123456789012:role/my-momento-metrics-role"));
+    /// # }
+    /// # fn remove_example(request: PutFunctionRequest) {
+    /// // Or remove any configuration so the function follows your account-wide default:
+    /// let request = request.metrics_config(FunctionMetricsConfigChange::Remove);
+    /// # }
+    /// ```
+    pub fn metrics_config(
+        mut self,
+        metrics_config: impl Into<FunctionMetricsConfigChange>,
+    ) -> Self {
+        self.metrics_config = Some(metrics_config.into());
+        self
+    }
 }
 
 impl MomentoRequest for PutFunctionRequest {
@@ -106,6 +138,7 @@ impl MomentoRequest for PutFunctionRequest {
                     .into_iter()
                     .map(|(k, v)| (k, v.into()))
                     .collect(),
+                metrics_config: self.metrics_config.map(Into::into),
                 wasm_location: Some(self.wasm_source.into()),
             },
         )?;

--- a/src/functions/messages/put_function_config.rs
+++ b/src/functions/messages/put_function_config.rs
@@ -1,7 +1,10 @@
 use std::time::Duration;
 
 use crate::{
-    functions::{CurrentFunctionVersion, Function, FunctionClient, MomentoRequest},
+    functions::{
+        CurrentFunctionVersion, Function, FunctionClient, FunctionMetricsConfigChange,
+        MomentoRequest,
+    },
     utils::prep_request_with_timeout,
     MomentoError, MomentoResult,
 };
@@ -40,6 +43,7 @@ pub struct PutFunctionConfigRequest {
     cache_name: String,
     function_specifier: FunctionSpecifier,
     new_version: Option<CurrentFunctionVersion>,
+    metrics_config: Option<FunctionMetricsConfigChange>,
 }
 
 impl PutFunctionConfigRequest {
@@ -56,6 +60,7 @@ impl PutFunctionConfigRequest {
                 name: function_name.into(),
             }),
             new_version: None,
+            metrics_config: None,
         }
     }
 
@@ -66,12 +71,41 @@ impl PutFunctionConfigRequest {
             cache_name: cache_name.clone(),
             function_specifier: FunctionSpecifier::FunctionId(function_id.into()),
             new_version: None,
+            metrics_config: None,
         }
     }
 
     /// Choose the version to use upon invocation
     pub fn current_version(mut self, current_version: impl Into<CurrentFunctionVersion>) -> Self {
         self.new_version = Some(current_version.into());
+        self
+    }
+
+    /// Change delivery of this function's metrics to your own CloudWatch account, without
+    /// re-uploading the wasm.
+    ///
+    /// Pass a [`FunctionMetricsConfig`](crate::functions::FunctionMetricsConfig) to configure
+    /// metrics for just this function, taking precedence over your account-wide default, or
+    /// [`FunctionMetricsConfigChange::Remove`](crate::functions::FunctionMetricsConfigChange::Remove)
+    /// to clear an existing configuration so the function follows your account-wide default. Omit it
+    /// to leave the function's current setting unchanged.
+    /// ```rust
+    /// # use momento::functions::{FunctionMetricsConfig, FunctionMetricsConfigChange, PutFunctionConfigRequest};
+    /// # fn example(request: PutFunctionConfigRequest) {
+    /// // Set the configuration for this function:
+    /// let request = request
+    ///     .metrics_config(FunctionMetricsConfig::enabled("arn:aws:iam::123456789012:role/my-momento-metrics-role"));
+    /// # }
+    /// # fn remove_example(request: PutFunctionConfigRequest) {
+    /// // Or remove any configuration so the function follows your account-wide default:
+    /// let request = request.metrics_config(FunctionMetricsConfigChange::Remove);
+    /// # }
+    /// ```
+    pub fn metrics_config(
+        mut self,
+        metrics_config: impl Into<FunctionMetricsConfigChange>,
+    ) -> Self {
+        self.metrics_config = Some(metrics_config.into());
         self
     }
 }
@@ -88,6 +122,7 @@ impl MomentoRequest for PutFunctionConfigRequest {
                 new_version: self
                     .new_version
                     .map(momento_protos::function_types::CurrentFunctionVersion::from),
+                metrics_config: self.metrics_config.map(Into::into),
             },
         )?;
 

--- a/src/functions/mod.rs
+++ b/src/functions/mod.rs
@@ -6,8 +6,9 @@ mod function_client_builder;
 mod messages;
 
 pub use function::{
-    CurrentFunctionVersion, EnvironmentValue, Function, FunctionVersion, FunctionVersionId, Wasm,
-    WasmSource, WasmVersionId,
+    CurrentFunctionVersion, EnvironmentValue, Function, FunctionMetricsConfig,
+    FunctionMetricsConfigChange, FunctionVersion, FunctionVersionId, Wasm, WasmSource,
+    WasmVersionId,
 };
 pub use function_client::FunctionClient;
 pub use function_client_builder::FunctionClientBuilder;


### PR DESCRIPTION
Pulls in the latest client-protos, allowing callers to
set a function metrics config if they would like CloudWatch metrics
for their function(s) published to their AWS account.
