### PR TITLE
feat: add protosocket delete method

### DIFF
--- a/src/cache/messages/data/scalar/delete.rs
+++ b/src/cache/messages/data/scalar/delete.rs
@@ -32,8 +32,8 @@ use crate::{
 /// # }
 /// ```
 pub struct DeleteRequest<K: IntoBytes> {
-    cache_name: String,
-    key: K,
+    pub(crate) cache_name: String,
+    pub(crate) key: K,
 }
 
 impl<K: IntoBytes> DeleteRequest<K> {

--- a/src/protosocket/cache/cache_client.rs
+++ b/src/protosocket/cache/cache_client.rs
@@ -1,7 +1,7 @@
 use momento_protos::protosocket::cache::{CacheCommand, CacheResponse};
 use protosocket_rpc::client::{ConnectionPool, RpcClient};
 
-use crate::cache::{GetRequest, SetRequest};
+use crate::cache::{DeleteRequest, GetRequest, SetRequest};
 use crate::protosocket::cache::cache_client_builder::NeedsDefaultTtl;
 use crate::protosocket::cache::connection_manager::ProtosocketConnectionManager;
 use crate::protosocket::cache::{Configuration, MomentoProtosocketRequest};
@@ -178,6 +178,45 @@ impl ProtosocketCacheClient {
         value: impl IntoBytes,
     ) -> MomentoResult<crate::cache::SetResponse> {
         let request = SetRequest::new(cache_name, key, value);
+        request.send(self, self.request_timeout).await
+    }
+
+    /// Deletes an item in a Momento Cache
+    ///
+    /// # Arguments
+    ///
+    /// * `cache_name` - name of cache
+    /// * `key` - key of the item to delete
+    ///
+    /// # Examples
+    /// Assumes that a ProtosocketCacheClient named `cache_client` has been created and is available.
+    /// ```no_run
+    /// # fn main() -> anyhow::Result<()> {
+    /// # use momento_test_util::create_doctest_protosocket_cache_client;
+    /// # tokio_test::block_on(async {
+    /// # let (cache_client, cache_name) = create_doctest_protosocket_cache_client().await;
+    /// use momento::cache::DeleteResponse;
+    /// use momento::MomentoErrorCode;
+    ///
+    /// match cache_client.delete(&cache_name, "key").await {
+    ///     Ok(_) => println!("DeleteResponse successful"),
+    ///     Err(e) => if let MomentoErrorCode::CacheNotFoundError = e.error_code {
+    ///         println!("Cache not found: {}", &cache_name);
+    ///     } else {
+    ///         eprintln!("Error deleting value in cache {}: {}", &cache_name, e);
+    ///     }
+    /// }
+    /// # Ok(())
+    /// # })
+    /// # }
+    /// ```
+    /// You can also use the [send_request](ProtosocketCacheClient::send_request) method to delete an item using a [DeleteRequest].
+    pub async fn delete(
+        &self,
+        cache_name: impl Into<String>,
+        key: impl IntoBytes,
+    ) -> MomentoResult<crate::cache::DeleteResponse> {
+        let request = DeleteRequest::new(cache_name, key);
         request.send(self, self.request_timeout).await
     }
 

--- a/src/protosocket/cache/messages/scalar/delete.rs
+++ b/src/protosocket/cache/messages/scalar/delete.rs
@@ -1,0 +1,50 @@
+use std::time::Duration;
+
+use crate::cache::DeleteRequest;
+use crate::protosocket::cache::MomentoProtosocketRequest;
+use crate::{utils, IntoBytes, MomentoError, MomentoResult, ProtosocketCacheClient};
+use momento_protos::protosocket::cache::cache_command::RpcKind;
+use momento_protos::protosocket::cache::cache_response::Kind;
+use momento_protos::protosocket::cache::unary::Command;
+use momento_protos::protosocket::cache::{CacheCommand, DeleteCommand, DeleteResponse, Unary};
+use protosocket_rpc::ProtosocketControlCode;
+
+impl<K: IntoBytes> MomentoProtosocketRequest for DeleteRequest<K> {
+    type Response = crate::cache::DeleteResponse;
+
+    async fn send(
+        self,
+        client: &ProtosocketCacheClient,
+        timeout: Duration,
+    ) -> MomentoResult<Self::Response> {
+        utils::execute_protosocket_request_with_timeout(|| self.send_delete(client), timeout).await
+    }
+}
+
+impl<K: IntoBytes> DeleteRequest<K> {
+    async fn send_delete(
+        self,
+        client: &ProtosocketCacheClient,
+    ) -> MomentoResult<crate::cache::DeleteResponse> {
+        let completion = client
+            .protosocket_connection()
+            .await?
+            .send_unary(CacheCommand {
+                message_id: client.message_id(),
+                control_code: ProtosocketControlCode::Normal as u32,
+                rpc_kind: Some(RpcKind::Unary(Unary {
+                    command: Some(Command::Delete(DeleteCommand {
+                        namespace: self.cache_name.to_string(),
+                        key: self.key.into_bytes(),
+                    })),
+                })),
+            })
+            .await?;
+        let response = completion.await?;
+        match response.kind {
+            Some(Kind::Delete(DeleteResponse {})) => Ok(crate::cache::DeleteResponse {}),
+            Some(Kind::Error(error)) => Err(MomentoError::protosocket_command_error(error)),
+            _ => Err(MomentoError::protosocket_unexpected_kind_error()),
+        }
+    }
+}

--- a/src/protosocket/cache/messages/scalar/mod.rs
+++ b/src/protosocket/cache/messages/scalar/mod.rs
@@ -1,2 +1,3 @@
+pub mod delete;
 pub mod get;
 pub mod set;


### PR DESCRIPTION
rounds out the 3 main cache APIs for the ProtosocketCacheClient