### PR TITLE
fix: connection timeout and az fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,6 +1060,7 @@ name = "momento"
 version = "0.67.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "base64",
  "base64-url",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ doc = false
 
 [dependencies]
 momento-protos = "0.133.2"
+arc-swap = "1"
 base64 = "0.22"
 bytes = "1"
 derive_more = { version = "2.0.1", features = ["full"] }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -149,34 +149,23 @@ impl MomentoError {
 
     /// Classify a failure to obtain a connection from the protosocket pool.
     ///
-    /// The `io::ErrorKind` is the only channel available for typing a connect
-    /// failure, because `protosocket_rpc::Error` is a closed enum owned by that
-    /// crate. Kinds arrive from two places: address selection failures stamped
-    /// by the connection manager, and real transport kinds propagated up from
-    /// `protosocket_rpc::client::connect`.
+    /// `io::ErrorKind` is the only channel for typing a connect failure, since
+    /// `protosocket_rpc::Error` is a closed enum owned by that crate.
     pub(crate) fn protosocket_connect_error(error: protosocket_rpc::Error) -> Self {
         let error_code = match &error {
             protosocket_rpc::Error::IoFailure(io_error) => match io_error.kind() {
-                // Credentials were rejected; retrying will not help.
+                // Rejected credentials aren't worth retrying.
                 std::io::ErrorKind::PermissionDenied => MomentoErrorCode::AuthenticationError,
-                // Misconfiguration, such as an unparseable hostname. Also not
-                // worth retrying.
+                // Misconfiguration (e.g. an unparseable hostname) isn't worth retrying either.
                 std::io::ErrorKind::InvalidInput => MomentoErrorCode::InvalidArgumentError,
-                // AddrNotAvailable, ConnectionRefused, TimedOut, InvalidData, and
-                // every other transport-level failure: the server was not
-                // reachable or not usable. ServerUnavailable is the code callers
-                // already treat as retryable.
-                //
-                // TimedOut deliberately lands here rather than in TimeoutError.
-                // It represents a connect deadline, not a request deadline, and
-                // the right response is to retry against a different address --
-                // which ServerUnavailable gets us. TimeoutError is generally not
-                // treated as retryable, so "correcting" this mapping would
-                // quietly disable connect-time failover.
+                // Every other transport failure, including TimedOut: this is a connect
+                // deadline, not a request deadline, so it should retry against a
+                // different address like any other unreachable server. Mapping it to
+                // TimeoutError instead would quietly disable connect-time failover,
+                // since callers generally don't retry TimeoutError.
                 _ => MomentoErrorCode::ServerUnavailable,
             },
-            // A panicked connect task surfaces here rather than as an IoFailure:
-            // the connection pool maps a tokio JoinError to this variant.
+            // The connection pool maps a panicked connect task's JoinError here.
             protosocket_rpc::Error::ConnectionIsClosed => MomentoErrorCode::ServerUnavailable,
             protosocket_rpc::Error::CancelledRemotely => MomentoErrorCode::CancelledError,
             protosocket_rpc::Error::Finished => MomentoErrorCode::UnknownError,
@@ -550,11 +539,8 @@ mod tests {
 
     #[test]
     fn a_connect_timeout_is_server_unavailable_not_a_request_timeout() {
-        // This mapping looks wrong at a glance and is load-bearing. A connect
-        // deadline should send callers at a different address, and callers
-        // generally treat ServerUnavailable as retryable but TimeoutError as
-        // terminal. Flipping this to TimeoutError silently disables connect-time
-        // failover.
+        // Looks wrong at a glance, but is load-bearing: flipping this to
+        // TimeoutError would silently disable connect-time failover.
         let error = MomentoError::protosocket_connect_error(io_failure(ErrorKind::TimedOut));
         assert_eq!(error.error_code, MomentoErrorCode::ServerUnavailable);
         assert_ne!(error.error_code, MomentoErrorCode::TimeoutError);
@@ -562,8 +548,7 @@ mod tests {
 
     #[test]
     fn a_panicked_connect_task_is_retryable() {
-        // ConnectionPool maps a tokio JoinError to ConnectionIsClosed, so this
-        // arrives without an io::Error behind it.
+        // No io::Error here: ConnectionPool maps a panicked task's JoinError to this.
         let error =
             MomentoError::protosocket_connect_error(protosocket_rpc::Error::ConnectionIsClosed);
         assert_eq!(error.error_code, MomentoErrorCode::ServerUnavailable);
@@ -578,9 +563,7 @@ mod tests {
 
     #[test]
     fn the_underlying_error_kind_survives() {
-        // Regression test: the kind used to be destroyed by a `format!` on the
-        // way out of the connection manager, leaving callers unable to tell a
-        // refused connection from anything else.
+        // Regression test: this used to be lost to a `format!` on the way out.
         let error =
             MomentoError::protosocket_connect_error(io_failure(ErrorKind::ConnectionRefused));
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -147,6 +147,47 @@ impl MomentoError {
         }
     }
 
+    /// Classify a failure to obtain a connection from the protosocket pool.
+    ///
+    /// The `io::ErrorKind` is the only channel available for typing a connect
+    /// failure, because `protosocket_rpc::Error` is a closed enum owned by that
+    /// crate. Kinds arrive from two places: address selection failures stamped
+    /// by the connection manager, and real transport kinds propagated up from
+    /// `protosocket_rpc::client::connect`.
+    pub(crate) fn protosocket_connect_error(error: protosocket_rpc::Error) -> Self {
+        let error_code = match &error {
+            protosocket_rpc::Error::IoFailure(io_error) => match io_error.kind() {
+                // Credentials were rejected; retrying will not help.
+                std::io::ErrorKind::PermissionDenied => MomentoErrorCode::AuthenticationError,
+                // Misconfiguration, such as an unparseable hostname. Also not
+                // worth retrying.
+                std::io::ErrorKind::InvalidInput => MomentoErrorCode::InvalidArgumentError,
+                // AddrNotAvailable, ConnectionRefused, TimedOut, InvalidData, and
+                // every other transport-level failure: the server was not
+                // reachable or not usable. ServerUnavailable is the code callers
+                // already treat as retryable.
+                //
+                // TimedOut deliberately lands here rather than in TimeoutError.
+                // It represents a connect deadline, not a request deadline, and
+                // the right response is to retry against a different address --
+                // which ServerUnavailable gets us. TimeoutError is generally not
+                // treated as retryable, so "correcting" this mapping would
+                // quietly disable connect-time failover.
+                _ => MomentoErrorCode::ServerUnavailable,
+            },
+            // A panicked connect task surfaces here rather than as an IoFailure:
+            // the connection pool maps a tokio JoinError to this variant.
+            protosocket_rpc::Error::ConnectionIsClosed => MomentoErrorCode::ServerUnavailable,
+            protosocket_rpc::Error::CancelledRemotely => MomentoErrorCode::CancelledError,
+            protosocket_rpc::Error::Finished => MomentoErrorCode::UnknownError,
+        };
+        Self {
+            message: format!("Failed to establish a connection to the cache: {error}"),
+            error_code,
+            inner_error: Some(ProtosocketCacheError::Protosocket { cause: error }.into()),
+        }
+    }
+
     /// Returns details about the internal grpc error if available
     pub fn details(&self) -> Option<MomentoGrpcErrorDetails> {
         if let Some(ErrorSource::TonicStatus(status)) = &self.inner_error {
@@ -462,6 +503,95 @@ impl From<protosocket_rpc::Error> for MomentoError {
             inner_error: Some(ErrorSource::Protosocket(
                 ProtosocketCacheError::Protosocket { cause: error },
             )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::ErrorKind;
+
+    fn io_failure(kind: ErrorKind) -> protosocket_rpc::Error {
+        protosocket_rpc::Error::IoFailure(std::io::Error::new(kind, "test").into())
+    }
+
+    #[test]
+    fn rejected_credentials_are_not_retryable() {
+        let error =
+            MomentoError::protosocket_connect_error(io_failure(ErrorKind::PermissionDenied));
+        assert_eq!(error.error_code, MomentoErrorCode::AuthenticationError);
+    }
+
+    #[test]
+    fn misconfiguration_is_not_retryable() {
+        let error = MomentoError::protosocket_connect_error(io_failure(ErrorKind::InvalidInput));
+        assert_eq!(error.error_code, MomentoErrorCode::InvalidArgumentError);
+    }
+
+    #[test]
+    fn transport_failures_are_retryable() {
+        for kind in [
+            ErrorKind::ConnectionRefused,
+            ErrorKind::AddrNotAvailable,
+            ErrorKind::HostUnreachable,
+            ErrorKind::InvalidData,
+            ErrorKind::ConnectionReset,
+        ] {
+            let error = MomentoError::protosocket_connect_error(io_failure(kind));
+            assert_eq!(
+                error.error_code,
+                MomentoErrorCode::ServerUnavailable,
+                "{:?} should be retryable",
+                kind
+            );
+        }
+    }
+
+    #[test]
+    fn a_connect_timeout_is_server_unavailable_not_a_request_timeout() {
+        // This mapping looks wrong at a glance and is load-bearing. A connect
+        // deadline should send callers at a different address, and callers
+        // generally treat ServerUnavailable as retryable but TimeoutError as
+        // terminal. Flipping this to TimeoutError silently disables connect-time
+        // failover.
+        let error = MomentoError::protosocket_connect_error(io_failure(ErrorKind::TimedOut));
+        assert_eq!(error.error_code, MomentoErrorCode::ServerUnavailable);
+        assert_ne!(error.error_code, MomentoErrorCode::TimeoutError);
+    }
+
+    #[test]
+    fn a_panicked_connect_task_is_retryable() {
+        // ConnectionPool maps a tokio JoinError to ConnectionIsClosed, so this
+        // arrives without an io::Error behind it.
+        let error =
+            MomentoError::protosocket_connect_error(protosocket_rpc::Error::ConnectionIsClosed);
+        assert_eq!(error.error_code, MomentoErrorCode::ServerUnavailable);
+    }
+
+    #[test]
+    fn remote_cancellation_maps_to_cancelled() {
+        let error =
+            MomentoError::protosocket_connect_error(protosocket_rpc::Error::CancelledRemotely);
+        assert_eq!(error.error_code, MomentoErrorCode::CancelledError);
+    }
+
+    #[test]
+    fn the_underlying_error_kind_survives() {
+        // Regression test: the kind used to be destroyed by a `format!` on the
+        // way out of the connection manager, leaving callers unable to tell a
+        // refused connection from anything else.
+        let error =
+            MomentoError::protosocket_connect_error(io_failure(ErrorKind::ConnectionRefused));
+
+        match error.inner_error {
+            Some(ErrorSource::Protosocket(ProtosocketCacheError::Protosocket {
+                cause: protosocket_rpc::Error::IoFailure(io_error),
+            })) => assert_eq!(io_error.kind(), ErrorKind::ConnectionRefused),
+            other => panic!(
+                "expected the original io error to be preserved, got {:?}",
+                other
+            ),
         }
     }
 }

--- a/src/protosocket/cache/address_provider.rs
+++ b/src/protosocket/cache/address_provider.rs
@@ -2,9 +2,16 @@ use std::{
     collections::HashMap,
     net::SocketAddr,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use crate::CredentialProvider;
+
+/// Bounds the TCP+TLS handshake for the `/endpoints` control-plane request.
+const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Bounds the entire `/endpoints` request, connect through response body.
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, Default)]
 pub(crate) struct Addresses {
@@ -94,6 +101,8 @@ impl AddressProvider {
         let client = reqwest::Client::builder()
             .tls_built_in_native_certs(true)
             .tls_built_in_root_certs(true)
+            .connect_timeout(HTTP_CONNECT_TIMEOUT)
+            .timeout(HTTP_REQUEST_TIMEOUT)
             .build()
             .expect("must be able to build client");
         Self {

--- a/src/protosocket/cache/address_provider.rs
+++ b/src/protosocket/cache/address_provider.rs
@@ -6,7 +6,6 @@ use std::{
 
 use crate::CredentialProvider;
 
-// Todo: should make the connections try to balance better than random
 #[derive(serde::Deserialize, serde::Serialize, Debug, Default)]
 pub(crate) struct Addresses {
     #[serde(flatten)]
@@ -14,20 +13,44 @@ pub(crate) struct Addresses {
 }
 
 impl Addresses {
-    /// Get a list of socket addresses, optionally filtered by availability zone ID.
-    /// If an az_id is provided, only addresses in that availability zone will be returned,
-    pub fn for_az(&self, az_id: Option<&str>) -> Vec<SocketAddr> {
-        if let Some(az_id) = az_id {
-            if let Some(addresses) = self.azs.get(&AzId(az_id.to_string())) {
-                if !addresses.is_empty() {
-                    return addresses.iter().map(|a| a.socket_address).collect();
-                }
-            }
-        }
+    /// Addresses published for one availability zone ID. Empty if the zone is
+    /// not in the map, which is a real signal rather than a reason to silently
+    /// widen to other zones.
+    pub fn in_az(&self, az_id: &str) -> Vec<SocketAddr> {
         self.azs
-            .values()
-            .flat_map(|addresses| addresses.iter().map(|a| a.socket_address))
-            .collect()
+            .get(&AzId(az_id.to_string()))
+            .map(|addresses| addresses.iter().map(|a| a.socket_address).collect())
+            .unwrap_or_default()
+    }
+
+    /// Every published address, across all availability zones.
+    pub fn all(&self) -> Vec<SocketAddr> {
+        self.sorted(self.azs.values().flatten())
+    }
+
+    /// Every published address outside the given availability zone. Used when
+    /// the local zone is unreachable: widening to [`all`](Self::all) would keep
+    /// offering the very addresses we are trying to escape.
+    pub fn outside_az(&self, az_id: &str) -> Vec<SocketAddr> {
+        let local = AzId(az_id.to_string());
+        self.sorted(
+            self.azs
+                .iter()
+                .filter(|(zone, _)| **zone != local)
+                .flat_map(|(_, addresses)| addresses),
+        )
+    }
+
+    /// Collect addresses in a stable order.
+    ///
+    /// The zones live in a `HashMap`, whose iteration order varies run to run
+    /// and even call to call. Round-robin selection indexes into this list, so
+    /// without a defined order successive connections would not reliably land
+    /// on different addresses.
+    fn sorted<'a>(&self, addresses: impl Iterator<Item = &'a Address>) -> Vec<SocketAddr> {
+        let mut addresses: Vec<SocketAddr> = addresses.map(|a| a.socket_address).collect();
+        addresses.sort_unstable();
+        addresses
     }
 }
 
@@ -144,5 +167,107 @@ impl AddressProvider {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn address(last_octet: u8) -> SocketAddr {
+        SocketAddr::from(([10, 0, 0, last_octet], 9004))
+    }
+
+    /// Two zones: usw2-az1 holds .1 and .2, usw2-az2 holds .3.
+    fn addresses() -> Addresses {
+        Addresses {
+            azs: HashMap::from([
+                (
+                    AzId("usw2-az1".to_string()),
+                    vec![
+                        Address {
+                            socket_address: address(1),
+                        },
+                        Address {
+                            socket_address: address(2),
+                        },
+                    ],
+                ),
+                (
+                    AzId("usw2-az2".to_string()),
+                    vec![Address {
+                        socket_address: address(3),
+                    }],
+                ),
+            ]),
+        }
+    }
+
+    #[test]
+    fn in_az_returns_only_that_zone() {
+        assert_eq!(addresses().in_az("usw2-az1"), vec![address(1), address(2)]);
+        assert_eq!(addresses().in_az("usw2-az2"), vec![address(3)]);
+    }
+
+    #[test]
+    fn in_az_is_empty_for_an_unknown_zone() {
+        // An AZ *name* rather than an AZ ID lands here, as does a zone with no
+        // cache hosts. Notably it does not silently widen.
+        assert!(addresses().in_az("us-west-2a").is_empty());
+        assert!(addresses().in_az("usw2-az9").is_empty());
+    }
+
+    #[test]
+    fn all_returns_every_zone() {
+        assert_eq!(addresses().all(), vec![address(1), address(2), address(3)]);
+    }
+
+    #[test]
+    fn outside_az_excludes_the_local_zone() {
+        assert_eq!(addresses().outside_az("usw2-az1"), vec![address(3)]);
+        assert_eq!(
+            addresses().outside_az("usw2-az2"),
+            vec![address(1), address(2)]
+        );
+    }
+
+    #[test]
+    fn outside_az_is_empty_when_there_is_nowhere_else_to_go() {
+        let single_zone = Addresses {
+            azs: HashMap::from([(
+                AzId("usw2-az1".to_string()),
+                vec![Address {
+                    socket_address: address(1),
+                }],
+            )]),
+        };
+        assert!(single_zone.outside_az("usw2-az1").is_empty());
+    }
+
+    #[test]
+    fn outside_az_returns_everything_for_an_unknown_zone() {
+        assert_eq!(
+            addresses().outside_az("usw2-az9"),
+            vec![address(1), address(2), address(3)]
+        );
+    }
+
+    #[test]
+    fn ordering_is_stable_across_calls() {
+        // Round-robin indexes into these lists, so a HashMap's varying iteration
+        // order would otherwise stop successive connects from rotating.
+        let addresses = addresses();
+        let first = addresses.all();
+        for _ in 0..20 {
+            assert_eq!(addresses.all(), first);
+        }
+    }
+
+    #[test]
+    fn empty_map_yields_nothing() {
+        let empty = Addresses::default();
+        assert!(empty.all().is_empty());
+        assert!(empty.in_az("usw2-az1").is_empty());
+        assert!(empty.outside_az("usw2-az1").is_empty());
     }
 }

--- a/src/protosocket/cache/address_provider.rs
+++ b/src/protosocket/cache/address_provider.rs
@@ -20,9 +20,8 @@ pub(crate) struct Addresses {
 }
 
 impl Addresses {
-    /// Addresses published for one availability zone ID. Empty if the zone is
-    /// not in the map, which is a real signal rather than a reason to silently
-    /// widen to other zones.
+    /// Addresses published for one availability zone ID. Empty if the zone
+    /// isn't in the map -- that's a real signal, not a reason to widen.
     pub fn in_az(&self, az_id: &str) -> Vec<SocketAddr> {
         self.azs
             .get(&AzId(az_id.to_string()))
@@ -35,9 +34,8 @@ impl Addresses {
         self.sorted(self.azs.values().flatten())
     }
 
-    /// Every published address outside the given availability zone. Used when
-    /// the local zone is unreachable: widening to [`all`](Self::all) would keep
-    /// offering the very addresses we are trying to escape.
+    /// Every published address outside the given zone. Unlike [`all`](Self::all),
+    /// doesn't keep offering the addresses we're trying to escape.
     pub fn outside_az(&self, az_id: &str) -> Vec<SocketAddr> {
         let local = AzId(az_id.to_string());
         self.sorted(
@@ -48,12 +46,9 @@ impl Addresses {
         )
     }
 
-    /// Collect addresses in a stable order.
-    ///
-    /// The zones live in a `HashMap`, whose iteration order varies run to run
-    /// and even call to call. Round-robin selection indexes into this list, so
-    /// without a defined order successive connections would not reliably land
-    /// on different addresses.
+    /// Collect addresses in a stable order. `HashMap` iteration order varies
+    /// call to call, and round-robin selection indexes into this list, so an
+    /// undefined order would stop successive connects from rotating.
     fn sorted<'a>(&self, addresses: impl Iterator<Item = &'a Address>) -> Vec<SocketAddr> {
         let mut addresses: Vec<SocketAddr> = addresses.map(|a| a.socket_address).collect();
         addresses.sort_unstable();
@@ -220,8 +215,7 @@ mod tests {
 
     #[test]
     fn in_az_is_empty_for_an_unknown_zone() {
-        // An AZ *name* rather than an AZ ID lands here, as does a zone with no
-        // cache hosts. Notably it does not silently widen.
+        // Covers an AZ *name* passed where an ID belongs, among other cases.
         assert!(addresses().in_az("us-west-2a").is_empty());
         assert!(addresses().in_az("usw2-az9").is_empty());
     }
@@ -263,8 +257,6 @@ mod tests {
 
     #[test]
     fn ordering_is_stable_across_calls() {
-        // Round-robin indexes into these lists, so a HashMap's varying iteration
-        // order would otherwise stop successive connects from rotating.
         let addresses = addresses();
         let first = addresses.all();
         for _ in 0..20 {

--- a/src/protosocket/cache/az_circuit.rs
+++ b/src/protosocket/cache/az_circuit.rs
@@ -1,0 +1,189 @@
+use rand::Rng;
+use std::{
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+
+/// How long the local availability zone is skipped after its first connect failure.
+const BASE_WIDEN_MS: u64 = 500;
+
+/// The ceiling on that window.
+const MAX_WIDEN_MS: u64 = 5_000;
+
+/// Tracks whether the local availability zone is currently reachable, so that
+/// [`AzAffinity::Preferred`](super::config::configuration::AzAffinity) can fall
+/// back to other zones instead of staying pinned to a zone it cannot reach.
+///
+/// This deliberately does *not* track health per address. The `/endpoints` API
+/// publishes healthy hosts, so per-host health is the control plane's job and
+/// duplicating it client-side would be both redundant and less informed. What
+/// the control plane cannot see is a fault visible only from this client's
+/// vantage point -- a degraded cross-zone link, or egress broken for one zone --
+/// where the published hosts really are healthy and we still cannot reach them.
+/// That is the one thing this covers.
+#[derive(Debug)]
+pub(crate) struct AzCircuit {
+    state: Mutex<State>,
+    base: Duration,
+    cap: Duration,
+}
+
+#[derive(Debug, Default)]
+struct State {
+    /// When set and still in the future, skip the local zone.
+    widen_until: Option<Instant>,
+    consecutive_failures: u32,
+}
+
+impl Default for AzCircuit {
+    fn default() -> Self {
+        Self::new(
+            Duration::from_millis(BASE_WIDEN_MS),
+            Duration::from_millis(MAX_WIDEN_MS),
+        )
+    }
+}
+
+impl AzCircuit {
+    fn new(base: Duration, cap: Duration) -> Self {
+        Self {
+            state: Mutex::new(State::default()),
+            base,
+            cap,
+        }
+    }
+
+    /// Whether the local availability zone should be skipped right now.
+    #[allow(clippy::expect_used)]
+    pub fn should_widen(&self) -> bool {
+        let state = self.state.lock().expect("local mutex must not be poisoned");
+        state
+            .widen_until
+            .is_some_and(|deadline| deadline > Instant::now())
+    }
+
+    /// Record a failed connection attempt against an address in the local zone,
+    /// opening (or extending) the window during which the zone is skipped.
+    #[allow(clippy::expect_used)]
+    pub fn record_local_failure(&self) {
+        let mut state = self.state.lock().expect("local mutex must not be poisoned");
+        state.consecutive_failures = state.consecutive_failures.saturating_add(1);
+        let window = self.widen_window(state.consecutive_failures);
+        state.widen_until = Some(Instant::now() + window);
+        log::warn!(
+            "local availability zone connect failure #{}, preferring other zones for {:?}",
+            state.consecutive_failures,
+            window,
+        );
+    }
+
+    /// Record a successful connection against an address in the local zone,
+    /// closing the circuit and resetting the backoff.
+    #[allow(clippy::expect_used)]
+    pub fn record_local_success(&self) {
+        let mut state = self.state.lock().expect("local mutex must not be poisoned");
+        if state.widen_until.is_some() {
+            log::info!("local availability zone is reachable again");
+        }
+        state.widen_until = None;
+        state.consecutive_failures = 0;
+    }
+
+    /// Exponential growth with jitter over the lower half of the window, so
+    /// that connections which failed together do not probe the local zone in
+    /// lockstep.
+    fn widen_window(&self, consecutive_failures: u32) -> Duration {
+        let shift = consecutive_failures.saturating_sub(1).min(16);
+        let ceiling = ((self.base.as_millis() as u64) << shift).min(self.cap.as_millis() as u64);
+        Duration::from_millis(rand::rng().random_range(ceiling / 2..=ceiling))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Windows short enough to wait out in a test.
+    fn test_circuit() -> AzCircuit {
+        AzCircuit::new(Duration::from_millis(40), Duration::from_millis(120))
+    }
+
+    #[test]
+    fn a_fresh_circuit_prefers_the_local_zone() {
+        assert!(!test_circuit().should_widen());
+    }
+
+    #[test]
+    fn a_local_failure_widens_then_expires() {
+        let circuit = test_circuit();
+
+        circuit.record_local_failure();
+        assert!(circuit.should_widen());
+
+        // The first window is 20-40ms.
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(!circuit.should_widen());
+    }
+
+    #[test]
+    fn success_closes_the_circuit_immediately() {
+        let circuit = test_circuit();
+
+        circuit.record_local_failure();
+        assert!(circuit.should_widen());
+
+        circuit.record_local_success();
+        assert!(!circuit.should_widen());
+    }
+
+    #[test]
+    fn success_resets_the_backoff_ladder() {
+        let circuit = test_circuit();
+
+        for _ in 0..10 {
+            circuit.record_local_failure();
+        }
+        circuit.record_local_success();
+        circuit.record_local_failure();
+
+        let state = circuit.state.lock().expect("not poisoned");
+        assert_eq!(state.consecutive_failures, 1);
+    }
+
+    #[test]
+    fn the_window_is_capped_and_never_zero() {
+        let circuit = test_circuit();
+        // Including values that would overflow an unclamped shift.
+        for failures in [1, 2, 5, 10, 32, 64, u32::MAX] {
+            let window = circuit.widen_window(failures);
+            assert!(
+                window <= Duration::from_millis(120),
+                "{} failures produced {:?}, above the cap",
+                failures,
+                window
+            );
+            assert!(
+                window >= Duration::from_millis(20),
+                "{} failures produced {:?}, below the floor",
+                failures,
+                window
+            );
+        }
+    }
+
+    #[test]
+    fn the_window_grows_with_consecutive_failures() {
+        // Jitter covers the lower half of each window, so compare the ceilings:
+        // one failure tops out at 40ms, four at 120ms (the cap).
+        let circuit = test_circuit();
+        assert!(circuit.widen_window(1) <= Duration::from_millis(40));
+        assert!(circuit.widen_window(4) > Duration::from_millis(40));
+    }
+
+    #[test]
+    fn production_defaults_are_sane() {
+        let circuit = AzCircuit::default();
+        assert!(circuit.widen_window(1) <= Duration::from_millis(BASE_WIDEN_MS));
+        assert!(circuit.widen_window(u32::MAX) <= Duration::from_millis(MAX_WIDEN_MS));
+    }
+}

--- a/src/protosocket/cache/az_circuit.rs
+++ b/src/protosocket/cache/az_circuit.rs
@@ -4,23 +4,20 @@ use std::{
     time::{Duration, Instant},
 };
 
-/// How long the local availability zone is skipped after its first connect failure.
+/// How long the local zone is skipped after its first connect failure.
 const BASE_WIDEN_MS: u64 = 500;
 
-/// The ceiling on that window.
+/// Ceiling on that window.
 const MAX_WIDEN_MS: u64 = 5_000;
 
-/// Tracks whether the local availability zone is currently reachable, so that
-/// [`AzAffinity::Preferred`](super::config::configuration::AzAffinity) can fall
-/// back to other zones instead of staying pinned to a zone it cannot reach.
+/// Tracks whether the local availability zone is currently reachable, so
+/// `az_id` preference can fall back to other zones instead of staying pinned
+/// to one it can't reach.
 ///
-/// This deliberately does *not* track health per address. The `/endpoints` API
-/// publishes healthy hosts, so per-host health is the control plane's job and
-/// duplicating it client-side would be both redundant and less informed. What
-/// the control plane cannot see is a fault visible only from this client's
-/// vantage point -- a degraded cross-zone link, or egress broken for one zone --
-/// where the published hosts really are healthy and we still cannot reach them.
-/// That is the one thing this covers.
+/// Deliberately doesn't track per-address health -- the `/endpoints` API
+/// already publishes healthy hosts, so that's the control plane's job. What it
+/// can't see is a fault visible only from this client (a degraded cross-zone
+/// link, broken egress for one zone), which is what this covers.
 #[derive(Debug)]
 pub(crate) struct AzCircuit {
     state: Mutex<State>,
@@ -62,8 +59,7 @@ impl AzCircuit {
             .is_some_and(|deadline| deadline > Instant::now())
     }
 
-    /// Record a failed connection attempt against an address in the local zone,
-    /// opening (or extending) the window during which the zone is skipped.
+    /// Record a local-zone connect failure, opening or extending the skip window.
     #[allow(clippy::expect_used)]
     pub fn record_local_failure(&self) {
         let mut state = self.state.lock().expect("local mutex must not be poisoned");
@@ -77,8 +73,7 @@ impl AzCircuit {
         );
     }
 
-    /// Record a successful connection against an address in the local zone,
-    /// closing the circuit and resetting the backoff.
+    /// Record a local-zone connect success, closing the circuit.
     #[allow(clippy::expect_used)]
     pub fn record_local_success(&self) {
         let mut state = self.state.lock().expect("local mutex must not be poisoned");
@@ -89,9 +84,8 @@ impl AzCircuit {
         state.consecutive_failures = 0;
     }
 
-    /// Exponential growth with jitter over the lower half of the window, so
-    /// that connections which failed together do not probe the local zone in
-    /// lockstep.
+    /// Exponential growth, jittered so connections that failed together don't
+    /// re-probe the local zone in lockstep.
     fn widen_window(&self, consecutive_failures: u32) -> Duration {
         let shift = consecutive_failures.saturating_sub(1).min(16);
         let ceiling = ((self.base.as_millis() as u64) << shift).min(self.cap.as_millis() as u64);

--- a/src/protosocket/cache/az_circuit.rs
+++ b/src/protosocket/cache/az_circuit.rs
@@ -1,6 +1,6 @@
 use rand::Rng;
 use std::{
-    sync::Mutex,
+    sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
     time::{Duration, Instant},
 };
 
@@ -9,6 +9,9 @@ const BASE_WIDEN_MS: u64 = 500;
 
 /// Ceiling on that window.
 const MAX_WIDEN_MS: u64 = 5_000;
+
+/// Sentinel for "not currently widening", stored in `widen_until_millis`.
+const NOT_WIDENING: u64 = u64::MAX;
 
 /// Tracks whether the local availability zone is currently reachable, so
 /// `az_id` preference can fall back to other zones instead of staying pinned
@@ -20,16 +23,17 @@ const MAX_WIDEN_MS: u64 = 5_000;
 /// link, broken egress for one zone), which is what this covers.
 #[derive(Debug)]
 pub(crate) struct AzCircuit {
-    state: Mutex<State>,
+    /// Fixed reference point; `widen_until_millis` is stored as an offset from
+    /// this, since `Instant` itself can't live in an atomic.
+    epoch: Instant,
+    widen_until_millis: AtomicU64,
+    consecutive_failures: AtomicU32,
+    /// Set by a failure, cleared only by a confirmed full recovery (not by an
+    /// ordinary connect landing back on the local zone) -- see
+    /// [`Self::acknowledge_recovery`].
+    recovery_needed: AtomicBool,
     base: Duration,
     cap: Duration,
-}
-
-#[derive(Debug, Default)]
-struct State {
-    /// When set and still in the future, skip the local zone.
-    widen_until: Option<Instant>,
-    consecutive_failures: u32,
 }
 
 impl Default for AzCircuit {
@@ -44,44 +48,69 @@ impl Default for AzCircuit {
 impl AzCircuit {
     fn new(base: Duration, cap: Duration) -> Self {
         Self {
-            state: Mutex::new(State::default()),
+            epoch: Instant::now(),
+            widen_until_millis: AtomicU64::new(NOT_WIDENING),
+            consecutive_failures: AtomicU32::new(0),
+            recovery_needed: AtomicBool::new(false),
             base,
             cap,
         }
     }
 
     /// Whether the local availability zone should be skipped right now.
-    #[allow(clippy::expect_used)]
     pub fn should_widen(&self) -> bool {
-        let state = self.state.lock().expect("local mutex must not be poisoned");
-        state
-            .widen_until
-            .is_some_and(|deadline| deadline > Instant::now())
+        let widen_until = self.widen_until_millis.load(Ordering::Relaxed);
+        widen_until != NOT_WIDENING && widen_until > self.millis_since_epoch()
+    }
+
+    /// Whether a recovery sweep is outstanding -- there has been a local
+    /// failure since the last confirmed full recovery. Unlike
+    /// [`Self::should_widen`], this does not decay on its own; only
+    /// [`Self::acknowledge_recovery`] clears it.
+    pub fn recovery_needed(&self) -> bool {
+        self.recovery_needed.load(Ordering::Relaxed)
     }
 
     /// Record a local-zone connect failure, opening or extending the skip window.
-    #[allow(clippy::expect_used)]
     pub fn record_local_failure(&self) {
-        let mut state = self.state.lock().expect("local mutex must not be poisoned");
-        state.consecutive_failures = state.consecutive_failures.saturating_add(1);
-        let window = self.widen_window(state.consecutive_failures);
-        state.widen_until = Some(Instant::now() + window);
+        let failures = self.consecutive_failures.fetch_add(1, Ordering::Relaxed) + 1;
+        let window = self.widen_window(failures);
+        let deadline = self
+            .millis_since_epoch()
+            .saturating_add(window.as_millis() as u64);
+        self.widen_until_millis.store(deadline, Ordering::Relaxed);
+        self.recovery_needed.store(true, Ordering::Relaxed);
         log::warn!(
-            "local availability zone connect failure #{}, preferring other zones for {:?}",
-            state.consecutive_failures,
-            window,
+            "local availability zone connect failure #{failures}, preferring other zones for {window:?}",
         );
     }
 
-    /// Record a local-zone connect success, closing the circuit.
-    #[allow(clippy::expect_used)]
+    /// Record a local-zone connect success, closing the circuit. Does not by
+    /// itself clear [`Self::recovery_needed`] -- an ordinary connect landing
+    /// on the local zone only proves one pool slot is fine, not that every
+    /// slot is. Only a prober's full-pool rebuild can claim that; see
+    /// [`Self::acknowledge_recovery`].
     pub fn record_local_success(&self) {
-        let mut state = self.state.lock().expect("local mutex must not be poisoned");
-        if state.widen_until.is_some() {
+        let was_widening = self
+            .widen_until_millis
+            .swap(NOT_WIDENING, Ordering::Relaxed)
+            != NOT_WIDENING;
+        self.consecutive_failures.store(0, Ordering::Relaxed);
+        if was_widening {
             log::info!("local availability zone is reachable again");
         }
-        state.widen_until = None;
-        state.consecutive_failures = 0;
+    }
+
+    /// Record that a recovery sweep has confirmed the local zone is healthy
+    /// and rebuilt every pool slot's chance to use it. Closes the circuit and
+    /// clears [`Self::recovery_needed`].
+    pub fn acknowledge_recovery(&self) {
+        self.record_local_success();
+        self.recovery_needed.store(false, Ordering::Relaxed);
+    }
+
+    fn millis_since_epoch(&self) -> u64 {
+        self.epoch.elapsed().as_millis() as u64
     }
 
     /// Exponential growth, jittered so connections that failed together don't
@@ -108,6 +137,11 @@ mod tests {
     }
 
     #[test]
+    fn a_fresh_circuit_needs_no_recovery() {
+        assert!(!test_circuit().recovery_needed());
+    }
+
+    #[test]
     fn a_local_failure_widens_then_expires() {
         let circuit = test_circuit();
 
@@ -117,6 +151,19 @@ mod tests {
         // The first window is 20-40ms.
         std::thread::sleep(Duration::from_millis(100));
         assert!(!circuit.should_widen());
+    }
+
+    #[test]
+    fn a_local_failure_marks_recovery_needed_and_it_does_not_decay() {
+        let circuit = test_circuit();
+
+        circuit.record_local_failure();
+        assert!(circuit.recovery_needed());
+
+        // Unlike should_widen, this stays true even after the window expires.
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(!circuit.should_widen());
+        assert!(circuit.recovery_needed());
     }
 
     #[test]
@@ -131,6 +178,28 @@ mod tests {
     }
 
     #[test]
+    fn an_ordinary_success_does_not_clear_recovery_needed() {
+        let circuit = test_circuit();
+
+        circuit.record_local_failure();
+        circuit.record_local_success();
+
+        // One slot reconnecting on its own doesn't prove every slot has.
+        assert!(circuit.recovery_needed());
+    }
+
+    #[test]
+    fn only_acknowledge_recovery_clears_recovery_needed() {
+        let circuit = test_circuit();
+
+        circuit.record_local_failure();
+        circuit.acknowledge_recovery();
+
+        assert!(!circuit.recovery_needed());
+        assert!(!circuit.should_widen());
+    }
+
+    #[test]
     fn success_resets_the_backoff_ladder() {
         let circuit = test_circuit();
 
@@ -140,8 +209,7 @@ mod tests {
         circuit.record_local_success();
         circuit.record_local_failure();
 
-        let state = circuit.state.lock().expect("not poisoned");
-        assert_eq!(state.consecutive_failures, 1);
+        assert_eq!(circuit.consecutive_failures.load(Ordering::Relaxed), 1);
     }
 
     #[test]

--- a/src/protosocket/cache/cache_client.rs
+++ b/src/protosocket/cache/cache_client.rs
@@ -1,13 +1,16 @@
+use arc_swap::ArcSwap;
 use momento_protos::protosocket::cache::{CacheCommand, CacheResponse};
 use protosocket_rpc::client::{ConnectionPool, RpcClient};
 
 use crate::cache::{DeleteRequest, GetRequest, SetRequest};
 use crate::protosocket::cache::cache_client_builder::NeedsDefaultTtl;
 use crate::protosocket::cache::connection_manager::ProtosocketConnectionManager;
+use crate::protosocket::cache::recovery_prober::BackgroundRecoveryProber;
 use crate::protosocket::cache::{Configuration, MomentoProtosocketRequest};
 use crate::{utils, IntoBytes, MomentoError, MomentoResult, ProtosocketCacheClientBuilder};
 use std::convert::TryInto;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 // TODO: remove `no_run` on doc examples to allow fully running them as doctests
@@ -47,20 +50,39 @@ use std::time::Duration;
 /// ```
 #[derive(Clone, Debug)]
 pub struct ProtosocketCacheClient {
-    client_pool: std::sync::Arc<ConnectionPool<ProtosocketConnectionManager>>,
+    client_pool: Arc<ArcSwap<ConnectionPool<ProtosocketConnectionManager>>>,
+    /// `None` when no availability zone preference is configured -- there's
+    /// nothing for the prober to actively recover toward. Held so it shuts
+    /// down when the last clone of this client is dropped.
+    _recovery_prober: Option<Arc<BackgroundRecoveryProber>>,
     message_id: std::sync::Arc<AtomicU64>,
     item_default_ttl: Duration,
     request_timeout: Duration,
 }
 
 impl ProtosocketCacheClient {
+    /// `client_connector` is a separate parameter from the already-built
+    /// `client_pool` (rather than deriving the pool from it here) because the
+    /// recovery prober needs its own long-lived clone to rebuild fresh pools
+    /// with, independent of the one used to build `client_pool` itself.
     pub(crate) fn new(
         client_pool: ConnectionPool<ProtosocketConnectionManager>,
+        client_connector: ProtosocketConnectionManager,
+        connection_count: usize,
+        runtime: &tokio::runtime::Handle,
         default_ttl: Duration,
         configuration: Configuration,
     ) -> Self {
+        let client_pool = Arc::new(ArcSwap::new(Arc::new(client_pool)));
+        let recovery_prober = BackgroundRecoveryProber::spawn(
+            runtime,
+            client_connector,
+            connection_count,
+            client_pool.clone(),
+        );
         Self {
-            client_pool: std::sync::Arc::new(client_pool),
+            client_pool,
+            _recovery_prober: recovery_prober.map(Arc::new),
             message_id: std::sync::Arc::new(AtomicU64::new(0)),
             item_default_ttl: default_ttl,
             request_timeout: configuration.timeout(),
@@ -241,6 +263,7 @@ impl ProtosocketCacheClient {
     ) -> MomentoResult<RpcClient<CacheCommand, CacheResponse>> {
         let pooled_client = self
             .client_pool
+            .load_full()
             .get_connection()
             .await
             .map_err(MomentoError::protosocket_connect_error)?;

--- a/src/protosocket/cache/cache_client.rs
+++ b/src/protosocket/cache/cache_client.rs
@@ -239,9 +239,11 @@ impl ProtosocketCacheClient {
     pub(crate) async fn protosocket_connection(
         &self,
     ) -> MomentoResult<RpcClient<CacheCommand, CacheResponse>> {
-        let pooled_client = self.client_pool.get_connection().await.map_err(|e| {
-            MomentoError::unknown_error("protosocket_connection", Some(format!("{e:?}")))
-        })?;
+        let pooled_client = self
+            .client_pool
+            .get_connection()
+            .await
+            .map_err(MomentoError::protosocket_connect_error)?;
         Ok(pooled_client.clone())
     }
 

--- a/src/protosocket/cache/cache_client_builder.rs
+++ b/src/protosocket/cache/cache_client_builder.rs
@@ -136,15 +136,19 @@ impl ProtosocketCacheClientBuilder<ReadyToBuild> {
         } = self.state;
         let client_connector = ProtosocketConnectionManager::new(
             credential_provider,
-            runtime,
+            runtime.clone(),
             configuration.az_id.clone(),
             configuration.connect_timeout,
         )?;
 
-        let client_pool = ConnectionPool::new(client_connector, configuration.connection_count());
+        let connection_count = configuration.connection_count();
+        let client_pool = ConnectionPool::new(client_connector.clone(), connection_count);
 
         Ok(ProtosocketCacheClient::new(
             client_pool,
+            client_connector,
+            connection_count,
+            &runtime,
             default_ttl,
             configuration,
         ))

--- a/src/protosocket/cache/cache_client_builder.rs
+++ b/src/protosocket/cache/cache_client_builder.rs
@@ -138,6 +138,7 @@ impl ProtosocketCacheClientBuilder<ReadyToBuild> {
             credential_provider,
             runtime,
             configuration.az_id.clone(),
+            configuration.connect_timeout,
         )?;
 
         let client_pool = ConnectionPool::new(client_connector, configuration.connection_count());

--- a/src/protosocket/cache/config/configuration.rs
+++ b/src/protosocket/cache/config/configuration.rs
@@ -1,5 +1,12 @@
 use std::time::Duration;
 
+/// Default for [`Configuration::connect_timeout`]. None of the TCP handshake,
+/// TLS handshake, or auth round trip has a deadline of its own, so without
+/// this an unreachable endpoint that drops packets instead of refusing them
+/// can hang a connection pool slot for the OS's TCP timeout (~2 minutes on
+/// Linux).
+pub(crate) const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// Configuration for a Momento ProtosocketCacheClient.
 ///
 /// Static, versioned configurations are provided for different environments:
@@ -28,6 +35,8 @@ pub struct Configuration {
     pub(crate) connection_count: usize,
     /// Optional availability zone ID to use for preferring connections to one az or another.
     pub(crate) az_id: Option<String>,
+    /// How long a single connection attempt may take before it is abandoned.
+    pub(crate) connect_timeout: Duration,
 }
 
 impl Configuration {
@@ -62,6 +71,19 @@ impl Configuration {
     /// Set the availability zone id hint to use for preferring connections to one az or another.
     pub fn set_az_id(&mut self, az_id: Option<String>) -> &mut Self {
         self.az_id = az_id;
+        self
+    }
+
+    /// Returns how long a single connection attempt may take before it is
+    /// abandoned and retried against a different address.
+    pub fn connect_timeout(&self) -> Duration {
+        self.connect_timeout
+    }
+
+    /// Set how long a single connection attempt may take before it is
+    /// abandoned and retried against a different address.
+    pub fn set_connect_timeout(&mut self, connect_timeout: Duration) -> &mut Self {
+        self.connect_timeout = connect_timeout;
         self
     }
 }
@@ -146,6 +168,7 @@ impl ConfigurationBuilder<ReadyToBuild> {
             timeout,
             connection_count,
             az_id,
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
         }
     }
 }
@@ -153,5 +176,30 @@ impl ConfigurationBuilder<ReadyToBuild> {
 impl From<ConfigurationBuilder<ReadyToBuild>> for Configuration {
     fn from(builder: ConfigurationBuilder<ReadyToBuild>) -> Configuration {
         builder.build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> Configuration {
+        Configuration::builder()
+            .timeout(Duration::from_secs(1))
+            .connection_count(1)
+            .az_id(None)
+            .build()
+    }
+
+    #[test]
+    fn connect_timeout_defaults_without_being_specified() {
+        assert_eq!(config().connect_timeout(), DEFAULT_CONNECT_TIMEOUT);
+    }
+
+    #[test]
+    fn connect_timeout_can_be_overridden_after_build() {
+        let mut config = config();
+        config.set_connect_timeout(Duration::from_millis(500));
+        assert_eq!(config.connect_timeout(), Duration::from_millis(500));
     }
 }

--- a/src/protosocket/cache/connection_manager.rs
+++ b/src/protosocket/cache/connection_manager.rs
@@ -55,17 +55,15 @@ pub(crate) struct ProtosocketConnectionManager {
     address_provider: Arc<AddressProvider>,
     _background_address_loader: Option<Arc<BackgroundAddressLoader>>,
     az_id: Option<String>,
-    /// Shared across every pool slot, so one slot discovering the local zone is
-    /// unreachable steers the others too.
+    /// Shared across pool slots, so one slot's failure steers the others too.
     az_circuit: Arc<AzCircuit>,
     connection_sequence: Arc<AtomicUsize>,
     /// See [`Configuration::connect_timeout`](crate::protosocket::cache::Configuration::connect_timeout).
     connect_timeout: Duration,
 }
 
-/// Where a selected address came from. Log-only: this is deliberately not
-/// surfaced to callers, because the service already reports which availability
-/// zone traffic arrives in.
+/// Where a selected address came from. Log-only -- not surfaced to callers,
+/// since the service already reports which zone traffic arrives in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AzRouting {
     /// An address in the configured availability zone.
@@ -85,8 +83,8 @@ enum ConnectFailure {
 
 impl From<ConnectFailure> for protosocket_rpc::Error {
     fn from(failure: ConnectFailure) -> Self {
-        // protosocket_rpc::Error is a closed enum owned by that crate, so an
-        // io::ErrorKind is the only way to carry a type out of here.
+        // protosocket_rpc::Error is a closed enum, so io::ErrorKind is the only
+        // way to carry a type out of here.
         let (kind, message) = match failure {
             ConnectFailure::NoAddresses => (
                 std::io::ErrorKind::AddrNotAvailable,
@@ -103,9 +101,8 @@ impl From<ConnectFailure> for protosocket_rpc::Error {
 enum EstablishError {
     /// The endpoint did not answer, or answered unusably.
     Transport(protosocket_rpc::Error),
-    /// The endpoint answered and rejected our credentials. That says nothing
-    /// about the zone, so it must not open the circuit -- otherwise a bad API
-    /// key would push every client off its local zone.
+    /// The endpoint rejected our credentials -- not evidence about the zone,
+    /// so this must not open the circuit.
     Rejected(protosocket_rpc::Error),
 }
 
@@ -178,14 +175,8 @@ impl ProtosocketConnectionManager {
         })
     }
 
-    /// Choose the address for the next connection attempt.
-    ///
-    /// Preference for the configured availability zone is soft: when this client
-    /// cannot reach that zone, it moves to the others rather than staying pinned
-    /// to endpoints it has just failed to reach. Per-host health is deliberately
-    /// not tracked here -- the `/endpoints` API publishes healthy hosts, so that
-    /// is the control plane's job. What the control plane cannot see is a fault
-    /// visible only from this client, which is what the circuit covers.
+    /// Choose the address for the next connection attempt. AZ preference is
+    /// soft: see [`AzCircuit`] for when and why it gives way to other zones.
     async fn select_address(&self) -> Result<(SocketAddr, AzRouting), ConnectFailure> {
         let mut addresses = self.address_provider.get_addresses();
         if addresses.all().is_empty() {
@@ -237,10 +228,9 @@ impl ProtosocketConnectionManager {
 }
 
 /// Narrow the published addresses down to the ones worth trying, and report
-/// where they came from.
-///
-/// Split out from [`ProtosocketConnectionManager::select_address`] so it can be
-/// exercised against a fixed address map.
+/// where they came from. Split out from
+/// [`select_address`](ProtosocketConnectionManager::select_address) so it's
+/// testable against a fixed address map.
 fn choose_candidates(
     addresses: &Addresses,
     az_id: Option<&str>,
@@ -249,17 +239,15 @@ fn choose_candidates(
     let (candidates, routing) = match az_id {
         None => (addresses.all(), AzRouting::Unpinned),
 
-        // The local zone is unreachable. Escape it entirely rather than widening
-        // to every address, which would keep offering the very endpoints we are
-        // trying to avoid.
+        // Local zone is unreachable: escape it entirely rather than widening to
+        // every address, which would keep offering what we're trying to avoid.
         Some(az_id) if should_widen => (addresses.outside_az(az_id), AzRouting::Fallback),
 
         Some(az_id) => {
             let local = addresses.in_az(az_id);
             if local.is_empty() {
-                // Quiet degradation is the failure mode most worth avoiding
-                // here. This is usually an availability zone *name* passed where
-                // an ID belongs, or a zone with no cache hosts.
+                // Usually an AZ *name* passed where an ID belongs. Log loudly
+                // rather than degrade quietly.
                 log::warn!(
                     "az_id {az_id} is not present in the address map; connecting without zone preference"
                 );
@@ -270,8 +258,8 @@ fn choose_candidates(
         }
     };
 
-    // Escaping the local zone can leave nothing behind, if it is the only zone
-    // publishing addresses. A cross-zone connection beats no connection.
+    // If the local zone was the only one publishing addresses, escaping it
+    // leaves nothing -- a cross-zone connection beats no connection.
     if candidates.is_empty() {
         (addresses.all(), AzRouting::Unpinned)
     } else {
@@ -279,8 +267,8 @@ fn choose_candidates(
     }
 }
 
-/// Spread connections across the candidates. The candidate lists are sorted, so
-/// advancing the sequence reliably lands on a different address.
+/// Spread connections across the candidates. Lists are sorted, so advancing
+/// the sequence reliably lands on a different address.
 fn round_robin(candidates: &[SocketAddr], sequence: usize) -> Option<SocketAddr> {
     if candidates.is_empty() {
         return None;
@@ -288,9 +276,8 @@ fn round_robin(candidates: &[SocketAddr], sequence: usize) -> Option<SocketAddr>
     Some(candidates[sequence % candidates.len()])
 }
 
-/// Rejected credentials are a permanent failure that says nothing about the
-/// endpoint. A transport error during the handshake means the endpoint itself is
-/// suspect, and an unrecognized response means the connection is unusable.
+/// Rejected credentials say nothing about the endpoint; a transport error or an
+/// unrecognized response does.
 fn classify_auth_failure(address: SocketAddr, error: MomentoError) -> EstablishError {
     match error.inner_error {
         Some(ErrorSource::Protosocket(ProtosocketCacheError::CommandError { cause })) => {
@@ -317,10 +304,9 @@ fn classify_auth_failure(address: SocketAddr, error: MomentoError) -> EstablishE
 
 /// Resolve a `host:port` endpoint to a single socket address.
 ///
-/// Resolution failures are reported as `AddrNotAvailable` rather than
-/// `InvalidInput`: this call performs DNS, and a resolver blip is transient and
-/// worth retrying, whereas a genuinely malformed endpoint is indistinguishable
-/// from here. Erring toward retryable is the safer default.
+/// Failures are reported as `AddrNotAvailable`, not `InvalidInput`: a resolver
+/// blip is indistinguishable here from a malformed endpoint, and erring toward
+/// retryable is the safer default.
 fn resolve_endpoint(endpoint: &str) -> protosocket_rpc::Result<SocketAddr> {
     endpoint
         .to_socket_addrs()
@@ -359,8 +345,7 @@ impl ClientConnector for ProtosocketConnectionManager {
                 self.select_address().await?
             }
             EndpointSecurity::Tls => {
-                // Connect through the load balancer, which hides which zone the
-                // backend is in -- so zone preference does not apply here.
+                // Goes through the load balancer, which hides the backend's zone.
                 // Use the modified cache_endpoint with :9004 appended and https:// prefix removed
                 let mut cache_endpoint = self
                     .credential_provider
@@ -383,8 +368,7 @@ impl ClientConnector for ProtosocketConnectionManager {
 
         log::debug!("connecting over protosocket to {address} ({routing:?})");
 
-        // A hang has to become a failure, or none of the bookkeeping below ever
-        // runs. See `Configuration::set_connect_timeout`.
+        // A hang must become a failure, or the bookkeeping below never runs.
         let outcome = match tokio::time::timeout(self.connect_timeout, self.establish(address))
             .await
         {
@@ -415,8 +399,7 @@ impl ClientConnector for ProtosocketConnectionManager {
                 Ok(client)
             }
             Err(failure) => {
-                // Only a transport failure against the local zone is evidence
-                // that the zone is unreachable.
+                // Only a local-zone transport failure is evidence the zone is unreachable.
                 if routing == AzRouting::Local && matches!(failure, EstablishError::Transport(_)) {
                     self.az_circuit.record_local_failure();
                 }
@@ -449,10 +432,8 @@ async fn refresh_addresses_forever(
     }
 }
 
-/// Returns `protosocket_rpc::Result` rather than `MomentoResult` so that the
-/// `io::ErrorKind` from the transport survives. Converting to `MomentoError` and
-/// back would force the error through a string, and callers need the kind to
-/// tell a refused connection from a timeout from an unresolvable address.
+/// Returns `protosocket_rpc::Result`, not `MomentoResult`, so the transport's
+/// `io::ErrorKind` survives instead of being flattened through a string.
 async fn create_protosocket_connection(
     credential_provider: CredentialProvider,
     runtime: tokio::runtime::Handle,
@@ -483,10 +464,8 @@ async fn create_protosocket_connection(
     }
 }
 
-/// Build the TLS server name for a hostname.
-///
-/// An unusable hostname is a configuration problem rather than a transport one,
-/// so it is reported as `InvalidInput` and maps to a non-retryable error.
+/// Build the TLS server name for a hostname. An unusable one is a config
+/// problem, not a transport one, so it's reported as `InvalidInput`.
 fn server_name_for(hostname: &str) -> protosocket_rpc::Result<ServerName<'static>> {
     ServerName::try_from(hostname.to_string()).map_err(|e| {
         protosocket_rpc::Error::IoFailure(
@@ -557,8 +536,7 @@ mod tests {
         SocketAddr::from(([10, 0, 0, last_octet], 9004))
     }
 
-    /// Built by deserializing the `/endpoints` wire format, so these exercise
-    /// the real shape rather than a hand-assembled one.
+    /// Deserialized from the real `/endpoints` wire format, not hand-assembled.
     fn addresses(json: &str) -> Addresses {
         serde_json::from_str(json).expect("test fixture must parse")
     }
@@ -592,8 +570,7 @@ mod tests {
     fn an_unreachable_local_zone_is_escaped_entirely() {
         let (candidates, routing) = choose_candidates(&two_zones(), Some("usw2-az1"), true);
 
-        // Not merely widened: the local addresses must not reappear, or we would
-        // keep offering the endpoints we are trying to avoid.
+        // Not merely widened: the local addresses must not reappear.
         assert_eq!(candidates, vec![address(3)]);
         assert_eq!(routing, AzRouting::Fallback);
     }
@@ -608,8 +585,7 @@ mod tests {
 
     #[test]
     fn an_unknown_zone_connects_without_preference() {
-        // An availability zone *name* where an ID belongs is the likely cause,
-        // and it must not strand the client with nothing to connect to.
+        // Must not strand the client with nothing to connect to.
         let (candidates, routing) = choose_candidates(&two_zones(), Some("us-west-2a"), false);
 
         assert_eq!(candidates, vec![address(1), address(2), address(3)]);

--- a/src/protosocket/cache/connection_manager.rs
+++ b/src/protosocket/cache/connection_manager.rs
@@ -225,6 +225,40 @@ impl ProtosocketConnectionManager {
         .await
         .map_err(|e| classify_auth_failure(address, e))
     }
+
+    /// Whether an availability zone preference is configured at all -- used to
+    /// decide whether the recovery prober has anything to do.
+    pub(crate) fn has_az_preference(&self) -> bool {
+        self.az_id.is_some()
+    }
+
+    /// Shared handle to this manager's circuit, for the recovery prober.
+    pub(crate) fn az_circuit(&self) -> Arc<AzCircuit> {
+        self.az_circuit.clone()
+    }
+
+    /// Verify the local zone is reachable with a single bounded connection,
+    /// without touching [`AzCircuit`]. A rejection still counts as reachable:
+    /// the endpoint answered, which is itself proof of reachability -- see
+    /// [`classify_auth_failure`]. Only a transport failure means still down.
+    pub(crate) async fn probe_local_zone(&self) -> bool {
+        let Some(az_id) = self.az_id.as_deref() else {
+            return false;
+        };
+        let local = self.address_provider.get_addresses().in_az(az_id);
+        let sequence = self
+            .connection_sequence
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let Some(address) = round_robin(&local, sequence) else {
+            return false;
+        };
+
+        match tokio::time::timeout(self.connect_timeout, self.establish(address)).await {
+            Ok(Ok(_)) => true,
+            Ok(Err(EstablishError::Rejected(_))) => true,
+            Ok(Err(EstablishError::Transport(_))) | Err(_) => false,
+        }
+    }
 }
 
 /// Narrow the published addresses down to the ones worth trying, and report

--- a/src/protosocket/cache/connection_manager.rs
+++ b/src/protosocket/cache/connection_manager.rs
@@ -33,21 +33,6 @@ use std::{
 use crate::{ErrorSource, MomentoError, MomentoResult, ProtosocketCacheError};
 use std::net::ToSocketAddrs;
 
-/// How long a single connection attempt may take, covering the TCP connection,
-/// the TLS handshake, and the authentication round trip together.
-///
-/// None of those three has a deadline of its own. Without this, an endpoint that
-/// silently drops SYNs rather than refusing them hangs the connection pool slot
-/// for the operating system's TCP timeout -- roughly two minutes on Linux --
-/// while every later request for that slot waits on the same attempt, and the
-/// availability zone circuit never observes a failure to react to.
-///
-/// Seconds rather than milliseconds: callers apply their own per-request
-/// deadlines, but this connection outlives the request that triggered it and is
-/// still worth completing for later ones. A legitimate cross-zone TLS handshake
-/// plus authentication round trip can take a few hundred milliseconds.
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
-
 #[derive(Debug)]
 struct BackgroundAddressLoader {
     alive: Arc<AtomicBool>,
@@ -74,6 +59,8 @@ pub(crate) struct ProtosocketConnectionManager {
     /// unreachable steers the others too.
     az_circuit: Arc<AzCircuit>,
     connection_sequence: Arc<AtomicUsize>,
+    /// See [`Configuration::connect_timeout`](crate::protosocket::cache::Configuration::connect_timeout).
+    connect_timeout: Duration,
 }
 
 /// Where a selected address came from. Log-only: this is deliberately not
@@ -141,6 +128,7 @@ impl ProtosocketConnectionManager {
         credential_provider: CredentialProvider,
         runtime: tokio::runtime::Handle,
         az_id: Option<String>,
+        connect_timeout: Duration,
     ) -> MomentoResult<Self> {
         let hostname = Uri::from_str(&credential_provider.tls_cache_endpoint)
             .ok()
@@ -186,6 +174,7 @@ impl ProtosocketConnectionManager {
             az_id,
             az_circuit: Default::default(),
             connection_sequence: Default::default(),
+            connect_timeout,
         })
     }
 
@@ -395,16 +384,21 @@ impl ClientConnector for ProtosocketConnectionManager {
         log::debug!("connecting over protosocket to {address} ({routing:?})");
 
         // A hang has to become a failure, or none of the bookkeeping below ever
-        // runs. See CONNECT_TIMEOUT.
-        let outcome = match tokio::time::timeout(CONNECT_TIMEOUT, self.establish(address)).await {
+        // runs. See `Configuration::set_connect_timeout`.
+        let outcome = match tokio::time::timeout(self.connect_timeout, self.establish(address))
+            .await
+        {
             Ok(outcome) => outcome,
             Err(_elapsed) => {
-                log::warn!("connect to {address} timed out after {:?}", CONNECT_TIMEOUT);
+                log::warn!(
+                    "connect to {address} timed out after {:?}",
+                    self.connect_timeout
+                );
                 Err(EstablishError::Transport(
                     protosocket_rpc::Error::IoFailure(
                         std::io::Error::new(
                             std::io::ErrorKind::TimedOut,
-                            format!("connect to {} exceeded {:?}", address, CONNECT_TIMEOUT),
+                            format!("connect to {} exceeded {:?}", address, self.connect_timeout),
                         )
                         .into(),
                     ),

--- a/src/protosocket/cache/connection_manager.rs
+++ b/src/protosocket/cache/connection_manager.rs
@@ -1,6 +1,10 @@
 use crate::{
     credential_provider::EndpointSecurity,
-    protosocket::cache::{address_provider::AddressProvider, cache_client_builder::Codec},
+    protosocket::cache::{
+        address_provider::{AddressProvider, Addresses},
+        az_circuit::AzCircuit,
+        cache_client_builder::Codec,
+    },
     CredentialProvider,
 };
 use http::Uri;
@@ -17,6 +21,7 @@ use protosocket_rpc::{
 use rustls_pki_types::ServerName;
 use std::{
     convert::TryFrom,
+    net::SocketAddr,
     str::FromStr,
     sync::{
         atomic::{AtomicBool, AtomicUsize},
@@ -25,8 +30,23 @@ use std::{
     time::Duration,
 };
 
-use crate::{MomentoError, MomentoResult};
+use crate::{ErrorSource, MomentoError, MomentoResult, ProtosocketCacheError};
 use std::net::ToSocketAddrs;
+
+/// How long a single connection attempt may take, covering the TCP connection,
+/// the TLS handshake, and the authentication round trip together.
+///
+/// None of those three has a deadline of its own. Without this, an endpoint that
+/// silently drops SYNs rather than refusing them hangs the connection pool slot
+/// for the operating system's TCP timeout -- roughly two minutes on Linux --
+/// while every later request for that slot waits on the same attempt, and the
+/// availability zone circuit never observes a failure to react to.
+///
+/// Seconds rather than milliseconds: callers apply their own per-request
+/// deadlines, but this connection outlives the request that triggered it and is
+/// still worth completing for later ones. A legitimate cross-zone TLS handshake
+/// plus authentication round trip can take a few hundred milliseconds.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Debug)]
 struct BackgroundAddressLoader {
@@ -50,7 +70,64 @@ pub(crate) struct ProtosocketConnectionManager {
     address_provider: Arc<AddressProvider>,
     _background_address_loader: Option<Arc<BackgroundAddressLoader>>,
     az_id: Option<String>,
+    /// Shared across every pool slot, so one slot discovering the local zone is
+    /// unreachable steers the others too.
+    az_circuit: Arc<AzCircuit>,
     connection_sequence: Arc<AtomicUsize>,
+}
+
+/// Where a selected address came from. Log-only: this is deliberately not
+/// surfaced to callers, because the service already reports which availability
+/// zone traffic arrives in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AzRouting {
+    /// An address in the configured availability zone.
+    Local,
+    /// An address outside the configured zone, chosen because that zone is
+    /// currently unreachable from this client.
+    Fallback,
+    /// No zone preference was configured, or none could be applied.
+    Unpinned,
+}
+
+/// A failure to choose an address, before any socket work is attempted.
+#[derive(Debug, Clone, Copy)]
+enum ConnectFailure {
+    NoAddresses,
+}
+
+impl From<ConnectFailure> for protosocket_rpc::Error {
+    fn from(failure: ConnectFailure) -> Self {
+        // protosocket_rpc::Error is a closed enum owned by that crate, so an
+        // io::ErrorKind is the only way to carry a type out of here.
+        let (kind, message) = match failure {
+            ConnectFailure::NoAddresses => (
+                std::io::ErrorKind::AddrNotAvailable,
+                "no addresses available from address provider",
+            ),
+        };
+        protosocket_rpc::Error::IoFailure(std::io::Error::new(kind, message).into())
+    }
+}
+
+/// Whether a failed attempt is evidence about the reachability of the zone the
+/// address belongs to.
+#[derive(Debug)]
+enum EstablishError {
+    /// The endpoint did not answer, or answered unusably.
+    Transport(protosocket_rpc::Error),
+    /// The endpoint answered and rejected our credentials. That says nothing
+    /// about the zone, so it must not open the circuit -- otherwise a bad API
+    /// key would push every client off its local zone.
+    Rejected(protosocket_rpc::Error),
+}
+
+impl EstablishError {
+    fn into_inner(self) -> protosocket_rpc::Error {
+        match self {
+            EstablishError::Transport(error) | EstablishError::Rejected(error) => error,
+        }
+    }
 }
 
 impl ProtosocketConnectionManager {
@@ -107,9 +184,176 @@ impl ProtosocketConnectionManager {
             address_provider,
             _background_address_loader: background_address_loader,
             az_id,
+            az_circuit: Default::default(),
             connection_sequence: Default::default(),
         })
     }
+
+    /// Choose the address for the next connection attempt.
+    ///
+    /// Preference for the configured availability zone is soft: when this client
+    /// cannot reach that zone, it moves to the others rather than staying pinned
+    /// to endpoints it has just failed to reach. Per-host health is deliberately
+    /// not tracked here -- the `/endpoints` API publishes healthy hosts, so that
+    /// is the control plane's job. What the control plane cannot see is a fault
+    /// visible only from this client, which is what the circuit covers.
+    async fn select_address(&self) -> Result<(SocketAddr, AzRouting), ConnectFailure> {
+        let mut addresses = self.address_provider.get_addresses();
+        if addresses.all().is_empty() {
+            if let Err(e) = self.address_provider.try_refresh_addresses().await {
+                log::warn!("error refreshing address list: {e:?}");
+            }
+            addresses = self.address_provider.get_addresses();
+        }
+
+        let (candidates, routing) = choose_candidates(
+            &addresses,
+            self.az_id.as_deref(),
+            self.az_circuit.should_widen(),
+        );
+
+        let sequence = self
+            .connection_sequence
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        round_robin(&candidates, sequence)
+            .map(|address| (address, routing))
+            .ok_or(ConnectFailure::NoAddresses)
+    }
+
+    /// Open and authenticate one connection, classifying any failure by whether
+    /// it is evidence about the endpoint.
+    async fn establish(
+        &self,
+        address: SocketAddr,
+    ) -> Result<protosocket_rpc::client::RpcClient<CacheCommand, CacheResponse>, EstablishError>
+    {
+        let unauthenticated_client = create_protosocket_connection(
+            self.credential_provider.clone(),
+            self.runtime.clone(),
+            address,
+            &self.hostname,
+        )
+        .await
+        .map_err(EstablishError::Transport)?;
+
+        authenticate_protosocket_client(
+            unauthenticated_client,
+            self.credential_provider.clone(),
+            0xDEADBEEF,
+        )
+        .await
+        .map_err(|e| classify_auth_failure(address, e))
+    }
+}
+
+/// Narrow the published addresses down to the ones worth trying, and report
+/// where they came from.
+///
+/// Split out from [`ProtosocketConnectionManager::select_address`] so it can be
+/// exercised against a fixed address map.
+fn choose_candidates(
+    addresses: &Addresses,
+    az_id: Option<&str>,
+    should_widen: bool,
+) -> (Vec<SocketAddr>, AzRouting) {
+    let (candidates, routing) = match az_id {
+        None => (addresses.all(), AzRouting::Unpinned),
+
+        // The local zone is unreachable. Escape it entirely rather than widening
+        // to every address, which would keep offering the very endpoints we are
+        // trying to avoid.
+        Some(az_id) if should_widen => (addresses.outside_az(az_id), AzRouting::Fallback),
+
+        Some(az_id) => {
+            let local = addresses.in_az(az_id);
+            if local.is_empty() {
+                // Quiet degradation is the failure mode most worth avoiding
+                // here. This is usually an availability zone *name* passed where
+                // an ID belongs, or a zone with no cache hosts.
+                log::warn!(
+                    "az_id {az_id} is not present in the address map; connecting without zone preference"
+                );
+                (addresses.all(), AzRouting::Unpinned)
+            } else {
+                (local, AzRouting::Local)
+            }
+        }
+    };
+
+    // Escaping the local zone can leave nothing behind, if it is the only zone
+    // publishing addresses. A cross-zone connection beats no connection.
+    if candidates.is_empty() {
+        (addresses.all(), AzRouting::Unpinned)
+    } else {
+        (candidates, routing)
+    }
+}
+
+/// Spread connections across the candidates. The candidate lists are sorted, so
+/// advancing the sequence reliably lands on a different address.
+fn round_robin(candidates: &[SocketAddr], sequence: usize) -> Option<SocketAddr> {
+    if candidates.is_empty() {
+        return None;
+    }
+    Some(candidates[sequence % candidates.len()])
+}
+
+/// Rejected credentials are a permanent failure that says nothing about the
+/// endpoint. A transport error during the handshake means the endpoint itself is
+/// suspect, and an unrecognized response means the connection is unusable.
+fn classify_auth_failure(address: SocketAddr, error: MomentoError) -> EstablishError {
+    match error.inner_error {
+        Some(ErrorSource::Protosocket(ProtosocketCacheError::CommandError { cause })) => {
+            EstablishError::Rejected(protosocket_rpc::Error::IoFailure(
+                std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    format!("authentication rejected by {address}: {}", cause.message),
+                )
+                .into(),
+            ))
+        }
+        Some(ErrorSource::Protosocket(ProtosocketCacheError::Protosocket { cause })) => {
+            EstablishError::Transport(cause)
+        }
+        other => EstablishError::Transport(protosocket_rpc::Error::IoFailure(
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unexpected authentication response from {address}: {other:?}"),
+            )
+            .into(),
+        )),
+    }
+}
+
+/// Resolve a `host:port` endpoint to a single socket address.
+///
+/// Resolution failures are reported as `AddrNotAvailable` rather than
+/// `InvalidInput`: this call performs DNS, and a resolver blip is transient and
+/// worth retrying, whereas a genuinely malformed endpoint is indistinguishable
+/// from here. Erring toward retryable is the safer default.
+fn resolve_endpoint(endpoint: &str) -> protosocket_rpc::Result<SocketAddr> {
+    endpoint
+        .to_socket_addrs()
+        .map_err(|e| {
+            protosocket_rpc::Error::IoFailure(
+                std::io::Error::new(
+                    std::io::ErrorKind::AddrNotAvailable,
+                    format!("could not resolve endpoint {endpoint}: {e:?}"),
+                )
+                .into(),
+            )
+        })?
+        .next()
+        .ok_or_else(|| {
+            protosocket_rpc::Error::IoFailure(
+                std::io::Error::new(
+                    std::io::ErrorKind::AddrNotAvailable,
+                    format!("endpoint {endpoint} did not resolve to any address"),
+                )
+                .into(),
+            )
+        })
 }
 
 impl ClientConnector for ProtosocketConnectionManager {
@@ -120,125 +364,71 @@ impl ClientConnector for ProtosocketConnectionManager {
         self,
     ) -> protosocket_rpc::Result<protosocket_rpc::client::RpcClient<Self::Request, Self::Response>>
     {
-        let address = match self.credential_provider.endpoint_security {
-            EndpointSecurity::Tls => {
+        let (address, routing) = match self.credential_provider.endpoint_security {
+            EndpointSecurity::Tls if self.credential_provider.use_endpoints_http_api => {
                 log::debug!("selecting address from address provider for TLS endpoint");
-                if self.credential_provider.use_endpoints_http_api {
-                    if self
-                        .address_provider
-                        .get_addresses()
-                        .for_az(self.az_id.as_deref())
-                        .is_empty()
-                    {
-                        if let Err(e) = self.address_provider.try_refresh_addresses().await {
-                            log::warn!("error refreshing address list: {e:?}");
-                        }
-                    }
-                    let addresses = self
-                        .address_provider
-                        .get_addresses()
-                        .for_az(self.az_id.as_deref());
-                    if addresses.is_empty() {
-                        return Err(protosocket_rpc::Error::IoFailure(
-                            std::io::Error::new(
-                                std::io::ErrorKind::AddrNotAvailable,
-                                "No addresses available from address provider",
-                            )
-                            .into(),
-                        ));
-                    }
-                    addresses[self
-                        .connection_sequence
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                        % addresses.len()]
-                } else {
-                    // Use the modified cache_endpoint with :9004 appended and https:// prefix removed
-                    let mut cache_endpoint = self
-                        .credential_provider
-                        .cache_endpoint
-                        .strip_prefix("https://")
-                        .unwrap_or(&self.credential_provider.cache_endpoint)
-                        .to_string();
-                    cache_endpoint.push_str(":9004");
+                self.select_address().await?
+            }
+            EndpointSecurity::Tls => {
+                // Connect through the load balancer, which hides which zone the
+                // backend is in -- so zone preference does not apply here.
+                // Use the modified cache_endpoint with :9004 appended and https:// prefix removed
+                let mut cache_endpoint = self
+                    .credential_provider
+                    .cache_endpoint
+                    .strip_prefix("https://")
+                    .unwrap_or(&self.credential_provider.cache_endpoint)
+                    .to_string();
+                cache_endpoint.push_str(":9004");
 
-                    cache_endpoint
-                        .to_socket_addrs()
-                        .map_err(|e| {
-                            protosocket_rpc::Error::IoFailure(
-                                std::io::Error::other(format!(
-                                    "could not parse address from endpoint: {}: {:?}",
-                                    self.credential_provider.cache_endpoint, e
-                                ))
-                                .into(),
-                            )
-                        })?
-                        .next()
-                        .ok_or_else(|| {
-                            protosocket_rpc::Error::IoFailure(
-                                std::io::Error::new(
-                                    std::io::ErrorKind::AddrNotAvailable,
-                                    format!(
-                                        "Unable to connect: endpoint '{}' did not resolve.",
-                                        cache_endpoint
-                                    ),
-                                )
-                                .into(),
-                            )
-                        })?
-                }
+                (resolve_endpoint(&cache_endpoint)?, AzRouting::Unpinned)
             }
             _ => {
                 log::debug!("using endpoint address directly for endpoint override");
-                self.credential_provider
-                    .cache_endpoint
-                    .to_socket_addrs()
-                    .map_err(|e| {
-                        protosocket_rpc::Error::IoFailure(
-                            std::io::Error::other(format!(
-                                "could not parse address from endpoint: {}: {:?}",
-                                self.credential_provider.cache_endpoint, e
-                            ))
-                            .into(),
-                        )
-                    })?
-                    .next()
-                    .ok_or_else(|| {
-                        protosocket_rpc::Error::IoFailure(
-                            std::io::Error::new(
-                                std::io::ErrorKind::AddrNotAvailable,
-                                "Failed to resolve endpoint hostname into a valid address",
-                            )
-                            .into(),
-                        )
-                    })?
+                (
+                    resolve_endpoint(&self.credential_provider.cache_endpoint)?,
+                    AzRouting::Unpinned,
+                )
             }
         };
-        log::debug!("connecting over protosocket to {address}");
-        let unauthenticated_client = create_protosocket_connection(
-            self.credential_provider.clone(),
-            self.runtime.clone(),
-            address,
-            &self.hostname,
-        )
-        .await
-        .map_err(|e| {
-            protosocket_rpc::Error::IoFailure(
-                std::io::Error::other(format!("could not connect {e:?}")).into(),
-            )
-        })?;
-        let client = authenticate_protosocket_client(
-            unauthenticated_client,
-            self.credential_provider.clone(),
-            0xDEADBEEF,
-        )
-        .await
-        .map_err(|e| {
-            protosocket_rpc::Error::IoFailure(
-                std::io::Error::other(format!("could not authenticate {e:?}")).into(),
-            )
-        })?;
-        log::debug!("successfully created and authenticated protosocket client");
-        Ok(client)
+
+        log::debug!("connecting over protosocket to {address} ({routing:?})");
+
+        // A hang has to become a failure, or none of the bookkeeping below ever
+        // runs. See CONNECT_TIMEOUT.
+        let outcome = match tokio::time::timeout(CONNECT_TIMEOUT, self.establish(address)).await {
+            Ok(outcome) => outcome,
+            Err(_elapsed) => {
+                log::warn!("connect to {address} timed out after {:?}", CONNECT_TIMEOUT);
+                Err(EstablishError::Transport(
+                    protosocket_rpc::Error::IoFailure(
+                        std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            format!("connect to {} exceeded {:?}", address, CONNECT_TIMEOUT),
+                        )
+                        .into(),
+                    ),
+                ))
+            }
+        };
+
+        match outcome {
+            Ok(client) => {
+                if routing == AzRouting::Local {
+                    self.az_circuit.record_local_success();
+                }
+                log::debug!("successfully created and authenticated protosocket client");
+                Ok(client)
+            }
+            Err(failure) => {
+                // Only a transport failure against the local zone is evidence
+                // that the zone is unreachable.
+                if routing == AzRouting::Local && matches!(failure, EstablishError::Transport(_)) {
+                    self.az_circuit.record_local_failure();
+                }
+                Err(failure.into_inner())
+            }
+        }
     }
 }
 
@@ -265,39 +455,27 @@ async fn refresh_addresses_forever(
     }
 }
 
+/// Returns `protosocket_rpc::Result` rather than `MomentoResult` so that the
+/// `io::ErrorKind` from the transport survives. Converting to `MomentoError` and
+/// back would force the error through a string, and callers need the kind to
+/// tell a refused connection from a timeout from an unresolvable address.
 async fn create_protosocket_connection(
     credential_provider: CredentialProvider,
     runtime: tokio::runtime::Handle,
     address: std::net::SocketAddr,
     hostname: &str,
-) -> MomentoResult<protosocket_rpc::client::RpcClient<CacheCommand, CacheResponse>> {
+) -> protosocket_rpc::Result<protosocket_rpc::client::RpcClient<CacheCommand, CacheResponse>> {
     match credential_provider.endpoint_security {
         EndpointSecurity::Tls | EndpointSecurity::TlsOverride => {
             log::debug!("creating TLS connection to {address}");
-            let server_name = ServerName::try_from(hostname.to_string()).map_err(|_| {
-                MomentoError::unknown_error(
-                    "build",
-                    Some(format!(
-                        "Error creating server name from hostname: {}",
-                        hostname
-                    )),
-                )
-            })?;
+            let server_name = server_name_for(hostname)?;
             let connector = WebpkiTlsStreamConnector::new(server_name);
             log::debug!("created TLS connector for server name: {}", hostname);
             create_connection_with_connector(address, connector, runtime).await
         }
         EndpointSecurity::Unverified => {
             log::debug!("creating unverified TLS connection to {address}");
-            let server_name = ServerName::try_from(hostname.to_string()).map_err(|_| {
-                MomentoError::unknown_error(
-                    "build",
-                    Some(format!(
-                        "Error creating server name from hostname: {}",
-                        hostname
-                    )),
-                )
-            })?;
+            let server_name = server_name_for(hostname)?;
             let connector = UnverifiedTlsStreamConnector::new(server_name);
             create_connection_with_connector(address, connector, runtime).await
         }
@@ -311,11 +489,27 @@ async fn create_protosocket_connection(
     }
 }
 
+/// Build the TLS server name for a hostname.
+///
+/// An unusable hostname is a configuration problem rather than a transport one,
+/// so it is reported as `InvalidInput` and maps to a non-retryable error.
+fn server_name_for(hostname: &str) -> protosocket_rpc::Result<ServerName<'static>> {
+    ServerName::try_from(hostname.to_string()).map_err(|e| {
+        protosocket_rpc::Error::IoFailure(
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("could not build a TLS server name from hostname {hostname}: {e:?}"),
+            )
+            .into(),
+        )
+    })
+}
+
 async fn create_connection_with_connector<C>(
     address: std::net::SocketAddr,
     connector: C,
     runtime: tokio::runtime::Handle,
-) -> MomentoResult<protosocket_rpc::client::RpcClient<CacheCommand, CacheResponse>>
+) -> protosocket_rpc::Result<protosocket_rpc::client::RpcClient<CacheCommand, CacheResponse>>
 where
     C: protosocket_rpc::client::StreamConnector + Send + 'static,
 {
@@ -358,5 +552,123 @@ pub(crate) async fn authenticate_protosocket_client(
         }
         Some(Kind::Error(error)) => Err(MomentoError::protosocket_command_error(error)),
         _ => Err(MomentoError::protosocket_unexpected_kind_error()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn address(last_octet: u8) -> SocketAddr {
+        SocketAddr::from(([10, 0, 0, last_octet], 9004))
+    }
+
+    /// Built by deserializing the `/endpoints` wire format, so these exercise
+    /// the real shape rather than a hand-assembled one.
+    fn addresses(json: &str) -> Addresses {
+        serde_json::from_str(json).expect("test fixture must parse")
+    }
+
+    /// usw2-az1 holds .1 and .2; usw2-az2 holds .3.
+    fn two_zones() -> Addresses {
+        addresses(
+            r#"{
+                "usw2-az1": [
+                    {"socket_address": "10.0.0.1:9004"},
+                    {"socket_address": "10.0.0.2:9004"}
+                ],
+                "usw2-az2": [{"socket_address": "10.0.0.3:9004"}]
+            }"#,
+        )
+    }
+
+    fn one_zone() -> Addresses {
+        addresses(r#"{"usw2-az1": [{"socket_address": "10.0.0.1:9004"}]}"#)
+    }
+
+    #[test]
+    fn a_reachable_local_zone_is_preferred() {
+        let (candidates, routing) = choose_candidates(&two_zones(), Some("usw2-az1"), false);
+
+        assert_eq!(candidates, vec![address(1), address(2)]);
+        assert_eq!(routing, AzRouting::Local);
+    }
+
+    #[test]
+    fn an_unreachable_local_zone_is_escaped_entirely() {
+        let (candidates, routing) = choose_candidates(&two_zones(), Some("usw2-az1"), true);
+
+        // Not merely widened: the local addresses must not reappear, or we would
+        // keep offering the endpoints we are trying to avoid.
+        assert_eq!(candidates, vec![address(3)]);
+        assert_eq!(routing, AzRouting::Fallback);
+    }
+
+    #[test]
+    fn escaping_the_only_zone_falls_back_rather_than_failing() {
+        let (candidates, routing) = choose_candidates(&one_zone(), Some("usw2-az1"), true);
+
+        assert_eq!(candidates, vec![address(1)]);
+        assert_eq!(routing, AzRouting::Unpinned);
+    }
+
+    #[test]
+    fn an_unknown_zone_connects_without_preference() {
+        // An availability zone *name* where an ID belongs is the likely cause,
+        // and it must not strand the client with nothing to connect to.
+        let (candidates, routing) = choose_candidates(&two_zones(), Some("us-west-2a"), false);
+
+        assert_eq!(candidates, vec![address(1), address(2), address(3)]);
+        assert_eq!(routing, AzRouting::Unpinned);
+    }
+
+    #[test]
+    fn no_configured_zone_uses_every_address() {
+        let (candidates, routing) = choose_candidates(&two_zones(), None, false);
+
+        assert_eq!(candidates, vec![address(1), address(2), address(3)]);
+        assert_eq!(routing, AzRouting::Unpinned);
+    }
+
+    #[test]
+    fn the_circuit_is_ignored_without_a_configured_zone() {
+        let (candidates, routing) = choose_candidates(&two_zones(), None, true);
+
+        assert_eq!(candidates, vec![address(1), address(2), address(3)]);
+        assert_eq!(routing, AzRouting::Unpinned);
+    }
+
+    #[test]
+    fn an_empty_address_map_yields_no_candidates() {
+        let (candidates, _) = choose_candidates(&Addresses::default(), Some("usw2-az1"), false);
+
+        assert!(candidates.is_empty());
+        assert_eq!(round_robin(&candidates, 0), None);
+    }
+
+    #[test]
+    fn round_robin_advances_with_the_sequence() {
+        let candidates = vec![address(1), address(2), address(3)];
+
+        assert_eq!(round_robin(&candidates, 0), Some(address(1)));
+        assert_eq!(round_robin(&candidates, 1), Some(address(2)));
+        assert_eq!(round_robin(&candidates, 2), Some(address(3)));
+        assert_eq!(round_robin(&candidates, 3), Some(address(1)));
+    }
+
+    #[test]
+    fn a_connect_failure_is_typed_as_unavailable_and_retryable() {
+        let error: protosocket_rpc::Error = ConnectFailure::NoAddresses.into();
+
+        match &error {
+            protosocket_rpc::Error::IoFailure(io_error) => {
+                assert_eq!(io_error.kind(), std::io::ErrorKind::AddrNotAvailable)
+            }
+            other => panic!("expected an IoFailure, got {:?}", other),
+        }
+        assert_eq!(
+            MomentoError::protosocket_connect_error(error).error_code,
+            crate::MomentoErrorCode::ServerUnavailable
+        );
     }
 }

--- a/src/protosocket/cache/mod.rs
+++ b/src/protosocket/cache/mod.rs
@@ -12,5 +12,7 @@ mod connection_manager;
 
 mod address_provider;
 
+mod az_circuit;
+
 mod messages;
 pub use messages::MomentoProtosocketRequest;

--- a/src/protosocket/cache/mod.rs
+++ b/src/protosocket/cache/mod.rs
@@ -14,5 +14,7 @@ mod address_provider;
 
 mod az_circuit;
 
+mod recovery_prober;
+
 mod messages;
 pub use messages::MomentoProtosocketRequest;

--- a/src/protosocket/cache/recovery_prober.rs
+++ b/src/protosocket/cache/recovery_prober.rs
@@ -1,0 +1,107 @@
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use arc_swap::ArcSwap;
+use protosocket_rpc::client::ConnectionPool;
+
+use super::connection_manager::ProtosocketConnectionManager;
+
+/// How often the prober checks whether a recovery sweep is due. Checking is
+/// cheap (one atomic load) when nothing needs fixing, so this doesn't need to
+/// be tight -- see [`AzCircuit::recovery_needed`](super::az_circuit::AzCircuit::recovery_needed).
+const PROBE_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Spacing between prewarming successive slots of a rebuilt pool, so a
+/// recovery sweep can never burst-connect the recovering zone even under
+/// concurrent load.
+const PREWARM_SPACING: Duration = Duration::from_millis(200);
+
+/// Background task that watches for the preferred availability zone becoming
+/// reachable again and, when it does, rebuilds the connection pool so every
+/// slot gets a fresh chance to use it -- rather than waiting indefinitely for
+/// an existing (healthy) fallback-zone connection to happen to die on its own.
+#[derive(Debug)]
+pub(crate) struct BackgroundRecoveryProber {
+    alive: Arc<AtomicBool>,
+    _join_handle: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for BackgroundRecoveryProber {
+    fn drop(&mut self) {
+        if self.alive.swap(false, Ordering::Relaxed) {
+            log::info!("shutting down az recovery prober");
+        }
+    }
+}
+
+impl BackgroundRecoveryProber {
+    /// Spawn the prober, or return `None` if there's no availability zone
+    /// preference to actively recover -- the loop would be a permanent no-op.
+    pub(crate) fn spawn(
+        runtime: &tokio::runtime::Handle,
+        connector: ProtosocketConnectionManager,
+        connection_count: usize,
+        pool: Arc<ArcSwap<ConnectionPool<ProtosocketConnectionManager>>>,
+    ) -> Option<Self> {
+        if !connector.has_az_preference() {
+            return None;
+        }
+
+        let alive = Arc::new(AtomicBool::new(true));
+        let join_handle = runtime.spawn(recover_forever(
+            alive.clone(),
+            connector,
+            connection_count,
+            pool,
+        ));
+        Some(Self {
+            alive,
+            _join_handle: join_handle,
+        })
+    }
+}
+
+async fn recover_forever(
+    alive: Arc<AtomicBool>,
+    connector: ProtosocketConnectionManager,
+    connection_count: usize,
+    pool: Arc<ArcSwap<ConnectionPool<ProtosocketConnectionManager>>>,
+) {
+    let mut interval = tokio::time::interval(PROBE_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let az_circuit = connector.az_circuit();
+
+    loop {
+        interval.tick().await;
+        if !alive.load(Ordering::Relaxed) {
+            break;
+        }
+
+        if !az_circuit.recovery_needed() {
+            continue;
+        }
+
+        if !connector.probe_local_zone().await {
+            log::debug!("az recovery probe: local zone still unreachable");
+            continue;
+        }
+
+        log::info!("az recovery probe succeeded, rebuilding connection pool");
+        let fresh_pool = ConnectionPool::new(connector.clone(), connection_count);
+        for key in 0..connection_count {
+            if let Err(e) = fresh_pool.get_connection_for_key(key).await {
+                log::warn!("az recovery prewarm failed for slot {key}: {e:?}");
+            }
+            tokio::time::sleep(PREWARM_SPACING).await;
+        }
+
+        pool.store(Arc::new(fresh_pool));
+        az_circuit.acknowledge_recovery();
+        log::info!("az recovery complete: connection pool rebuilt against the local zone");
+    }
+}


### PR DESCRIPTION
adding protosocket connection resiliency:

- configurable connection timeout to fail fast instead of hanging if endpoints are unreachable
- AZ circuit breaker to temporarily fallback to other AZs if the preferred one is unavailable/unreachable
- more comprehensible protosocket connection errors 
- refactored connection manager and added more tests

tested against alpha and confirmed the protosocket client will fallback to another AZ if cut off from its preferred AZ but safely switch back to the preferred one without dropping requests once the path is unblocked

yellow is preferred az, green is fallback az
<img width="524" height="266" alt="image" src="https://github.com/user-attachments/assets/8fba3d33-cab9-400f-9e46-b936d31be220" />
